### PR TITLE
feat: add /blog/rss.xml route

### DIFF
--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -1,0 +1,46 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { getBlogPostListings } from "~/lib/blog.server";
+
+const getCData = (text: string) => {
+  return `<![CDATA[${text}]]>`;
+};
+
+export const loader: LoaderFunction = async () => {
+  const blogUrl = `https://remix.run/blog`;
+  const posts = await getBlogPostListings();
+
+  const rss = `
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+      <channel>
+        <title>Remix Blog</title>
+        <link>${blogUrl}</link>
+        <atom:link href="${blogUrl}/rss.xml" rel="self" type="application/rss+xml" />
+        <description>Thoughts about building excellent user experiences with Remix.</description>
+        <language>en-us</language>
+        <generator>https://github.com/remix-run/remix</generator>
+        <copyright>© Shopify, Inc.</copyright>
+        ${posts
+          .map(post =>
+            `
+            <item>
+              <title>${getCData(post.title)}</title>
+              <description>RFC-822 date: ${getCData(post.summary)}</description>
+              <pubDate>${new Date(post.dateDisplay).toUTCString()}</pubDate>
+              <link>${blogUrl}/${post.slug}</link>
+              <guid>${blogUrl}/${post.slug}</guid>
+            </item>
+          `.trim(),
+          )
+          .join('\n')}
+      </channel>
+    </rss>
+  `.trim();
+
+
+  return new Response(rss, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, max-age=0",
+    },
+  });
+};

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -1,6 +1,7 @@
 import type { LoaderFunction } from "@remix-run/node";
 import { getBlogPostListings } from "~/lib/blog.server";
 import { Feed } from "feed";
+import { CACHE_CONTROL } from "~/lib/http.server";
 
 export const loader: LoaderFunction = async () => {
   const blogUrl = `https://remix.run/blog`;
@@ -29,7 +30,7 @@ export const loader: LoaderFunction = async () => {
   return new Response(feed.rss2(), {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": "public, max-age=0",
+      "Cache-Control": CACHE_CONTROL.DEFAULT,
     },
   });
 };

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -6,7 +6,6 @@ import { CACHE_CONTROL } from "~/lib/http.server";
 export const loader: LoaderFunction = async () => {
   const blogUrl = `https://remix.run/blog`;
   const posts = await getBlogPostListings();
-  const latestPost = posts.length > 0 ? posts[0] : null;
   
   const feed = new Feed({
     id: blogUrl,
@@ -14,7 +13,7 @@ export const loader: LoaderFunction = async () => {
     description: "Thoughts about building excellent user experiences with Remix.",
     link: blogUrl,
     language: 'en',
-    updated: latestPost ? new Date(latestPost.dateDisplay) : new Date(),
+    updated: posts.length > 0 ? new Date(posts[0].dateDisplay) : new Date(),
     generator: "https://github.com/jpmonette/feed",
     copyright: "© Shopify, Inc.",
   });

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -6,16 +6,19 @@ import { CACHE_CONTROL } from "~/lib/http.server";
 export const loader: LoaderFunction = async () => {
   const blogUrl = `https://remix.run/blog`;
   const posts = await getBlogPostListings();
-
+  const latestPost = posts.length > 0 ? posts[0] : null;
+  
   const feed = new Feed({
     id: blogUrl,
     title: "Remix Blog",
     description: "Thoughts about building excellent user experiences with Remix.",
     link: blogUrl,
     language: 'en',
+    updated: latestPost ? new Date(latestPost.dateDisplay) : new Date(),
     generator: "https://github.com/jpmonette/feed",
     copyright: "© Shopify, Inc.",
   });
+
   posts.forEach((post) => {
     const postLink = `${blogUrl}/${post.slug}`;
     feed.addItem({

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -12,7 +12,7 @@ export const loader: LoaderFunction = async () => {
     title: "Remix Blog",
     description: "Thoughts about building excellent user experiences with Remix.",
     link: blogUrl,
-    language: 'en-us',
+    language: 'en',
     generator: "https://github.com/jpmonette/feed",
     copyright: "© Shopify, Inc.",
   });

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -26,7 +26,7 @@ export const loader: LoaderFunction = async () => {
       title: post.title,
       link: postLink,
       date: new Date(post.dateDisplay),
-      description: post.dateDisplay,
+      description: post.summary,
     });
   });
 

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -24,7 +24,7 @@ export const loader: LoaderFunction = async () => {
             `
             <item>
               <title>${getCData(post.title)}</title>
-              <description>RFC-822 date: ${getCData(post.summary)}</description>
+              <description>${getCData(post.summary)}</description>
               <pubDate>${new Date(post.dateDisplay).toUTCString()}</pubDate>
               <link>${blogUrl}/${post.slug}</link>
               <guid>${blogUrl}/${post.slug}</guid>

--- a/app/routes/_extras.blog.rss[.xml].tsx
+++ b/app/routes/_extras.blog.rss[.xml].tsx
@@ -1,43 +1,32 @@
 import type { LoaderFunction } from "@remix-run/node";
 import { getBlogPostListings } from "~/lib/blog.server";
-
-const getCData = (text: string) => {
-  return `<![CDATA[${text}]]>`;
-};
+import { Feed } from "feed";
 
 export const loader: LoaderFunction = async () => {
   const blogUrl = `https://remix.run/blog`;
   const posts = await getBlogPostListings();
 
-  const rss = `
-    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-      <channel>
-        <title>Remix Blog</title>
-        <link>${blogUrl}</link>
-        <atom:link href="${blogUrl}/rss.xml" rel="self" type="application/rss+xml" />
-        <description>Thoughts about building excellent user experiences with Remix.</description>
-        <language>en-us</language>
-        <generator>https://github.com/remix-run/remix</generator>
-        <copyright>© Shopify, Inc.</copyright>
-        ${posts
-          .map(post =>
-            `
-            <item>
-              <title>${getCData(post.title)}</title>
-              <description>${getCData(post.summary)}</description>
-              <pubDate>${new Date(post.dateDisplay).toUTCString()}</pubDate>
-              <link>${blogUrl}/${post.slug}</link>
-              <guid>${blogUrl}/${post.slug}</guid>
-            </item>
-          `.trim(),
-          )
-          .join('\n')}
-      </channel>
-    </rss>
-  `.trim();
+  const feed = new Feed({
+    id: blogUrl,
+    title: "Remix Blog",
+    description: "Thoughts about building excellent user experiences with Remix.",
+    link: blogUrl,
+    language: 'en-us',
+    generator: "https://github.com/jpmonette/feed",
+    copyright: "© Shopify, Inc.",
+  });
+  posts.forEach((post) => {
+    const postLink = `${blogUrl}/${post.slug}`;
+    feed.addItem({
+      id: postLink,
+      title: post.title,
+      link: postLink,
+      date: new Date(post.dateDisplay),
+      description: post.dateDisplay,
+    });
+  });
 
-
-  return new Response(rss, {
+  return new Response(feed.rss2(), {
     headers: {
       "Content-Type": "application/xml",
       "Cache-Control": "public, max-age=0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "fathom-client": "^3.6.0",
+        "feed": "^4.2.2",
         "follow-redirects": "^1.15.5",
         "front-matter": "^4.0.2",
         "gray-matter": "^4.0.3",
@@ -8019,6 +8020,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/fflate": {
@@ -22186,6 +22198,17 @@
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-parse-from-string": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "fathom-client": "^3.6.0",
+    "feed": "^4.2.2",
     "follow-redirects": "^1.15.5",
     "front-matter": "^4.0.2",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
closes #182 

As mentioned by @slorber and @brookslybrand , I also think that Remix should have an RSS feed for blog posts. Therefore, I updated it so that an appropriate RSS feed can be visible by accessing /blog/rss.xml.