### PR TITLE
fix: revert using octokit for getRepoContent

### DIFF
--- a/app/lib/gh-docs/branches.ts
+++ b/app/lib/gh-docs/branches.ts
@@ -1,5 +1,7 @@
 import { LRUCache } from "lru-cache";
-import type { CacheContext } from ".";
+import type { Octokit } from "octokit";
+
+type CacheContext = { octokit: Octokit };
 
 declare global {
   var branchesCache: LRUCache<string, string[], CacheContext>;

--- a/app/lib/gh-docs/docs.ts
+++ b/app/lib/gh-docs/docs.ts
@@ -6,7 +6,6 @@ import { getRepoTarballStream } from "./repo-tarball";
 import { createTarFileProcessor } from "./tarball.server";
 import { load as $ } from "cheerio";
 import { env } from "~/env.server";
-import type { CacheContext } from ".";
 
 interface MenuDocAttributes {
   title: string;
@@ -30,7 +29,7 @@ export interface Doc extends Omit<MenuDoc, "hasContent"> {
 
 declare global {
   var menuCache: LRUCache<string, MenuDoc[]>;
-  var docCache: LRUCache<string, Doc, CacheContext>;
+  var docCache: LRUCache<string, Doc>;
 }
 
 let NO_CACHE = env.NO_CACHE;
@@ -82,7 +81,7 @@ function parseAttrs(
  * let's have simpler and faster deployments with just one origin server, but
  * still distribute the documents across the CDN.
  */
-global.docCache ??= new LRUCache<string, Doc, CacheContext>({
+global.docCache ??= new LRUCache<string, Doc>({
   max: 300,
   ttl: NO_CACHE ? 1 : 1000 * 60 * 5, // 5 minutes
   allowStale: !NO_CACHE,
@@ -90,14 +89,10 @@ global.docCache ??= new LRUCache<string, Doc, CacheContext>({
   fetchMethod: fetchDoc,
 });
 
-async function fetchDoc(
-  key: string,
-  _staleValue: Doc | undefined,
-  { context }: LRUCache.FetchOptionsWithContext<string, Doc, CacheContext>,
-): Promise<Doc> {
+async function fetchDoc(key: string): Promise<Doc> {
   let [repo, ref, slug] = key.split(":");
   let filename = `${slug}.md`;
-  let md = await getRepoContent(repo, ref, filename, context);
+  let md = await getRepoContent(repo, ref, filename);
   if (md === null) {
     throw Error(`Could not find ${filename} in ${repo}@${ref}`);
   }
@@ -128,10 +123,9 @@ export async function getDoc(
   repo: string,
   ref: string,
   slug: string,
-  context: CacheContext,
 ): Promise<Doc | undefined> {
   let key = `${repo}:${ref}:${slug}`;
-  let doc = await docCache.fetch(key, { context });
+  let doc = await docCache.fetch(key);
 
   return doc || undefined;
 }

--- a/app/lib/gh-docs/index.ts
+++ b/app/lib/gh-docs/index.ts
@@ -15,8 +15,6 @@ export {
 
 export type { Doc } from "./docs";
 
-export type CacheContext = { octokit: Octokit };
-
 const REPO = env.SOURCE_REPO;
 const RELEASE_PACKAGE = env.RELEASE_PACKAGE;
 
@@ -50,8 +48,8 @@ export function getRepoDocsMenu(ref: string, lang: string) {
   return getMenu(REPO, fixupRefName(ref), lang);
 }
 
-export function getRepoDoc(ref: string, slug: string, context: CacheContext) {
-  return getDoc(REPO, fixupRefName(ref), slug, context);
+export function getRepoDoc(ref: string, slug: string) {
+  return getDoc(REPO, fixupRefName(ref), slug);
 }
 
 function fixupRefName(ref: string) {

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -3,8 +3,6 @@ import path from "path";
 import invariant from "tiny-invariant";
 import { env } from "~/env.server";
 
-import type { CacheContext } from ".";
-
 /**
  * Fetches the contents of a file in a repository or from your local disk.
  *
@@ -16,22 +14,16 @@ export async function getRepoContent(
   repoPair: string,
   ref: string,
   filepath: string,
-  context: CacheContext,
 ): Promise<string | null> {
   if (ref === "local") return getLocalContent(filepath);
   let [owner, repo] = repoPair.split("/");
-  let contents = await context.octokit.rest.repos.getContent({
-    owner,
-    repo,
-    ref,
-    path: filepath,
-    mediaType: { format: "raw" },
-  });
-
-  // when using `format: raw` the data property is the file contents
-  let md = contents.data as unknown;
-  if (md == null || typeof md !== "string") return null;
-  return md;
+  let pathname = `/${owner}/${repo}/${ref}/${filepath}`;
+  let response = await fetch(
+    new URL(pathname, "https://raw.githubusercontent.com/").href,
+    { headers: { "User-Agent": `docs:${owner}/${repo}` } },
+  );
+  if (!response.ok) return null;
+  return response.text();
 }
 
 /**

--- a/app/lib/gh-docs/tags.ts
+++ b/app/lib/gh-docs/tags.ts
@@ -2,9 +2,8 @@ import { LRUCache } from "lru-cache";
 import parseLinkHeader from "parse-link-header";
 import semver from "semver";
 import type { Octokit } from "octokit";
-import type { CacheContext as BaseCacheContext } from ".";
 
-type CacheContext = BaseCacheContext & { releasePackage: string };
+type CacheContext = { octokit: Octokit; releasePackage: string };
 declare global {
   var tagsCache: LRUCache<string, string[], CacheContext>;
 }

--- a/app/lib/resources.server.ts
+++ b/app/lib/resources.server.ts
@@ -4,7 +4,9 @@ import { env } from "~/env.server";
 import { processMarkdown } from "./md.server";
 import resourcesYamlFileContents from "../../data/resources.yaml?raw";
 import { slugify } from "~/ui/primitives/utils";
-import type { CacheContext } from "./gh-docs";
+import type { Octokit } from "octokit";
+
+export type CacheContext = { octokit: Octokit };
 
 // TODO: parse this with zod
 let _resources: ResourceYamlData[] = yaml.parse(resourcesYamlFileContents);

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -2,7 +2,6 @@ import { handleRedirects } from "~/lib/http.server";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { redirect, json } from "@remix-run/node";
 import { getRepoDoc } from "~/lib/gh-docs";
-import { octokit } from "~/lib/github.server";
 
 // We use the catch-all route to attempt to find a doc for the given path. If a
 // doc isn't found, we return a 404 as expected. However we also log those
@@ -56,7 +55,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   try {
     let ref = "main";
     let lang = "en";
-    let doc = await getRepoDoc(ref, `docs/${params["*"]}`, { octokit });
+    let doc = await getRepoDoc(ref, `docs/${params["*"]}`);
     if (!doc) throw null;
     // FIXME: This results in two fetches, as the loader for the docs page will
     // repeat the request cycle. This isn't a problem if the doc is in the LRU

--- a/app/routes/docs.$lang.$ref.$.tsx
+++ b/app/routes/docs.$lang.$ref.$.tsx
@@ -24,7 +24,6 @@ import cx from "clsx";
 import { useDelegatedReactRouterLinks } from "~/ui/delegate-links";
 import type { loader as docsLayoutLoader } from "~/routes/docs.$lang.$ref";
 import type { loader as rootLoader } from "~/root";
-import { octokit } from "~/lib/github.server";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   let url = new URL(request.url);
@@ -34,7 +33,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     let slug = params["*"]?.endsWith("/changelog")
       ? "CHANGELOG"
       : `docs/${params["*"] || "index"}`;
-    let doc = await getRepoDoc(params.ref, slug, { octokit });
+    let doc = await getRepoDoc(params.ref, slug);
     if (!doc) throw null;
     return json(
       { doc, pageUrl },


### PR DESCRIPTION
In #191 we switched from using fetching against `https://raw.githubusercontent.com/` directly and instead opted to use `octokit`. While this was appropriate (and necessary) for the [resources](https://remix.run/resources) page, it caused a problem for our docs pages.

503 errors started showing up on the docs pages for various users

![image](https://github.com/remix-run/remix-website/assets/12396812/a3c97f2e-016b-4eb5-a543-368765a944bb)

Inside of our Fly logs we started getting these errors

> Request quota exhausted for request GET /repos/{owner}/{repo}/contents/{path}

It seems like when trying to fetch the docs it would hit `octokit`'s rate limiting. I deployed this change to main ~45min before putting up this PR and so far errors seem to be abated

<img width="475" alt="image" src="https://github.com/remix-run/remix-website/assets/12396812/38b247ad-127e-469b-a1dc-819a5d01f5aa">

The only thing I'm still confused about is why this issue didn't show up sooner. Not sure if the amount of traffic we've been getting since [our last announcement](https://twitter.com/remix_run/status/1760052041156604381) overwhelmed it and it was never able to recover.

Either way, we'll merge this revert in and continue to monitor. 