### PR TITLE
fix: resolve symlinked files

### DIFF
--- a/app/lib/gh-docs/branches.ts
+++ b/app/lib/gh-docs/branches.ts
@@ -1,7 +1,6 @@
 import { LRUCache } from "lru-cache";
-import type { Octokit } from "octokit";
+import type { CacheContext } from ".";
 
-type CacheContext = { octokit: Octokit };
 declare global {
   var branchesCache: LRUCache<string, string[], CacheContext>;
 }

--- a/app/lib/gh-docs/docs.ts
+++ b/app/lib/gh-docs/docs.ts
@@ -6,9 +6,7 @@ import { getRepoTarballStream } from "./repo-tarball";
 import { createTarFileProcessor } from "./tarball.server";
 import { load as $ } from "cheerio";
 import { env } from "~/env.server";
-import type { Octokit } from "octokit";
-
-type CacheContext = { octokit: Octokit };
+import type { CacheContext } from ".";
 
 interface MenuDocAttributes {
   title: string;

--- a/app/lib/gh-docs/index.ts
+++ b/app/lib/gh-docs/index.ts
@@ -15,6 +15,8 @@ export {
 
 export type { Doc } from "./docs";
 
+export type CacheContext = { octokit: Octokit };
+
 const REPO = env.SOURCE_REPO;
 const RELEASE_PACKAGE = env.RELEASE_PACKAGE;
 
@@ -48,8 +50,8 @@ export function getRepoDocsMenu(ref: string, lang: string) {
   return getMenu(REPO, fixupRefName(ref), lang);
 }
 
-export function getRepoDoc(ref: string, slug: string) {
-  return getDoc(REPO, fixupRefName(ref), slug);
+export function getRepoDoc(ref: string, slug: string, context: CacheContext) {
+  return getDoc(REPO, fixupRefName(ref), slug, context);
 }
 
 function fixupRefName(ref: string) {

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -3,7 +3,6 @@ import path from "path";
 import invariant from "tiny-invariant";
 import { env } from "~/env.server";
 
-import type { octokit } from "../github.server";
 import type { CacheContext } from ".";
 
 /**
@@ -26,20 +25,13 @@ export async function getRepoContent(
     repo,
     ref,
     path: filepath,
-    mediaType: { format: "base64" },
+    mediaType: { format: "raw" },
   });
 
-  return base64DecodeFileContents(contents);
-}
-
-export function base64DecodeFileContents(
-  contents: Awaited<ReturnType<typeof octokit.rest.repos.getContent>>,
-): string | null {
-  if ("type" in contents.data && contents.data.type === "file") {
-    return Buffer.from(contents.data.content, "base64").toString("utf-8");
-  }
-
-  return null;
+  // when using `format: raw` the data property is the file contents
+  let md = contents.data as unknown;
+  if (md == null || typeof md !== "string") return null;
+  return md;
 }
 
 /**

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -2,10 +2,9 @@ import fsp from "fs/promises";
 import path from "path";
 import invariant from "tiny-invariant";
 import { env } from "~/env.server";
-import type { Octokit } from "octokit";
-import type { octokit } from "../github.server";
 
-type CacheContext = { octokit: Octokit };
+import type { octokit } from "../github.server";
+import type { CacheContext } from ".";
 
 /**
  * Fetches the contents of a file in a repository or from your local disk.

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -26,6 +26,12 @@ export async function getRepoContent(
     mediaType: { format: "base64" },
   });
 
+  return base64DecodeFileContents(contents);
+}
+
+export function base64DecodeFileContents(
+  contents: Awaited<ReturnType<typeof octokit.rest.repos.getContent>>,
+): string | null {
   if ("type" in contents.data && contents.data.type === "file") {
     return Buffer.from(contents.data.content, "base64").toString("utf-8");
   }

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -2,7 +2,10 @@ import fsp from "fs/promises";
 import path from "path";
 import invariant from "tiny-invariant";
 import { env } from "~/env.server";
-import { octokit } from "../github.server";
+import type { Octokit } from "octokit";
+import type { octokit } from "../github.server";
+
+type CacheContext = { octokit: Octokit };
 
 /**
  * Fetches the contents of a file in a repository or from your local disk.
@@ -15,10 +18,11 @@ export async function getRepoContent(
   repoPair: string,
   ref: string,
   filepath: string,
+  context: CacheContext,
 ): Promise<string | null> {
   if (ref === "local") return getLocalContent(filepath);
   let [owner, repo] = repoPair.split("/");
-  let contents = await octokit.rest.repos.getContent({
+  let contents = await context.octokit.rest.repos.getContent({
     owner,
     repo,
     ref,

--- a/app/lib/gh-docs/tags.ts
+++ b/app/lib/gh-docs/tags.ts
@@ -2,8 +2,9 @@ import { LRUCache } from "lru-cache";
 import parseLinkHeader from "parse-link-header";
 import semver from "semver";
 import type { Octokit } from "octokit";
+import type { CacheContext as BaseCacheContext } from ".";
 
-type CacheContext = { octokit: Octokit; releasePackage: string };
+type CacheContext = BaseCacheContext & { releasePackage: string };
 declare global {
   var tagsCache: LRUCache<string, string[], CacheContext>;
 }

--- a/app/lib/resources.server.ts
+++ b/app/lib/resources.server.ts
@@ -3,9 +3,9 @@ import { LRUCache } from "lru-cache";
 import { env } from "~/env.server";
 import { base64DecodeFileContents } from "./gh-docs/repo-content";
 import { processMarkdown } from "./md.server";
-import type { Octokit } from "octokit";
 import resourcesYamlFileContents from "../../data/resources.yaml?raw";
 import { slugify } from "~/ui/primitives/utils";
+import type { CacheContext } from "./gh-docs";
 
 // TODO: parse this with zod
 let _resources: ResourceYamlData[] = yaml.parse(resourcesYamlFileContents);
@@ -36,7 +36,6 @@ type ResourceYamlKeys =
   | "featured";
 type ResourceYamlData = Pick<Resource, ResourceYamlKeys>;
 type ResourceGitHubData = Omit<Resource, ResourceYamlKeys>;
-type CacheContext = { octokit: Octokit };
 
 /**
  * Gets all of the resources, fetching and merging GitHub data for each one

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -2,6 +2,7 @@ import { handleRedirects } from "~/lib/http.server";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { redirect, json } from "@remix-run/node";
 import { getRepoDoc } from "~/lib/gh-docs";
+import { octokit } from "~/lib/github.server";
 
 // We use the catch-all route to attempt to find a doc for the given path. If a
 // doc isn't found, we return a 404 as expected. However we also log those
@@ -55,7 +56,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   try {
     let ref = "main";
     let lang = "en";
-    let doc = await getRepoDoc(ref, `docs/${params["*"]}`);
+    let doc = await getRepoDoc(ref, `docs/${params["*"]}`, { octokit });
     if (!doc) throw null;
     // FIXME: This results in two fetches, as the loader for the docs page will
     // repeat the request cycle. This isn't a problem if the doc is in the LRU

--- a/app/routes/docs.$lang.$ref.$.tsx
+++ b/app/routes/docs.$lang.$ref.$.tsx
@@ -24,6 +24,7 @@ import cx from "clsx";
 import { useDelegatedReactRouterLinks } from "~/ui/delegate-links";
 import type { loader as docsLayoutLoader } from "~/routes/docs.$lang.$ref";
 import type { loader as rootLoader } from "~/root";
+import { octokit } from "~/lib/github.server";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   let url = new URL(request.url);
@@ -33,7 +34,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     let slug = params["*"]?.endsWith("/changelog")
       ? "CHANGELOG"
       : `docs/${params["*"] || "index"}`;
-    let doc = await getRepoDoc(params.ref, slug);
+    let doc = await getRepoDoc(params.ref, slug, { octokit });
     if (!doc) throw null;
     return json(
       { doc, pageUrl },


### PR DESCRIPTION
mcansh/remix-fastify root README is a symlink to the README in packages/remix-fastify and using the raw.github... doesnt follow the redirect

closes #190

feel free to close if any of the other commenters on the issue also do the work so they can get the contribution :)

Signed-off-by: Logan McAnsh <logan@mcan.sh>
