### PR TITLE
Add types/validation for matches

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -142,8 +142,12 @@ function Document({
 export default function App() {
   let matches = useMatches();
   let { noIndex } = useLoaderData<typeof loader>();
-  // @ts-expect-error -- useMatches types changed to `unknown`, need to validate
-  let forceDark = matches.some((match) => match.handle?.forceDark);
+  let forceDark = matches.some(({ handle }) => {
+    if (handle && typeof handle === "object" && "forceDark" in handle) {
+      return handle.forceDark;
+    }
+    return false;
+  });
 
   if (process.env.NODE_ENV !== "development") {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/app/routes/conf.2023.tsx
+++ b/app/routes/conf.2023.tsx
@@ -226,20 +226,25 @@ function isExternalUrl(value: string, currentHost: string) {
 const HeaderLink = React.forwardRef<HTMLAnchorElement, HeaderLinkProps>(
   ({ to, children, className, prefetch = "none", ...props }, ref) => {
     let rootMatch = useMatches().find((match) => match.id === "root")!;
-    // @ts-expect-error -- useMatches types changed to `unknown`, need to validate
-    let external = isExternalUrl(to, rootMatch.data.host);
-    if (external) {
-      return (
-        <a
-          ref={ref}
-          className={cx("text-base font-semibold", className)}
-          href={to}
-          children={children}
-          target="_blank"
-          rel="noopener noreferrer"
-          {...props}
-        />
-      );
+    if (
+      rootMatch.data &&
+      typeof rootMatch.data === "object" &&
+      "host" in rootMatch.data &&
+      typeof rootMatch.data.host === "string"
+    ) {
+      if (isExternalUrl(to, rootMatch.data.host)) {
+        return (
+          <a
+            ref={ref}
+            className={cx("text-base font-semibold", className)}
+            href={to}
+            children={children}
+            target="_blank"
+            rel="noopener noreferrer"
+            {...props}
+          />
+        );
+      }
     }
 
     return (

--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -36,6 +36,7 @@ import { octokit } from "~/lib/github.server";
 import { useColorScheme } from "~/lib/color-scheme";
 import { env } from "~/env.server";
 import { CACHE_CONTROL } from "~/lib/http.server";
+import invariant from "tiny-invariant";
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   let { lang = "en", ref = "main", "*": splat } = params;
@@ -754,10 +755,13 @@ function InnerContainer({ children }: { children: React.ReactNode }) {
   );
 }
 
+function hasDoc(data: unknown): data is { doc: Doc } {
+  return !!data && typeof data === "object" && "doc" in data;
+}
+
 function useDoc(): Doc | null {
-  let data = useMatches().slice(-1)[0].data;
-  if (!data) return null;
-  // @ts-expect-error -- useMatches types changed to `unknown`, need to validate
+  let data = useMatches().at(-1)?.data;
+  invariant(hasDoc(data), "No doc data found in loader data");
   return data.doc;
 }
 


### PR DESCRIPTION
In this PR, I added zod validation for matches and remove `ts-expect-error` annotation.

## Related
- https://github.com/remix-run/remix-website/issues/109