### PR TITLE
Fix broken docs meta and scroll padding

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -99,8 +99,9 @@ function Document({
   let colorScheme = useColorScheme();
   let matches = useMatches();
   let isDocsPage = !!matches.find((match) =>
-    match.id.startsWith("routes/docs/"),
+    match.id.startsWith("routes/docs"),
   );
+
   return (
     <html
       lang="en"

--- a/app/routes/docs.$lang.$ref.$.tsx
+++ b/app/routes/docs.$lang.$ref.$.tsx
@@ -54,7 +54,7 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => {
   return headers;
 };
 
-const LAYOUT_LOADER_KEY = "routes/docs/$lang.$ref";
+const LAYOUT_LOADER_KEY = "routes/docs.$lang.$ref";
 
 export const meta: MetaFunction<
   typeof loader,
@@ -64,6 +64,7 @@ export const meta: MetaFunction<
   }
 > = (args) => {
   let { data } = args;
+
   let matchesData = getMatchesData(args);
   let parentData = matchesData[LAYOUT_LOADER_KEY];
   if (!data) {


### PR DESCRIPTION
When I changed from v1 to v2 paths in #132 there were a few places we were using string matching that broke.

This is maybe a little bit precarious to begin with. Probably a good opportunity to think about adding more tests or if there's a better way to do this sort of matching