### PR TITLE
Fix author stuff

### DIFF
--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -8,7 +8,7 @@ import { json } from "@remix-run/node";
 import invariant from "ts-invariant";
 
 import { getBlogPost } from "~/utils/md.server";
-import type { MarkdownPost } from "~/utils/md.server";
+import type { BlogPost as MarkdownPost } from "~/utils/md.server";
 import mdStyles from "~/styles/md.css";
 import { useRef } from "react";
 import { useDelegatedReactRouterLinks } from "~/components/delegate-links";
@@ -23,7 +23,7 @@ export let loader: LoaderFunction = async ({ params, request }) => {
   let requestUrl = new URL(request.url);
   let siteUrl = requestUrl.protocol + "//" + requestUrl.host;
 
-  let post: MarkdownPost = await getBlogPost(slug);
+  let post = await getBlogPost(slug);
   return json<LoaderData>(
     { siteUrl, post },
     { headers: { "Cache-Control": CACHE_CONTROL } }


### PR DESCRIPTION
Removing author meta from the frontmatter busted some stuff with our seed script and with markdown validation. Fixed that here, but I think we should also address the fact that we're duplicating some hairy logic that has long ago diverged to the point where I think we should handle MD/blog post parsing the same in both our app logic and the seed script.