### PR TITLE
Fix memory leaks with undici introduction

### DIFF
--- a/app/lib/conf2023.server.ts
+++ b/app/lib/conf2023.server.ts
@@ -61,6 +61,8 @@ export async function getSpeakers(
     },
   });
   if (!fetched.ok) {
+    // Need to consume for undici since it won't garbage collect
+    await fetched.text();
     throw new Error(
       "Error fetching speakers, responded with status: " + fetched.status,
     );
@@ -124,6 +126,8 @@ export async function getConfSessions(
     },
   });
   if (!fetched.ok) {
+    // Need to consume for undici since it won't garbage collect
+    await fetched.text();
     throw new Error(
       "Error fetching speakers, responded with status: " + fetched.status,
     );
@@ -187,6 +191,8 @@ export async function getSchedules(
     getSpeakers(),
   ]);
   if (!fetched.ok) {
+    // Need to consume for undici since it won't garbage collect
+    await fetched.text();
     throw new Error(
       "Error fetching schedule, responded with status: " + fetched.status,
     );
@@ -460,6 +466,8 @@ async function fetchNaiveStaleWhileRevalidate(
     throw err;
   }
   if (res.status === 504) {
+    // Need to consume for undici since it won't garbage collect
+    await res.text();
     return fetchWithForceCache();
   }
 

--- a/app/lib/gh-docs/repo-content.ts
+++ b/app/lib/gh-docs/repo-content.ts
@@ -22,7 +22,11 @@ export async function getRepoContent(
     new URL(pathname, "https://raw.githubusercontent.com/").href,
     { headers: { "User-Agent": `docs:${owner}/${repo}` } },
   );
-  if (!response.ok) return null;
+  if (!response.ok) {
+    // Need to consume for undici since it won't garbage collect
+    await response.text();
+    return null;
+  }
   return response.text();
 }
 

--- a/app/lib/resources.server/index.ts
+++ b/app/lib/resources.server/index.ts
@@ -164,7 +164,9 @@ async function getSponsorUrl(owner: string) {
   let sponsorUrl = `${GITHUB_URL}/sponsors/${owner}`;
 
   try {
-    let response = await fetch(sponsorUrl);
+    // We don't need the body, just need to know if it's redirected
+    // method: "HEAD" removes the need for garbage collection: https://github.com/nodejs/undici?tab=readme-ov-file#garbage-collection
+    let response = await fetch(sponsorUrl, { method: "HEAD" });
     return !response.redirected ? sponsorUrl : undefined;
   } catch (e) {
     console.error("Failed to fetch sponsor url for", owner);

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
     arraybuffer(),
     remix({
       future: {
-        unstable_singleFetch: false,
+        unstable_singleFetch: true,
       },
     }),
   ],


### PR DESCRIPTION
[Undici does not garbage collect unconsumed response bodies](https://github.com/nodejs/undici?tab=readme-ov-file#garbage-collection)

> The [Fetch Standard](https://fetch.spec.whatwg.org/) allows users to skip consuming the response body by relying on [garbage collection](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_Management#garbage_collection) to release connection resources. Undici does not do the same. Therefore, it is important to always either consume or cancel the response body.

This ended up causing a memory leak because I was relying on this without realizing when determining whether or not a Remix Resource's creator has a GitHub Sponsors page setup.