### PR TITLE
Tweaks for better Fly.io perf

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "deploy --config ./fly.production.toml --build-arg DATABASE_URL=file:/remixapp/prisma/remix.db?connection_limit=1 --strategy bluegreen"
+          args: "deploy --config ./fly.production.toml --build-arg DATABASE_URL=file:/remixapp/prisma/remix.db?connection_limit=1 --strategy rolling"

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -7,12 +7,13 @@ processes = []
 [build]
   builtin = "node"
 
+
 [env]
   PORT = "8080"
 
 [experimental]
   allowed_public_ports = []
-  auto_rollback = true
+  auto_rollback = false
 
 [[services]]
   http_checks = []
@@ -21,8 +22,8 @@ processes = []
   script_checks = []
 
   [services.concurrency]
-    hard_limit = 100
-    soft_limit = 80
+    hard_limit = 25
+    soft_limit = 20
     type = "requests"
 
   [[services.ports]]


### PR DESCRIPTION
This app is now running with 12 regions, and this: `fly scale count 12 --max-per-region=1`.

This gets the best possible geo distribution on deploys, rather than doubling up on regions. `bluegreen` deploy strategies won't work in this mode, so the PR changes it to a `rolling` deploy. Rolling deploys will be _very_ slow since it'll boot + sync each VM in sequence. I think the sync process is worth bundling into the build, if possible.

The app servers seem to slow down with >25 concurrent requests, so this changes the concurrency setting. With better geo distribution, the app will "load shed" to nearby regions when one VM has more than 25 requests in flight.