### PR TITLE
chore(resources): add @mcansh/vite-svg-sprite-plugin

### DIFF
--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -220,3 +220,9 @@
   imgSrc: "https://opengraph.githubassets.com/261c7cc1db489c2cba871b43957993802ec0f7c6609d06014534906a22036a7e/BRIKEV/remix-paraglidejs"
   initCommand: "npx @inlang/paraglide-js init && npm i remix-paraglidejs @inlang/paraglide-js-adapter-vite"
   category: "libraries"
+
+- title: ""
+  repoUrl: "https://github.com/mcansh/vite-svg-sprite-plugin"
+  imgSrc: "https://opengraph.githubassets.com/1/mcansh/vite-svg-sprite-plugin"
+  initCommand: "npm install @mcansh/vite-svg-sprite-plugin"
+  category: "libraries"


### PR DESCRIPTION
@mcansh/vite-svg-sprite-plugin is a vite plugin that will transform any imported svg files and combine them into an svg sprite sheet