### PR TITLE
Fix Overlapping Scroll in Docs Page Between Header and Elements

### DIFF
--- a/app/routes/docs.$lang.$ref.$.tsx
+++ b/app/routes/docs.$lang.$ref.$.tsx
@@ -158,7 +158,7 @@ export default function DocPage() {
 
 function LargeOnThisPage({ doc }: { doc: SerializeFrom<Doc> }) {
   return (
-    <div className="sticky top-36 order-1 mt-20 hidden max-h-[calc(100vh-9rem)] w-56 flex-shrink-0 self-start overflow-y-auto pb-10 xl:block">
+    <div className="sticky ml-4 top-36 order-1 mt-20 hidden max-h-[calc(100vh-9rem)] w-56 flex-shrink-0 self-start overflow-y-auto pb-10 xl:block">
       <nav className="mb-3 flex items-center font-semibold">On this page</nav>
       <ul className="md-toc flex flex-col flex-wrap gap-3 leading-[1.125]">
         {doc.headings.map((heading, i) => {

--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -119,22 +119,24 @@ export default function DocsLayout() {
         }
       >
         <InnerContainer>
-          <NavMenuDesktop />
-          <div
-            ref={docsContainer}
-            className={cx(
-              // add scroll margin to focused elements so that they aren't
-              // obscured by the sticky header
-              "[&_*:focus]:scroll-mt-[8rem] lg:[&_*:focus]:scroll-mt-[5rem]",
-              "min-h-[80vh]",
-              "lg:ml-72 lg:pl-6 xl:pl-10 2xl:pl-12",
-              !changingVersions && navigating
-                ? "opacity-25 transition-opacity delay-300"
-                : "",
-            )}
-          >
-            <Outlet />
-          </div>
+          <section className="flex">
+            <NavMenuDesktop />
+            <div
+              ref={docsContainer}
+              className={cx(
+                // add scroll margin to focused elements so that they aren't
+                // obscured by the sticky header
+                "[&_*:focus]:scroll-mt-[8rem] lg:[&_*:focus]:scroll-mt-[5rem]",
+                "min-h-[80vh]",
+                "lg:ml-3 lg:pl-6 xl:pl-10 2xl:pl-12",
+                !changingVersions && navigating
+                  ? "opacity-25 transition-opacity delay-300"
+                  : "",
+              )}
+            >
+              <Outlet />
+            </div>
+          </section>
           <div className="min-w-0 pt-8 sm:pt-10 lg:ml-72 lg:pl-6 lg:pt-12 xl:pl-10 2xl:pl-12">
             <Footer />
           </div>
@@ -617,7 +619,7 @@ function NavMenuMobile() {
 
 function NavMenuDesktop() {
   return (
-    <div className="fixed bottom-0 top-16 -ml-3 hidden w-72 flex-col gap-3 overflow-auto pb-10 pr-5 pt-5 lg:flex">
+    <div className="sticky bottom-0 top-16 -ml-3 hidden min-w-72 flex-col gap-3 overflow-auto pb-10 pr-5 pt-5 lg:flex">
       <DocSearchSection />
       <div className="[&_*:focus]:scroll-mt-[6rem]">
         <Menu />

--- a/app/routes/docs.$lang.$ref.tsx
+++ b/app/routes/docs.$lang.$ref.tsx
@@ -126,7 +126,7 @@ export default function DocsLayout() {
               className={cx(
                 // add scroll margin to focused elements so that they aren't
                 // obscured by the sticky header
-                "[&_*:focus]:scroll-mt-[8rem] lg:[&_*:focus]:scroll-mt-[5rem]",
+                "[&_*:focus]:scroll-mt-[8rem] lg:[&_*:focus]:scroll-mt-[5rem] overflow-hidden lg:overflow-auto",
                 "min-h-[80vh]",
                 "lg:ml-3 lg:pl-6 xl:pl-10 2xl:pl-12",
                 !changingVersions && navigating


### PR DESCRIPTION
This PR fixes the overlap between elements when scrolling on the docs page. Here's how it looks now:


https://github.com/remix-run/remix-website/assets/42539315/ae9e2e74-fbbf-4d7d-920c-5d098332eb57

Closes #239 