### PR TITLE
Remove public/ and add data/ to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ WORKDIR /remixapp
 
 COPY --from=production-deps /remixapp/node_modules /remixapp/node_modules
 COPY --from=build /remixapp/build /remixapp/build
-COPY --from=build /remixapp/public /remixapp/public
+COPY --from=build /remixapp/data /remixapp/data
 COPY --from=build /remixapp/server.js /remixapp/server.js
 COPY --from=build /remixapp/package.json /remixapp/package.json
 COPY --from=build /remixapp/start.sh /remixapp/start.sh


### PR DESCRIPTION
I was including `public/` for no reason, since it gets bundled into `build/` for Vite.

I was also not including `data/`, which is accessed via `fs` on the conference pages

This fixes both issues