### PR TITLE
fix: newsletter subscribition width on mobile /blog/:id

### DIFF
--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -134,7 +134,7 @@ export default function BlogPost() {
         </div>
       </div>
 
-      <div className="mt-24 mb-12 w-80 m-auto">
+      <div className="mt-24 mb-12 m-auto container sm:w-96">
         <h3 className="text-m-h3 font-bold mb-6 lg:text-d-h3">
           Get updates on the latest Remix news
         </h3>


### PR DESCRIPTION
Currently, the newsletter box on `/blog/:id` is too wide, resulting in x-coordinate scrollbars and visual crowding near the viewport edges.

<img width="400" alt="IMG_CADA14745DF2-1" src="https://user-images.githubusercontent.com/1316441/168694656-71ea554e-04b9-4548-a2ed-4351d5c486cf.jpeg">

This fixes that for smaller mobile devices, getting rid of the x-coordinate scrollbar as well as balanced spacing near the viewport edges.

<img width="400" alt="IMG_3B6F975B3FD7-1" src="https://user-images.githubusercontent.com/1316441/168695615-1bad5b3b-7e3a-46d3-8bcc-e084ae036f24.jpeg">

It works all the way down to small, narrow viewports.

<img width="509" alt="CleanShot 2022-05-16 at 16 56 44@2x" src="https://user-images.githubusercontent.com/1316441/168695698-705255d0-2bf2-469a-abbb-ae4d6d7f4607.png">




