### PR TITLE
feat(resources): add ability to choose package manager

### DIFF
--- a/app/lib/transformNpmCommand.ts
+++ b/app/lib/transformNpmCommand.ts
@@ -1,0 +1,21 @@
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
+
+export function transformNpmCommand(
+  prefix: string,
+  cmd: string,
+  packageManagerTarget: "yarn" | "bun" | "pnpm" | "npm",
+) {
+  if (prefix === "npm") {
+    if (cmd.split(" ")[0] === "install" && packageManagerTarget === "yarn") {
+      return `${packageManagerTarget} ${cmd.replace("install", "add")}`;
+    }
+    return `${packageManagerTarget} ${cmd}`;
+  }
+  switch (packageManagerTarget) {
+    case "bun":
+      return `bunx ${cmd}`;
+    case "pnpm":
+      return `pnpm dlx ${cmd}`;
+  }
+  return `${prefix} ${cmd}`;
+}

--- a/app/styles/resources.css
+++ b/app/styles/resources.css
@@ -41,7 +41,7 @@
   }
 
   & [data-code-block-copy] {
-    @apply absolute right-4 top-[1.125rem] h-5 w-5 cursor-pointer bg-white/80 opacity-0 dark:bg-gray-900/80;
+    @apply absolute top-[1.125rem] h-5 w-5 cursor-pointer bg-white/80 opacity-0 dark:bg-gray-900/80;
   }
 
   &:hover [data-code-block-copy],

--- a/app/ui/details-menu.tsx
+++ b/app/ui/details-menu.tsx
@@ -1,5 +1,7 @@
 import { forwardRef, useState, useRef, useEffect } from "react";
+import type { PropsWithChildren } from "react";
 import { useLocation, useNavigation } from "@remix-run/react";
+import cx from "clsx";
 
 /**
  * An enhanced `<details>` component that's intended to be used as a menu (a bit
@@ -77,10 +79,24 @@ export const DetailsMenu = forwardRef<
 });
 DetailsMenu.displayName = "DetailsMenu";
 
-export function DetailsPopup({ children }: { children: React.ReactNode }) {
+type DetailsPopupProps = {
+  className?: string;
+  childrenClassName?: string;
+};
+
+export function DetailsPopup({
+  children,
+  className = "",
+  childrenClassName = "",
+}: PropsWithChildren<DetailsPopupProps>) {
   return (
-    <div className="absolute right-0 z-20 md:left-0">
-      <div className="relative top-1 w-40 rounded-md border border-gray-100 bg-white p-1 shadow-sm  dark:border-gray-800 dark:bg-gray-900 ">
+    <div className={cx(className, "absolute right-0 z-20 md:left-0")}>
+      <div
+        className={cx(
+          childrenClassName,
+          "relative top-1 w-40 rounded-md border border-gray-100 bg-white p-1 shadow-sm  dark:border-gray-800 dark:bg-gray-900",
+        )}
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
This PR adds the ability to select the package manager (npm/yarn/pnpm/bun) when copying installation commands from the resources page.

<img width="379" alt="Capture d’écran 2024-02-03 à 19 01 51" src="https://github.com/remix-run/remix-website/assets/16417858/e2459e54-fb30-43c8-8925-342f94764f45">

I've used `DetailsMenu` component for the Dropdown menu logic.

Close #144