### PR TITLE
Fix #98: Redirect to main branch when only lang slug is present

### DIFF
--- a/app/routes/docs.$lang.ts
+++ b/app/routes/docs.$lang.ts
@@ -1,0 +1,5 @@
+import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
+export async function loader({ params }: LoaderFunctionArgs) {
+    const { lang, ref } = params;
+    return !ref ? redirect(`/docs/${lang}/main`) : null;
+}


### PR DESCRIPTION
# This PR will:
* Add `docs/$lang.ts` file for redirection from `docs/:lang` to `docs/:lang/main`. 