### PR TITLE
Add `react-router-dom` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-is": "^18.2.0",
+        "react-router-dom": "^6.22.0",
         "rehype-autolink-headings": "^6.1.1",
         "rehype-slug": "^5.1.0",
         "rehype-stringify": "^9.0.3",
@@ -2903,6 +2904,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/react/node_modules/react-router-dom": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.3.tgz",
+      "integrity": "sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==",
+      "dependencies": {
+        "@remix-run/router": "1.14.2",
+        "react-router": "6.21.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@remix-run/router": {
@@ -13214,12 +13231,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.3.tgz",
-      "integrity": "sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.0.tgz",
+      "integrity": "sha512-z2w+M4tH5wlcLmH3BMMOMdrtrJ9T3oJJNsAlBJbwk+8Syxd5WFJ7J5dxMEW0/GEXD1BBis4uXRrNIz3mORr0ag==",
       "dependencies": {
-        "@remix-run/router": "1.14.2",
-        "react-router": "6.21.3"
+        "@remix-run/router": "1.15.0",
+        "react-router": "6.22.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -13227,6 +13244,28 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/@remix-run/router": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
+      "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
+      "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
+      "dependencies": {
+        "@remix-run/router": "1.15.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
+    "react-router-dom": "^6.22.0",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.1.0",
     "rehype-stringify": "^9.0.3",


### PR DESCRIPTION
Due to the way `npm` solves peer dependencies making a flat `node_modules`, we were able to import `react-router-dom` in the project even when we didn't have it as dependency.

This adds the dependency to avoid possible future bugs for realying on an undeclared dependency.

Also, bumps `react-router-dom` version from 6.21.3 to 6.22.0

While this is not a switch to `pnpm`, it fixes the bug mentioned in #166