### PR TITLE
Fix invisible text

### DIFF
--- a/app/ui/subscribe.tsx
+++ b/app/ui/subscribe.tsx
@@ -165,7 +165,7 @@ function SubscribeStatus() {
   return (
     <div aria-live="polite" className="py-2">
       {isSuccessful && (
-        <div className="text-white">
+        <div>
           <b className="text-green-brand">Got it!</b> Please go{" "}
           <b className="text-red-brand">check your email</b> to confirm your
           subscription, otherwise you won't get our email.


### PR DESCRIPTION
There is invisible text (i.e. text that is white, same as background) when showing a subscription confirmation.
![image](https://github.com/remix-run/remix-website/assets/28629647/725f69c3-4144-4226-bc7c-60b352bccd1b)

The fix looks like this:
![image](https://github.com/remix-run/remix-website/assets/28629647/1f59d646-6682-4607-8131-0dc97fe51680)
