### PR TITLE
fix: pre/code links in docs under dark mode now look like links

### DIFF
--- a/app/styles/docs.css
+++ b/app/styles/docs.css
@@ -317,9 +317,11 @@
     @apply rounded bg-gray-100/50 px-1.5 pb-0.5 pt-px text-sm text-gray-700 dark:bg-gray-800/50;
   }
 
+  /* Undo the .md-prose code and .md-prose kbd color above for links. */
   & :is(a, h1, h2, h3, h4, h5, h6) code,
   & :is(a, h1, h2, h3, h4, h5, h6) kbd {
-    @apply text-inherit;
+    /* dark:text-inherit needs to be specified explicitly, otherwise the dark text color rule would override this rule. */
+    @apply text-inherit dark:text-inherit;
   }
 
   & :is(h1, h2, h3, h4, h5, h6) code {


### PR DESCRIPTION
Fixes #260.

| Light mode | Dark mode before with annotation | Dark mode after |
|-|-|-|
| ![Light mode screenshot of the .client modules page in Remix documentation. There are no handdrawn arrows. The same texts corresponding to the texts in the dark mode screenshot are visually distinct.](https://github.com/remix-run/remix-website/assets/11722318/6fb4de20-c124-4f80-8398-ddba7da450d1) | ![Dark mode screenshot of the .client modules page in Remix documentation, with two handdrawn arrows, one pointing to "useEffect" and is labeled "link", another pointing to ".client" and is labeled "not a link". The two texts being pointed to otherwise appear identical in style.](https://github.com/remix-run/remix-website/assets/11722318/1a694599-f198-4974-b459-dc70f294ebec) | ![Dark mode screenshot of the .client modules page in Remix documentation, with the same texts being visually distinct from each other.](https://github.com/remix-run/remix-website/assets/11722318/b8304543-c368-4e15-91f0-b7135b12c11e)


---

The colors of code and pre elements in md-prose blocks [are specified here](https://github.com/remix-run/remix-website/blob/524ab7aba54cf0a118f18cb96aa4f0ecf1793105/app/styles/docs.css#L297-L300):

```css
.md-prose {
  /* ... */
  & code,
  & kbd {
    @apply text-gray-700 dark:text-gray-300;
  }

  /* some other stuff... */

  & :is(a, h1, h2, h3, h4, h5, h6) code,
  & :is(a, h1, h2, h3, h4, h5, h6) kbd {
    @apply text-inherit;
  }
  /* ... */
}
```

which turns into this CSS:

```css
.md-prose code,
.md-prose kbd {
  --tw-text-opacity:1;
  color:rgb(67 67 67/var(--tw-text-opacity))
}
:is(.dark .md-prose code),
:is(.dark .md-prose kbd) {
  --tw-text-opacity:1;
  color:rgb(164 164 164/var(--tw-text-opacity));
}
.md-prose :is(a, h1, h2, h3, h4, h5, h6) code,
.md-prose :is(a, h1, h2, h3, h4, h5, h6) kbd {
  color:inherit;
}
```

The color rule applies to all prose `code` and `kbd` elements, then for specific situations (including under links) the color is reset to inherit. But in dark mode, `:is(.dark .md-prose code)` ends up with higher specificity (0-2-1) than `.md-prose :is(a, h1, h2, h3, h4, h5, h6) code` (0-1-2), thus nullifying the reset. So a `dark:text-inherit` needs to be specified explicitly to actually reset the color to inherit in dark mode.