### PR TITLE
Remove @remix-run/v1-meta

### DIFF
--- a/app/routes/conf.2023._index.tsx
+++ b/app/routes/conf.2023._index.tsx
@@ -2,7 +2,6 @@ import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import cx from "clsx";
 import {
   secondaryButtonLinkClass,
@@ -15,27 +14,16 @@ import { Link } from "~/ui/link";
 import { CACHE_CONTROL } from "~/lib/http.server";
 import { getSpeakers, getSponsors } from "~/lib/conf2023.server";
 import type { Speaker } from "~/lib/conf2023";
+import { getMeta } from "~/lib/meta";
 
 export const meta: MetaFunction<typeof loader> = (args) => {
-  let { siteUrl } = args.data || {};
-  let url = siteUrl ? `${siteUrl}/conf` : null;
-  let title = "Remix Conf — May 2023";
-  let image = siteUrl ? `${siteUrl}/conf-images/2023/og_image.jpg` : null;
-  let description =
-    "Join us in Salt Lake City, UT for our innaugural conference. Featuring distinguished speakers, workshops, and lots of fun in between. See you there!";
-  return metaV1(args, {
-    title,
-    description,
-    "og:url": url,
-    "og:title": title,
-    "og:description": description,
-    "og:image": image,
-    "twitter:card": "summary_large_image",
-    "twitter:creator": "@remix_run",
-    "twitter:site": "@remix_run",
-    "twitter:title": title,
-    "twitter:description": description,
-    "twitter:image": image,
+  const { siteUrl } = args.data || {};
+  return getMeta({
+    title: "Remix Conf — May 2023",
+    description:
+      "Join us in Salt Lake City, UT for our innaugural conference. Featuring distinguished speakers, workshops, and lots of fun in between. See you there!",
+    siteUrl: siteUrl ? `${siteUrl}/conf` : undefined,
+    image: siteUrl ? `${siteUrl}/conf-images/2023/og_image.jpg` : undefined,
   });
 };
 

--- a/app/routes/conf.2023._inner.schedule.tsx
+++ b/app/routes/conf.2023._inner.schedule.tsx
@@ -9,7 +9,6 @@ import type { MetaFunction } from "@remix-run/react";
 import cx from "clsx";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import { formatDate, getSchedules } from "~/lib/conf2023.server";
 import { CACHE_CONTROL } from "~/lib/http.server";
 import { slugify } from "~/ui/primitives/utils";
@@ -75,11 +74,11 @@ export async function loader(_: LoaderFunctionArgs) {
   );
 }
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Schedule",
-    description: "What's happening and when at Remix Conf",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Schedule" },
+    { description: "What's happening and when at Remix Conf" },
+  ];
 };
 
 export default function Safety() {

--- a/app/routes/conf.2023._inner.speakers.$speakerSlug.tsx
+++ b/app/routes/conf.2023._inner.speakers.$speakerSlug.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import { useLoaderData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import "~/styles/conf-speaker.css";
@@ -12,20 +11,13 @@ import invariant from "tiny-invariant";
 
 export const meta: MetaFunction<typeof loader> = (args) => {
   if (args.data) {
-    let { speaker /*, talks */ } = args.data;
-    return metaV1(args, {
-      title: `${speaker.nameFull} at Remix Conf`,
-      //   description: `${speaker.name} (${
-      //     speaker.title
-      //   }) is speaking at Remix Conf: ${talks
-      //     .map((t) => `"${t.title}"`)
-      //     .join(", ")}`,
-    });
+    const { speaker } = args.data;
+    return [{ title: `${speaker.nameFull} at Remix Conf` }];
   }
-  return metaV1(args, {
-    title: "Missing Speaker",
-    description: "There is no speaker info at this URL.",
-  });
+  return [
+    { title: "Missing Speaker" },
+    { description: "There is no speaker info at this URL." },
+  ];
 };
 
 export async function loader({ params }: LoaderFunctionArgs) {

--- a/app/routes/conf.2023._inner.sponsor.tsx
+++ b/app/routes/conf.2023._inner.sponsor.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf 2023 Sponsorship",
-    description: "Sponsorship opportunities for Remix Conf.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf 2023 Sponsorship" },
+    { description: "Sponsorship opportunities for Remix Conf." },
+  ];
 };
 
 export default function SponsorUs() {

--- a/app/routes/conf.2023.coc.tsx
+++ b/app/routes/conf.2023.coc.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Code of Conduct",
-    description: "Adapted from confcodeofconduct.com",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Code of Conduct" },
+    { description: "Adapted from confcodeofconduct.com" },
+  ];
 };
 
 export default function CoC() {


### PR DESCRIPTION
I remove metaV1 from the routes whose url start with `/conf/2023/`

related https://github.com/remix-run/remix-website/issues/214