### PR TITLE
adding active link css class for the on page side bar navigation in Remix docs

### DIFF
--- a/app/routes/docs.$lang.$ref.$.tsx
+++ b/app/routes/docs.$lang.$ref.$.tsx
@@ -6,6 +6,7 @@ import {
   useMatches,
   useParams,
   useRouteError,
+  NavLink,
 } from "@remix-run/react";
 import { json } from "@remix-run/node";
 import type {
@@ -179,12 +180,16 @@ function LargeOnThisPage({ doc }: { doc: SerializeFrom<Doc> }) {
         {doc.headings.map((heading, i) => {
           return (
             <li key={i}>
-              <Link
+              <NavLink
                 to={`#${heading.slug}`}
+                className={({ isActive, isPending }) =>
+                  cx(
+                    "group relative py-1 text-sm text-gray-500 decoration-gray-200 underline-offset-4 hover:underline dark:text-gray-400 dark:decoration-gray-500",
+                    isActive && "active", // Apply "active" class when the link is active
+                    isPending && "pending", // Apply "pending" class when the link is pending
+                  )
+                }
                 dangerouslySetInnerHTML={{ __html: heading.html || "" }}
-                className={cx(
-                  "group relative py-1 text-sm text-gray-500 decoration-gray-200 underline-offset-4 hover:underline dark:text-gray-400 dark:decoration-gray-500",
-                )}
               />
             </li>
           );


### PR DESCRIPTION
**Issue:**
While going through Remix docs, we see a on page navigation bar at the right side of the web page that helps us navigate to the content of the pages. While this is good feature one of the issue with this is, if we jump onto some content we do not actually see any active link, or any highlighted link representing which section of the page you are in or you just jumped in right now!

**Solution:**
For the solution i have tried to change the Link tag of the code to Navlink and add on the active and pending classes as defined by the Remix docs! 

**Task:**
The problem i am stuck at, is could not find in the main css file where i can update the active link same as the hover effect that is provided in the website, so to keep the change in link ui same in hover and clicked stage.

![image](https://github.com/remix-run/remix-website/assets/94035913/88fe31bb-36e9-4f15-90f5-8ee3df90b052)
