### PR TITLE
Set `color-scheme` to `dark` when dark mode is enabled

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -38,6 +38,10 @@ html {
   font-size: 16px;
 }
 
+.dark {
+    color-scheme: dark;
+}
+
 [hidden] {
   display: none !important;
 }


### PR DESCRIPTION
I updated the `tailwind.css` file to set `color-scheme` to `dark` when dark mode is enabled. This allows elements that do not have dark mode specific styles to fallback to the user-agent styles.

Below you will find a before and after image of the Remix docs loaded in the Brave browser. Focus your attention to the scrollbars, which are the only elements that I found to be impacted by this change.

Before:

![image](https://github.com/remix-run/remix-website/assets/24993818/b5f1dc87-9f66-47e2-b111-ecdf189811fa)

After:

![image](https://github.com/remix-run/remix-website/assets/24993818/b4ff37ef-5630-4d4e-8433-bd12ec8fe526)

This is the same approach that the Tailwind CSS docs has taken: https://github.com/tailwindlabs/tailwindcss.com/blob/master/src/css/base.css

Kevin Powell has a great video that goes into more detail: https://www.youtube.com/watch?v=zFFuV_vXNhY  