### PR TITLE
Add more robust ensureSecure

### DIFF
--- a/app/lib/http.server.ts
+++ b/app/lib/http.server.ts
@@ -89,12 +89,24 @@ export function removeTrailingSlashes(request: Request) {
   }
 }
 
+// Taken from https://github.com/remix-run/remix-jokes/blob/8f786d9d7fa7ea62203e87c1e0bdaa9bda3b28af/app/root.tsx#L25-L46
 export function ensureSecure(request: Request) {
-  let proto = request.headers.get("x-forwarded-proto");
-  if (proto === "http") {
-    let secureUrl = new URL(request.url);
-    secureUrl.protocol = "https:";
-    throw redirect(secureUrl.toString());
+  let url = new URL(request.url);
+  let hostname = url.hostname;
+  let proto = request.headers.get("X-Forwarded-Proto") ?? url.protocol;
+
+  url.host =
+    request.headers.get("X-Forwarded-Host") ??
+    request.headers.get("host") ??
+    url.host;
+  url.protocol = "https:";
+
+  if (proto === "http" && hostname !== "localhost") {
+    throw redirect(url.toString(), {
+      headers: {
+        "X-Forwarded-Proto": "https",
+      },
+    });
   }
 }
 


### PR DESCRIPTION
[It was noted](https://discord.com/channels/770287896669978684/940264701785423992/1157263496824750090) that http://remix.run is not redirecting to https://remix.run (I would recommend validating in an incognito browser)

For some reason staging doesn't have this problem, so not totally sure what's going on. Either way, attempting to fix this with a more robust version of `ensureSecure` taken from [this discussion](https://github.com/remix-run/remix/discussions/2915)