### PR TITLE
fix: account for menu categories that are also links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/react": "^3.5.2",
-        "@remix-run/express": "0.0.0-experimental-419fc7d09",
-        "@remix-run/node": "0.0.0-experimental-419fc7d09",
-        "@remix-run/react": "0.0.0-experimental-419fc7d09",
+        "@remix-run/express": "2.9.0-pre.0",
+        "@remix-run/node": "2.9.0-pre.0",
+        "@remix-run/react": "2.9.0-pre.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "cheerio": "^1.0.0-rc.12",
         "clsx": "^2.1.0",
@@ -48,7 +48,7 @@
         "remark-html": "^16.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.0",
-        "remix": "0.0.0-experimental-419fc7d09",
+        "remix": "2.9.0-pre.0",
         "satori": "^0.10.11",
         "semver": "^7.5.4",
         "shiki": "^0.14.7",
@@ -65,8 +65,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@remix-run/dev": "0.0.0-experimental-419fc7d09",
-        "@remix-run/eslint-config": "0.0.0-experimental-419fc7d09",
+        "@remix-run/dev": "2.9.0-pre.0",
+        "@remix-run/eslint-config": "2.9.0-pre.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@types/follow-redirects": "^1.14.4",
         "@types/gunzip-maybe": "^1.4.2",
@@ -2823,9 +2823,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-P1wlMGjDSTFGKIQg/upLJUh98Eqe7t3WtO7o8qam9eKWWvZsd5kVDumUELJZxV/o2IkwHbpaaGFrVmnSTxXAnA==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.9.0-pre.0.tgz",
+      "integrity": "sha512-FuAX3IsrUUD8laBvStVSW9VFFkfuE9NL36KkaJjBSqq7ybnN4jnkHrP/AzEJEMGiEFbZ1cP9FG0EvlGOYVPuaQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -2838,9 +2838,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "0.0.0-experimental-419fc7d09",
-        "@remix-run/router": "0.0.0-experimental-c7dd3d3a",
-        "@remix-run/server-runtime": "0.0.0-experimental-419fc7d09",
+        "@remix-run/node": "2.9.0-pre.0",
+        "@remix-run/router": "1.16.0-pre.0",
+        "@remix-run/server-runtime": "2.9.0-pre.0",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -2889,8 +2889,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^0.0.0-experimental-419fc7d09",
-        "@remix-run/serve": "^0.0.0-experimental-419fc7d09",
+        "@remix-run/react": "^2.9.0-pre.0",
+        "@remix-run/serve": "^2.9.0-pre.0",
         "typescript": "^5.1.0",
         "vite": "^5.1.0",
         "wrangler": "^3.28.2"
@@ -2926,9 +2926,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-AmY8S89Jr+J6h10GQ3qIG2sSOt47SwFotTi1Ra97Dv0E9EKSWoCH7ADqgoNSMxXEP0ymESKKk7Kz0tgRTzuSUQ==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.9.0-pre.0.tgz",
+      "integrity": "sha512-ss/1kFD5HeiuUknmgneaOrMQxOV32rps+OxztO+l1sKWu22PvygJPI+l/uB7EZTmfPnlE21SsboxKuUSxQQ72w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -2963,11 +2963,11 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-lmMjlTfKLhaHz9jgdlaFqXwmQ4vtzvHOaqMpA5sCyOW6+3Ba+Jp5+AEzQqpuO37l053p0AIq850q8qFhCGZkrg==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.9.0-pre.0.tgz",
+      "integrity": "sha512-gStm1lKr9Vg9+iTPiDeIeGWbfhHq2UHzXlDpsg+biQKLeImuD+bVljr75g6RxvBQCJIHwooy2AhS22RTMK6EQA==",
       "dependencies": {
-        "@remix-run/node": "0.0.0-experimental-419fc7d09"
+        "@remix-run/node": "2.9.0-pre.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2983,18 +2983,16 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-vhzuV9h8UqO6CRibhPrLvCIsciBdredICwP7dQsg/UUa8RX8XAuurPl+HSnMh7jRXxsLCEyyv38LXTsaalpdFw==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.0-pre.0.tgz",
+      "integrity": "sha512-KaZBOYvESktTydGb1yYqN1e21nKSm0thAk1YzkqiMlSS8HH7U8Y4Pta9++7LJC/TcI3aEGwco3eoc+S4/4BhDw==",
       "dependencies": {
-        "@remix-run/server-runtime": "0.0.0-experimental-419fc7d09",
-        "@remix-run/web-fetch": "^4.4.2",
-        "@remix-run/web-file": "^3.1.0",
-        "@remix-run/web-stream": "^1.1.0",
+        "@remix-run/server-runtime": "2.9.0-pre.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
-        "stream-slice": "^0.1.2"
+        "stream-slice": "^0.1.2",
+        "undici": "^6.10.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3009,14 +3007,14 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-k2rtLs0jW9PdMPA3JmXqpyxw+cljj9bvew+05dcHxM6QLCfn99AKf0jfkNEFZn4LtRB7O5VULwyo76vQ8chczg==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.9.0-pre.0.tgz",
+      "integrity": "sha512-qfYvqLZBmakuRLRxt6v1Y9DJgAyWs2EuGpnJgsCHG2h+GwMYg8nfuIQg2VGFV8mSKb66xJfny4oKpHDUQ+ikXA==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-c7dd3d3a",
-        "@remix-run/server-runtime": "0.0.0-experimental-419fc7d09",
-        "react-router": "0.0.0-experimental-c7dd3d3a",
-        "react-router-dom": "0.0.0-experimental-c7dd3d3a",
+        "@remix-run/router": "1.16.0-pre.0",
+        "@remix-run/server-runtime": "2.9.0-pre.0",
+        "react-router": "6.23.0-pre.0",
+        "react-router-dom": "6.23.0-pre.0",
         "turbo-stream": "^2.0.0"
       },
       "engines": {
@@ -3034,19 +3032,19 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "0.0.0-experimental-c7dd3d3a",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-0.0.0-experimental-c7dd3d3a.tgz",
-      "integrity": "sha512-reXnySaRGlEl6cOgF7fSQvIRzyRFUjGsez0kHQk0ok6Z3Y7n1PVTCKNhooSfOI1hBOi0c9cIMurhoTgjYXyxHw==",
+      "version": "1.16.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0-pre.0.tgz",
+      "integrity": "sha512-4KYbcmBcjX1HO/sLPZIcY87YWTF3e5qs9KTTieXE0HNukV2m199yTkMIjcmzTNL6w0wDj5YYc2YiXxm4W9qsTw==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-FGNKtn/0Dw3h3x/OJsJ4+RO+lBBBBLLsVC53D+XRfdHYyLQynwDY8191GXouW+FdInMAhKAHL7UzdNF4HSocYA==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.0-pre.0.tgz",
+      "integrity": "sha512-UIAtwc6YKq7QqzlCtCe306NCiksSSEJUNx88sJrfQEjBDmZbbgNE+X9UdnqrA+eVyxNRa9OWP1bnHuHssGihxg==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-c7dd3d3a",
+        "@remix-run/router": "1.16.0-pre.0",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
@@ -3072,57 +3070,6 @@
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/@remix-run/web-blob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0.tgz",
-      "integrity": "sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==",
-      "dependencies": {
-        "@remix-run/web-stream": "^1.1.0",
-        "web-encoding": "1.1.5"
-      }
-    },
-    "node_modules/@remix-run/web-fetch": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.2.tgz",
-      "integrity": "sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==",
-      "dependencies": {
-        "@remix-run/web-blob": "^3.1.0",
-        "@remix-run/web-file": "^3.1.0",
-        "@remix-run/web-form-data": "^3.1.0",
-        "@remix-run/web-stream": "^1.1.0",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "abort-controller": "^3.0.0",
-        "data-uri-to-buffer": "^3.0.1",
-        "mrmime": "^1.0.0"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      }
-    },
-    "node_modules/@remix-run/web-file": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0.tgz",
-      "integrity": "sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==",
-      "dependencies": {
-        "@remix-run/web-blob": "^3.1.0"
-      }
-    },
-    "node_modules/@remix-run/web-form-data": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0.tgz",
-      "integrity": "sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==",
-      "dependencies": {
-        "web-encoding": "1.1.5"
-      }
-    },
-    "node_modules/@remix-run/web-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0.tgz",
-      "integrity": "sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==",
-      "dependencies": {
-        "web-streams-polyfill": "^3.1.1"
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -4802,23 +4749,6 @@
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
       "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
     },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "optional": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5201,6 +5131,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6240,14 +6171,6 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7776,14 +7699,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8140,6 +8055,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -8682,6 +8598,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -9372,6 +9289,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -9478,6 +9396,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9572,6 +9491,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -9777,6 +9697,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
       "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.11"
       },
@@ -15567,14 +15488,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mrmime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -17306,11 +17219,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "0.0.0-experimental-c7dd3d3a",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-0.0.0-experimental-c7dd3d3a.tgz",
-      "integrity": "sha512-biSo7Pmedzrm9DXjC3ScIwCWVt3qVAutf51hJ/POxfcRYvhgi9ENNGHLjpqabBH4oI5IwI53Vh0w7pKOdadC9A==",
+      "version": "6.23.0-pre.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0-pre.0.tgz",
+      "integrity": "sha512-GawzByLrAoOr4Sc0ybAuYBTJmtysK8I7p3VuBQCzDCqXzu10uAP7tu0Iy+mv0SGkmzKpPXg4PUO26UQ9bBH7bg==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-c7dd3d3a"
+        "@remix-run/router": "1.16.0-pre.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17320,12 +17233,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "0.0.0-experimental-c7dd3d3a",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-0.0.0-experimental-c7dd3d3a.tgz",
-      "integrity": "sha512-pp1l8sk4Rc9vLucHgHU4B2LUL/4e6iwD7ipDGgfc9a08eNVowxaDJXkbtyYE10lpjaZZkXF1DFkdHfGrKeXWQw==",
+      "version": "6.23.0-pre.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0-pre.0.tgz",
+      "integrity": "sha512-TDEljjV6XwOEb9gp6FFNquAB0yY490lhSZRo4YNDPI8+QEA0n3yJ2VfIZLmxR70ljnFBwYOnWmNl94EHom/JjQ==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-c7dd3d3a",
-        "react-router": "0.0.0-experimental-c7dd3d3a"
+        "@remix-run/router": "1.16.0-pre.0",
+        "react-router": "6.23.0-pre.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -18433,9 +18346,9 @@
       }
     },
     "node_modules/remix": {
-      "version": "0.0.0-experimental-419fc7d09",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-0.0.0-experimental-419fc7d09.tgz",
-      "integrity": "sha512-RQNIZe52iKzrmHRX5becWJfh6xAA+UJWLrGhN2kuHgzEwNvy3Lvav4FnQEPXyn7Oi5L8hgErbELkpP3xUnIfgA==",
+      "version": "2.9.0-pre.0",
+      "resolved": "https://registry.npmjs.org/remix/-/remix-2.9.0-pre.0.tgz",
+      "integrity": "sha512-iANESLyd+cZrdd7VQkwET/Rva7cmogCS1KBYSS3dCMC9ZIX4fyQiTZngJld+J2682cIrHD1/rGR2Zty19IRKtg==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -20151,6 +20064,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.10.2.tgz",
+      "integrity": "sha512-HcVuBy7ACaDejIMdwCzAvO22OsiE6ir6ziTIr9kAE0vB+PheVe29ZvRN8p7FXCO2uZHTjEoUs5bPiFpuc/hwwQ==",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -20509,18 +20430,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -21904,17 +21813,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -21922,14 +21820,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -22026,6 +21916,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
       "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "@docsearch/css": "^3.5.2",
     "@docsearch/react": "^3.5.2",
-    "@remix-run/express": "0.0.0-experimental-419fc7d09",
-    "@remix-run/node": "0.0.0-experimental-419fc7d09",
-    "@remix-run/react": "0.0.0-experimental-419fc7d09",
+    "@remix-run/express": "2.9.0-pre.0",
+    "@remix-run/node": "2.9.0-pre.0",
+    "@remix-run/react": "2.9.0-pre.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "cheerio": "^1.0.0-rc.12",
     "clsx": "^2.1.0",
@@ -60,7 +60,7 @@
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
-    "remix": "0.0.0-experimental-419fc7d09",
+    "remix": "2.9.0-pre.0",
     "satori": "^0.10.11",
     "semver": "^7.5.4",
     "shiki": "^0.14.7",
@@ -77,8 +77,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@remix-run/dev": "0.0.0-experimental-419fc7d09",
-    "@remix-run/eslint-config": "0.0.0-experimental-419fc7d09",
+    "@remix-run/dev": "2.9.0-pre.0",
+    "@remix-run/eslint-config": "2.9.0-pre.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@types/follow-redirects": "^1.14.4",
     "@types/gunzip-maybe": "^1.4.2",


### PR DESCRIPTION
This thing is pretty ridiculous

The way our docs works you can technically have a category menu be a page itself, in which case it needs to be a link.

Additionally that doc can have children, so it still needs to be a collapsable menu. This is a monstrosity, but no idea if we ever did this with previous releases, so need to give a decent default behavior.

I did my best to clean up the code and colocate css that should be the same.

Also, sorry for my juvenile test doc names

https://github.com/remix-run/remix-website/assets/12396812/4a442310-1720-4486-a17b-cf08830acefa

