### PR TITLE
Balance spacing within multi-line alerts

### DIFF
--- a/app/styles/docs.css
+++ b/app/styles/docs.css
@@ -476,6 +476,13 @@
     @apply pointer-events-none absolute inset-0 opacity-10 content-[""];
   }
 
+  & docs-info > :last-child,
+  & docs-success > :last-child,
+  & docs-warning > :last-child,
+  & docs-error > :last-child {
+    @apply mb-0;
+  }
+
   & docs-warning {
     @apply text-yellow-800 dark:text-yellow-100;
   }


### PR DESCRIPTION
Before:

<img width="791" alt="Screenshot 2024-02-21 at 11 36 54 am" src="https://github.com/remix-run/remix-website/assets/696693/27852cc9-e049-4a45-a44a-4d72d38d3af2">

After:

<img width="781" alt="Screenshot 2024-02-21 at 11 37 05 am" src="https://github.com/remix-run/remix-website/assets/696693/bd3d7e8d-6e77-425b-804a-f9dc8ccab918">
