### PR TITLE
Remove @remix-run/v1-meta

### DIFF
--- a/app/routes/conf.2022._index.tsx
+++ b/app/routes/conf.2022._index.tsx
@@ -1,7 +1,6 @@
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import type { MetaFunction } from "@remix-run/react";
 import { OutlineButtonLink, primaryButtonLinkClass } from "~/ui/buttons";
 import "~/styles/index.css";
@@ -10,27 +9,16 @@ import type { Sponsor, Speaker } from "~/lib/conf";
 import { getSpeakers, getSponsors } from "~/lib/conf2022.server";
 import { Link } from "~/ui/link";
 import { CACHE_CONTROL } from "~/lib/http.server";
+import { getMeta } from "~/lib/meta";
 
 export const meta: MetaFunction<typeof loader> = (args) => {
   let { siteUrl } = args.data || {};
-  let url = siteUrl ? `${siteUrl}/conf` : null;
-  let title = "Remix Conf - May 24-25, 2022";
-  let image = siteUrl ? `${siteUrl}/conf-images/og.1.png` : null;
-  let description =
-    "Join us in Salt Lake City, UT for our innaugural conference. Featuring distinguished speakers, workshops, and lots of fun in between. See you there!";
-  return metaV1(args, {
-    title,
-    description,
-    "og:url": url,
-    "og:title": title,
-    "og:description": description,
-    "og:image": image,
-    "twitter:card": "summary_large_image",
-    "twitter:creator": "@remix_run",
-    "twitter:site": "@remix_run",
-    "twitter:title": title,
-    "twitter:description": description,
-    "twitter:image": image,
+  return getMeta({
+    title: "Remix Conf - May 24-25, 2022",
+    description:
+      "Join us in Salt Lake City, UT for our innaugural conference. Featuring distinguished speakers, workshops, and lots of fun in between. See you there!",
+    siteUrl: siteUrl ? `${siteUrl}/conf` : undefined,
+    image: siteUrl ? `${siteUrl}/conf-images/og.1.png` : undefined,
   });
 };
 

--- a/app/routes/conf.2022._inner.coc.tsx
+++ b/app/routes/conf.2022._inner.coc.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Code of Conduct",
-    description: "Adapted from confcodeofconduct.com",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Code of Conduct" },
+    { name: "description", content: "Adapted from confcodeofconduct.com" },
+  ];
 };
 
 export default function CoC() {

--- a/app/routes/conf.2022._inner.discord.tsx
+++ b/app/routes/conf.2022._inner.discord.tsx
@@ -2,13 +2,15 @@ import { Link } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import { primaryButtonLinkClass } from "~/ui/buttons";
 import { Discord } from "~/ui/icons";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Discord Server",
-    description: "Much of our coordination happens on Discord.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Discord Server" },
+    {
+      name: "description",
+      content: "Much of our coordination happens on Discord.",
+    },
+  ];
 };
 
 const channels = [

--- a/app/routes/conf.2022._inner.safety.tsx
+++ b/app/routes/conf.2022._inner.safety.tsx
@@ -1,11 +1,13 @@
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Discord Server",
-    description: "Much of our coordination happens on Discord.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Discord Server" },
+    {
+      name: "description",
+      content: "Much of our coordination happens on Discord.",
+    },
+  ];
 };
 
 export default function Safety() {

--- a/app/routes/conf.2022._inner.schedule.may-24.tsx
+++ b/app/routes/conf.2022._inner.schedule.may-24.tsx
@@ -1,12 +1,14 @@
 import type { MetaFunction } from "@remix-run/react";
 import { Link } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "May 24th at Remix Conf",
-    description: "May 24th is The Workshop and Welcome day at Remix.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "May 24th at Remix Conf" },
+    {
+      name: "description",
+      content: "May 24th is The Workshop and Welcome day at Remix.",
+    },
+  ];
 };
 
 export default function May24Schedule() {

--- a/app/routes/conf.2022._inner.schedule.may-25.tsx
+++ b/app/routes/conf.2022._inner.schedule.may-25.tsx
@@ -2,16 +2,18 @@ import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 import { getSchedule } from "~/lib/conf2022.server";
 import { CACHE_CONTROL } from "~/lib/http.server";
 import { slugify } from "~/ui/primitives/utils";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "May 25th at Remix Conf",
-    description: "May 25th is the day of the conference at Remix Conf.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "May 25th at Remix Conf" },
+    {
+      name: "description",
+      content: "May 25th is the day of the conference at Remix Conf.",
+    },
+  ];
 };
 
 type LoaderData = { scheduleItems: Awaited<ReturnType<typeof getSchedule>> };

--- a/app/routes/conf.2022._inner.schedule.may-26.tsx
+++ b/app/routes/conf.2022._inner.schedule.may-26.tsx
@@ -2,15 +2,17 @@ import { Link, useLoaderData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import { Discord } from "~/ui/icons";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "May 26th at Remix Conf",
-    description:
-      "May 26th is the day after the conference. Get together with other conference attendees before heading home.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "May 26th at Remix Conf" },
+    {
+      name: "description",
+      content:
+        "May 26th is the day after the conference. Get together with other conference attendees before heading home.",
+    },
+  ];
 };
 
 function getMapsDirections(address: string) {

--- a/app/routes/conf.2022._inner.schedule.tsx
+++ b/app/routes/conf.2022._inner.schedule.tsx
@@ -1,13 +1,12 @@
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "~/ui/primitives/tabs";
 import { Link, Outlet, useMatches, useNavigate } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 import type { MetaFunction } from "@remix-run/react";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Schedule",
-    description: "What's happening and when at Remix Conf",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Schedule" },
+    { name: "description", content: "What's happening and when at Remix Conf" },
+  ];
 };
 
 export default function Safety() {

--- a/app/routes/conf.2022._inner.speakers.$speakerSlug.tsx
+++ b/app/routes/conf.2022._inner.speakers.$speakerSlug.tsx
@@ -8,7 +8,6 @@ import {
 } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import { json } from "@remix-run/node";
-import { metaV1 } from "@remix-run/v1-meta";
 import { getSpeakers, getTalks } from "~/lib/conf2022.server";
 import "~/styles/conf-speaker.css";
 import { CACHE_CONTROL } from "~/lib/http.server";
@@ -17,19 +16,22 @@ import { slugify } from "~/ui/primitives/utils";
 export const meta: MetaFunction<typeof loader> = (args) => {
   if (args.data) {
     const { speaker, talks } = args.data;
-    return metaV1(args, {
-      title: `${speaker.name} at Remix Conf`,
-      description: `${speaker.name} (${
-        speaker.title
-      }) is speaking at Remix Conf: ${talks
-        .map((t) => `"${t.title}"`)
-        .join(", ")}`,
-    });
+    return [
+      { title: `${speaker.name} at Remix Conf` },
+      {
+        name: "description",
+        content: `${speaker.name} (${
+          speaker.title
+        }) is speaking at Remix Conf: ${talks
+          .map((t) => `"${t.title}"`)
+          .join(", ")}`,
+      },
+    ];
   }
-  return metaV1(args, {
-    title: "Missing Speaker",
-    description: "There is no speaker info at this URL.",
-  });
+  return [
+    { title: "Remix Conf Speaker" },
+    { name: "description", content: "Speaker at Remix Conf." },
+  ];
 };
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {

--- a/app/routes/conf.2022._inner.sponsor.tsx
+++ b/app/routes/conf.2022._inner.sponsor.tsx
@@ -1,11 +1,13 @@
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Sponsorship",
-    description: "Sponsorship opportunities for Remix Conf.",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Sponsorship" },
+    {
+      name: "description",
+      content: "Sponsorship opportunities for Remix Conf.",
+    },
+  ];
 };
 
 export default function SponsorUs() {

--- a/app/routes/conf.2022._inner.venue.tsx
+++ b/app/routes/conf.2022._inner.venue.tsx
@@ -3,14 +3,16 @@ import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import type { MetaFunction } from "@remix-run/react";
 import { useLoaderData, Link } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 import { primaryButtonLinkClass } from "~/ui/buttons";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Venue",
-    description: "Remix Conf in Salt Lake City, Utah at the Sheraton Hotel",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Venue" },
+    {
+      name: "description",
+      content: "Remix Conf in Salt Lake City, Utah at the Sheraton Hotel",
+    },
+  ];
 };
 
 const hotelImages = [

--- a/app/routes/conf.2022._inner.workshops.tsx
+++ b/app/routes/conf.2022._inner.workshops.tsx
@@ -1,12 +1,14 @@
 import { primaryButtonLinkClass } from "~/ui/buttons";
 import type { MetaFunction } from "@remix-run/react";
-import { metaV1 } from "@remix-run/v1-meta";
 
-export const meta: MetaFunction = (args) => {
-  return metaV1(args, {
-    title: "Remix Conf Workshops",
-    description: "Premium Remix Workshops from the Remix Team",
-  });
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Remix Conf Workshops" },
+    {
+      name: "description",
+      content: "Premium Remix Workshops from the Remix Team",
+    },
+  ];
 };
 
 export default function Workshops() {


### PR DESCRIPTION
I remove metaV1 from the routes whose url start with /conf/2022/

related https://github.com/remix-run/remix-website/issues/214