### PR TITLE
refactor: replace tailwind-extras.html with safelist feature

### DIFF
--- a/tailwind-extras.html
+++ b/tailwind-extras.html
@@ -1,3 +1,0 @@
-<!-- this is silly, but our docs have some tailwind classes so I've copied them here so that in CI tailwind will add the right classes, gonna think of something better but I'm really tired and just want to ship this ... -->
-<div class="mb-4 aspect-[4/3] w-full overflow-hidden rounded-lg"></div>
-<div class="aspect-[1/1] w-full overflow-hidden rounded-lg"></div>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,7 +7,20 @@ const defaultTheme = require("tailwindcss/defaultTheme");
 /** @type {TailwindConfig} */
 export default {
   mode: "jit",
-  content: ["./app/**/*.{ts,tsx}", "./data/**/*.md", "./tailwind-extras.html"],
+  content: ["./app/**/*.{ts,tsx}", "./data/**/*.md"],
+  // docs have some tailwind classes, tell tailwind to always add these classes
+  // so the right classes are still added in CI
+  safelist: [
+    "mb-4",
+    "aspect-[4/3]",
+    "w-full",
+    "overflow-hidden",
+    "rounded-lg",
+    "aspect-[1/1]",
+    "w-full",
+    "overflow-hidden",
+    "rounded-lg",
+  ],
   darkMode: "class",
   plugins: [aspectRatioPlugin, selectedVariantPlugin, expandedVariantPlugin],
   theme: {


### PR DESCRIPTION
> this is silly, but our docs have some tailwind classes so I've copied them here so that in CI tailwind will add the right classes, gonna think of something better but I'm really tired and just want to ship this ...

Tailwind has [safelist](https://tailwindcss.com/docs/content-configuration#safelisting-classes) for this purpose (forcing classes to be generated no matter what) and can be used instead of a quick workaround. Hopefully this is something better.

I rewrote the comment like this:

> docs have some tailwind classes, tell tailwind to always add these classes so the right classes are still added in CI

which should hopefully still adequately explain the intent of safelisting these classes.