### PR TITLE
Fix bad redirect logic

### DIFF
--- a/app/lib/gh-docs/params.ts
+++ b/app/lib/gh-docs/params.ts
@@ -29,8 +29,19 @@ export function validateParams(
       let latest = semver.maxSatisfying(tags, "*");
       let path = [first];
 
-      if (expandedRef) path.push(expandedRef);
-      else if (latest) path.push(latest, second);
+      if (expandedRef) {
+        path.push(expandedRef);
+      } else if (latest) {
+        if (semver.valid(second)) {
+          // If second looks like a semver tag but we didn't find it as a ref in
+          // the repo, we might just have a stale set of branches/tags from github.
+          // Instead of pushing both in and generating a 404 (/en/1.16.0/1.17.0/pages/...)
+          // we just point them back to the requested doc on main
+          path.push("main");
+        } else {
+          path.push(latest, second);
+        }
+      }
 
       if (splat) path.push(splat);
       return path.join("/");


### PR DESCRIPTION
Seems that if we run into a scenario where we get stale tags from github we can generate some bad redirects if users ask for the latest semver version.  In this instance, it seems like we hadn't been able to fetch latest tags including `1.17.0` so it was prepending the known latest release from it's cache of 1.16.0:

```
> curl -I https://remix.run/docs/en/1.17.0/pages/v2
HTTP/2 302
location: /docs/en/1.16.1/1.17.0/pages/v2
```