### PR TITLE
Fix busted showcase page on mobile

### DIFF
--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -62,7 +62,7 @@ export default function Showcase() {
       </div>
       <ul className="mt-8 grid w-full max-w-md grid-cols-1 gap-x-6 gap-y-10 self-center md:max-w-3xl md:grid-cols-2 lg:max-w-6xl lg:grid-cols-3 lg:gap-x-8">
         {showcaseExamples.map((example, i) => {
-          let preload: ShowcaseTypes["preload"] = i < 6 ? "auto" : "none";
+          let preload: ShowcaseTypes["preload"] = i < 2 ? "auto" : "none";
           return (
             <Fragment key={example.name}>
               <DesktopShowcase

--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -61,7 +61,7 @@ export default function Showcase() {
         </p>
       </div>
       <ul className="mt-8 grid w-full max-w-md grid-cols-1 gap-x-6 gap-y-10 self-center md:max-w-3xl md:grid-cols-2 lg:max-w-6xl lg:grid-cols-3 lg:gap-x-8">
-        {showcaseExamples.slice(0, 17).map((example, i) => {
+        {showcaseExamples.slice(0, 16).map((example, i) => {
           let preload: ShowcaseTypes["preload"] = i < 6 ? "auto" : "none";
           return (
             <Fragment key={example.name}>

--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -76,7 +76,8 @@ export default function Showcase() {
               />
               <MobileShowcase
                 isHydrated={isHydrated}
-                asImage={i > 5}
+                // asImage={i > 5}
+                asImage
                 // Only preload the first 2, since that's about all that should be "above the fold" on mobile
                 preload={i < 2 ? "auto" : "none"}
                 {...example}

--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -62,7 +62,7 @@ export default function Showcase() {
       </div>
       <ul className="mt-8 grid w-full max-w-md grid-cols-1 gap-x-6 gap-y-10 self-center md:max-w-3xl md:grid-cols-2 lg:max-w-6xl lg:grid-cols-3 lg:gap-x-8">
         {showcaseExamples.map((example, i) => {
-          let preload: ShowcaseTypes["preload"] = i < 2 ? "auto" : "none";
+          let preload: ShowcaseTypes["preload"] = i < 6 ? "auto" : "none";
           return (
             <Fragment key={example.name}>
               <DesktopShowcase
@@ -76,7 +76,8 @@ export default function Showcase() {
               />
               <MobileShowcase
                 isHydrated={isHydrated}
-                asImage={i > 5}
+                // asImage={i > 5}
+                asImage
                 // Only preload the first 2, since that's about all that should be "above the fold" on mobile
                 preload={i < 2 ? "auto" : "none"}
                 {...example}

--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -61,7 +61,7 @@ export default function Showcase() {
         </p>
       </div>
       <ul className="mt-8 grid w-full max-w-md grid-cols-1 gap-x-6 gap-y-10 self-center md:max-w-3xl md:grid-cols-2 lg:max-w-6xl lg:grid-cols-3 lg:gap-x-8">
-        {showcaseExamples.slice(1, 17).map((example, i) => {
+        {showcaseExamples.slice(0, 17).map((example, i) => {
           let preload: ShowcaseTypes["preload"] = i < 6 ? "auto" : "none";
           return (
             <Fragment key={example.name}>
@@ -76,8 +76,7 @@ export default function Showcase() {
               />
               <MobileShowcase
                 isHydrated={isHydrated}
-                // asImage={i > 5}
-                asImage
+                asImage={i > 5}
                 // Only preload the first 2, since that's about all that should be "above the fold" on mobile
                 preload={i < 2 ? "auto" : "none"}
                 {...example}

--- a/app/routes/_extras.showcase.tsx
+++ b/app/routes/_extras.showcase.tsx
@@ -61,7 +61,7 @@ export default function Showcase() {
         </p>
       </div>
       <ul className="mt-8 grid w-full max-w-md grid-cols-1 gap-x-6 gap-y-10 self-center md:max-w-3xl md:grid-cols-2 lg:max-w-6xl lg:grid-cols-3 lg:gap-x-8">
-        {showcaseExamples.map((example, i) => {
+        {showcaseExamples.slice(1, 17).map((example, i) => {
           let preload: ShowcaseTypes["preload"] = i < 6 ? "auto" : "none";
           return (
             <Fragment key={example.name}>


### PR DESCRIPTION
Currently the Showcase page is busted

https://github.com/remix-run/remix-website/assets/12396812/b8fb374e-2ec5-460c-8eb4-3637c9a7ea82

It seems to be a combination of too many examples and the autoplaying videos. I wanted to quickly fix page so we no longer have this experience, and will rework the page in #273 