### PR TITLE
fix: remove unnecessary horizontal scrollbar

### DIFF
--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -192,7 +192,7 @@ function Header() {
     >
       <InnerContainer>
         <div className="relative z-20 flex h-16 w-full items-center justify-between py-3">
-          <div className="flex w-full items-center justify-between gap-8 md:w-auto">
+          <div className="flex w-full items-center justify-between gap-4 sm:gap-8 md:w-auto">
             <Link
               className="flex"
               onContextMenu={(event) => {


### PR DESCRIPTION
While viewing the Remix documentation pages on my mobile device, I noticed the presence of an unnecessary scrollbar.

The mobile device I used for testing was a Galaxy Z Flip 3.

https://github.com/remix-run/remix-website/assets/66447334/7967254f-1175-45be-8e31-ba5683b0c178

I believe this issue emerged following the addition of a search icon to `<Header>` in this [PR](https://github.com/remix-run/remix-website/pull/177). So, I adjusted the gap between the logo and the list of icons within the `<Header>` to better accommodate mobile display sizes.

https://github.com/remix-run/remix-website/assets/66447334/1b85ac0a-8b7a-405b-9dc4-0e8a8f40fcf1

For reference, this unnecessary scrollbar was not observed on an iPhone SE. 


https://github.com/remix-run/remix-website/assets/66447334/33069091-a6ec-4148-996f-84398a14d680