### PR TITLE
Render docs search bar on all branches

### DIFF
--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -343,8 +343,6 @@ function VersionLink({
 }
 
 function DocSearchSection({ className }: { className?: string }) {
-  let { isLatest } = useLoaderData<typeof loader>();
-  if (!isLatest) return null;
   return (
     <div className={cx("relative lg:sticky lg:top-0 lg:z-10", className)}>
       <div className="absolute -top-24 hidden h-24 w-full bg-white dark:bg-gray-900 lg:block" />


### PR DESCRIPTION
## Changes

- Renders docs search bar on all branches by removing [these 2 lines](https://github.com/remix-run/remix-website/blob/main/app/routes/docs.%24lang.%24ref.tsx#L346-L347)
- Closes #200 

## Demonstration

| Before | After |
| ------ | ----- |
| ![before](https://github.com/remix-run/remix-website/assets/40516784/a6523f08-7819-49bc-81da-c63968ffd09b) | ![after](https://github.com/remix-run/remix-website/assets/40516784/cff40d18-3eed-4a2e-b1ee-b4b65e8d89b2) |
