### PR TITLE
Add `remix-paraglidejs` to the Resources page

### DIFF
--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -214,3 +214,9 @@
   imgSrc: "https://opengraph.githubassets.com/dcc2f67503a55cc9258730bd9e6c7e0bac4832a5c307934bc9ceb7adf7b33787/jacob-ebey/remix-shadcn"
   initCommand: "npx create-remix@latest --template jacob-ebey/remix-shadcn"
   category: "templates"
+
+- title: "Remix-ParaglideJS"
+  repoUrl: "https://github.com/BRIKEV/remix-paraglidejs"
+  imgSrc: "https://opengraph.githubassets.com/261c7cc1db489c2cba871b43957993802ec0f7c6609d06014534906a22036a7e/BRIKEV/remix-paraglidejs"
+  initCommand: "npx @inlang/paraglide-js init && npm i remix-paraglidejs @inlang/paraglide-js-adapter-vite"
+  category: "libraries"


### PR DESCRIPTION
This PR adds the [`remix-paraglidejs`](https://github.com/BRIKEV/remix-paraglidejs) library to the resources page. 
This is a remix library for working with the [ParaglideJS](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) i18n library. 