### PR TITLE
feat: Add global loading indicator to top nav

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,6 +25,7 @@ import { parseColorScheme } from "~/lib/color-scheme.server";
 import iconsHref from "~/icons.svg";
 import cx from "clsx";
 import { canUseDOM } from "./ui/primitives/utils";
+import { GlobalLoading } from "./ui/global-loading";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   removeTrailingSlashes(request);
@@ -128,6 +129,7 @@ function Document({
             : "bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-200",
         )}
       >
+        <GlobalLoading />
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/app/ui/global-loading.tsx
+++ b/app/ui/global-loading.tsx
@@ -1,21 +1,27 @@
-import * as React from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigation } from "@remix-run/react";
 import cx from "clsx";
 
 export function GlobalLoading() {
-  const transition = useNavigation();
-  const active = transition.state !== "idle";
+  let transition = useNavigation();
+  let active = transition.state !== "idle";
 
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [animationComplete, setAnimationComplete] = React.useState(true);
+  let ref = useRef<HTMLDivElement>(null);
+  let [animating, setAnimating] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!ref.current) return;
-    if (active) setAnimationComplete(false);
 
     Promise.allSettled(
       ref.current.getAnimations().map(({ finished }) => finished),
-    ).then(() => !active && setAnimationComplete(true));
+    ).then(() => {
+      if (!active) setAnimating(false);
+    });
+
+    if (active) {
+      let id = setTimeout(() => setAnimating(true), 100);
+      return () => clearTimeout(id);
+    }
   }, [active]);
 
   return (
@@ -30,11 +36,9 @@ export function GlobalLoading() {
         className={cx(
           "h-full bg-gradient-to-r from-blue-brand to-aqua-brand transition-all duration-500 ease-in-out",
           transition.state === "idle" &&
-            animationComplete &&
-            "w-0 opacity-0 transition-none",
+            (animating ? "w-full" : "w-0 opacity-0 transition-none"),
           transition.state === "submitting" && "w-4/12",
           transition.state === "loading" && "w-10/12",
-          transition.state === "idle" && !animationComplete && "w-full",
         )}
       />
     </div>

--- a/app/ui/global-loading.tsx
+++ b/app/ui/global-loading.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { useNavigation } from "@remix-run/react";
+import cx from "clsx";
+
+export function GlobalLoading() {
+  const transition = useNavigation();
+  const active = transition.state !== "idle";
+
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [animationComplete, setAnimationComplete] = React.useState(true);
+
+  React.useEffect(() => {
+    if (!ref.current) return;
+    if (active) setAnimationComplete(false);
+
+    Promise.allSettled(
+      ref.current.getAnimations().map(({ finished }) => finished),
+    ).then(() => !active && setAnimationComplete(true));
+  }, [active]);
+
+  return (
+    <div
+      role="progressbar"
+      aria-hidden={!active}
+      aria-valuetext={active ? "Loading" : undefined}
+      className="fixed inset-x-0 left-0 top-0 z-50 h-1 animate-pulse"
+    >
+      <div
+        ref={ref}
+        className={cx(
+          "h-full bg-gradient-to-r from-blue-brand to-aqua-brand transition-all duration-500 ease-in-out",
+          transition.state === "idle" &&
+            animationComplete &&
+            "w-0 opacity-0 transition-none",
+          transition.state === "submitting" && "w-4/12",
+          transition.state === "loading" && "w-10/12",
+          transition.state === "idle" && !animationComplete && "w-full",
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
According to @brophdawg11 's suggestion and issue #163 , I added this POC to the `root.tsx`.

In the example below I added a `await sleep(2000)` to the blog loaders and the theme switch action to see the complete animation and the places where the progressbar stops in both slow actions and loaders.

This was taken from my [blog post](https://dev.to/remix-run-br/creating-a-github-like-progress-bar-for-your-remix-app-153l) and I've been using this code successfully in almost all my Remix apps.
I appreciate any feedback if rejected and willing to make any modifications requested. ;)

I've chosen a gradient from `bg-blue-brand` to `bg-aqua-brand` I think works good on both dark and light modes.

## Preview:
![screen](https://github.com/remix-run/remix-website/assets/566971/4bfa7b1f-547f-4bf1-9c5f-b9a85373904e)
