### PR TITLE
Build with Dockerfile, seed db during build step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+Dockerfile.fly
+.envrc

--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -22,5 +22,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
+        env:
+          auth_token: ${{ secrets.AUTH_TOKEN }}
         with:
-          args: "deploy --config ./fly.production.toml --build-arg DATABASE_URL=file:/remixapp/prisma/remix.db?connection_limit=1 --strategy rolling"
+          args: "deploy --config ./fly.production.toml  --build-arg AUTH_TOKEN --strategy rolling"

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -23,5 +23,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
+        env:
+          auth_token: ${{ secrets.AUTH_TOKEN }}
         with:
-          args: "deploy --config ./fly.staging.toml --build-arg DATABASE_URL=file:/remixapp/prisma/remix.db?connection_limit=1 --strategy bluegreen"
+          args: "deploy --config ./fly.staging.toml --build-arg AUTH_TOKEN--strategy bluegreen"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 
 /.yalc
 yalc.lock
+
+.envrc

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,66 @@
+# base node image
+FROM node:16-bullseye-slim as base
+
+# Install openssl for Prisma
+RUN apt-get update && apt-get install -y openssl
+
+ENV NODE_ENV production
+
+# Install all node_modules, including dev dependencies
+FROM base as deps
+
+RUN mkdir /app
+WORKDIR /app
+
+ADD package.json package-lock.json ./
+RUN npm install --production=false
+
+# Setup production node_modules
+FROM base as production-deps
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=deps /app/node_modules /app/node_modules
+ADD package.json package-lock.json ./
+RUN npm prune --production
+
+# Build the app
+FROM base as build
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=deps /app/node_modules /app/node_modules
+
+ADD prisma .
+RUN npx prisma generate
+
+ADD . .
+RUN npm run build
+
+# Finally, build the production image with minimal footprint
+FROM base
+
+ENV NODE_ENV production
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=production-deps /app/node_modules /app/node_modules
+COPY --from=build /app/node_modules/.prisma /app/node_modules/.prisma
+COPY --from=build /app/build /app/build
+COPY --from=build /app/public /app/public
+ADD . .
+
+ENV SITE_URL=https://remix.run
+ENV REPO_DOCS_PATH=docs
+ENV REPO_LATEST_BRANCH=refs/heads/main
+ENV REPO=remix-run/remix
+ENV DATABASE_URL=file:/remixapp/prisma/remix.db?connection_limit=1
+ARG AUTH_TOKEN
+
+RUN mkdir -p /remixapp/prisma/ && npm run db:reset -- --force
+RUN npm run seed
+
+CMD ["npm", "run", "start"]

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -5,8 +5,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builtin = "node"
-
+  dockerfile = "Dockerfile.fly"
 
 [env]
   PORT = "8080"

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -5,7 +5,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builtin = "node"
+  dockerfile = "Dockerfile.fly"
 
 [env]
   PORT = "8080"


### PR DESCRIPTION
This requires `AUTH_TOKEN` to be set as a Github secret.

Fly deploys are slow because the DB seed process runs at boot. This branch seeds the DB at Docker build time, which will speed up deploys and make autoscaling possible.