### PR TITLE
Add background color to __mutation_code class

### DIFF
--- a/app/styles/bailwind.css
+++ b/app/styles/bailwind.css
@@ -22,7 +22,7 @@
 }
 
 .__mutation_code pre {
-  @apply h-[50vh] overflow-hidden py-2 sm:py-4;
+  @apply h-[50vh] overflow-hidden bg-gray-800 py-2 sm:py-4;
 
   & .codeblock-line {
     @apply relative block px-2 leading-relaxed sm:px-8;


### PR DESCRIPTION
While improving the styles to the site in #127 [this line was removed](https://github.com/remix-run/remix-website/commit/1692456460f9f06dc3b3c5e9ccf1175455dfd88b#diff-a77bf882aa4314d2c5c16abccc82037da094213a6f4d5b32d7ec907624227cc2L226-R223). This made all of the codeblocks on the docs look a little nicer.

However, it broke a bit of the home page experience toward the bottom:

![incorrect overlay of text on top of text](https://github.com/remix-run/remix-website/assets/12396812/ecc5392f-d6b1-4e89-97d8-75bc1536e662)

Simply adding this style to the `__mutation_code` class fixed the problem.

Personally, I think removing as much from the remark/shiki parsing as we can is probably a good thing. In pretty much all other cases we selected the `pre` tag directly.

At some point I would really love to go through all the styling on the website and unify it a bit more, since right now there's not a completely cohesive look and feel. It's fine, but it could be much better.