### PR TITLE
Import `matchPath` from declared dependency

### DIFF
--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -9,9 +9,9 @@ import {
   useNavigation,
   useParams,
   useResolvedPath,
+  matchPath,
 } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
-import { matchPath } from "react-router-dom";
 import { json, redirect } from "@remix-run/node";
 import type { LoaderFunctionArgs, HeadersFunction } from "@remix-run/node";
 import { metaV1 } from "@remix-run/v1-meta";


### PR DESCRIPTION
`matchPath` was being imported from an undeclared dependency, but could be used due to `npm` flattening peer-dependencies. This way we ensure we're using the expected version.