### PR TITLE
Draft: Testing out Single Fetch

### DIFF
--- a/app/lib/blog.server.ts
+++ b/app/lib/blog.server.ts
@@ -159,12 +159,12 @@ interface MarkdownPost {
   html: string;
 }
 
-export interface BlogAuthor {
+export type BlogAuthor = {
   name: string;
   title: string;
   avatar: string;
-}
+};
 
-export interface BlogPost extends Omit<MarkdownPost, "authors"> {
+export type BlogPost = Omit<MarkdownPost, "authors"> & {
   authors: BlogAuthor[];
-}
+};

--- a/app/routes/_extras.blog.$slug.tsx
+++ b/app/routes/_extras.blog.$slug.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
-import { json } from "@remix-run/node";
+import { unstable_data } from "@remix-run/node";
 import invariant from "tiny-invariant";
 
 import { getBlogPost } from "~/lib/blog.server";
@@ -24,7 +24,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
   let post = await getBlogPost(slug);
 
-  return json(
+  return unstable_data(
     { siteUrl, post },
     { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/react": "^3.5.2",
-        "@remix-run/express": "2.11.2",
-        "@remix-run/node": "2.11.2",
-        "@remix-run/react": "2.11.2",
+        "@remix-run/express": "v0.0.0-nightly-24d1b2186-20240830",
+        "@remix-run/node": "v0.0.0-nightly-24d1b2186-20240830",
+        "@remix-run/react": "v0.0.0-nightly-24d1b2186-20240830",
         "cheerio": "^1.0.0-rc.12",
         "clsx": "^2.1.0",
         "compression": "^1.7.4",
@@ -47,7 +47,6 @@
         "remark-html": "^16.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.0",
-        "remix": "2.11.2",
         "satori": "^0.10.14",
         "semver": "^7.5.4",
         "shiki": "^0.14.7",
@@ -64,8 +63,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@remix-run/dev": "2.11.2",
-        "@remix-run/eslint-config": "2.11.2",
+        "@remix-run/dev": "v0.0.0-nightly-24d1b2186-20240830",
+        "@remix-run/eslint-config": "v0.0.0-nightly-24d1b2186-20240830",
         "@testing-library/jest-dom": "^6.2.0",
         "@types/follow-redirects": "^1.14.4",
         "@types/gunzip-maybe": "^1.4.2",
@@ -2831,9 +2830,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.11.2.tgz",
-      "integrity": "sha512-9DGb2UOIO4jOdws04Z+KmCeEBqbP36XvJZdcd4w16wDGI0I1ZY1c5ro58tB/7zPwN40s9MD9UzCYm6P+EkdeAg==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-MSsBSyNkhLAr9xOYTLbwUc1YYGFXuVHdA4zdXrSDhzhnM2gr2uharuT3do4ZQGNhXmW2KdhiNBy23aTebdWR7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2847,9 +2846,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.11.2",
-        "@remix-run/router": "1.19.1",
-        "@remix-run/server-runtime": "2.11.2",
+        "@remix-run/node": "0.0.0-nightly-24d1b2186-20240830",
+        "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
+        "@remix-run/server-runtime": "0.0.0-nightly-24d1b2186-20240830",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -2898,8 +2897,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^2.11.2",
-        "@remix-run/serve": "^2.11.2",
+        "@remix-run/react": "^0.0.0-nightly-24d1b2186-20240830",
+        "@remix-run/serve": "^0.0.0-nightly-24d1b2186-20240830",
         "typescript": "^5.1.0",
         "vite": "^5.1.0",
         "wrangler": "^3.28.2"
@@ -2935,9 +2934,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.11.2.tgz",
-      "integrity": "sha512-IclP0pBI7cqmKhHqa6qWY0rAF7cXCM+xODuIkt9DpR6dvgDW3TpCTB4tqOavIYDsLGNkx1sPfkXjpe3FIrT9Xw==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-ykrMDRgcyttQ5JOGWS8zap7AmymuFhIE6gM75H93TKVMQh9GL7KkCsQEpOaDjSYkmjC5Iz8yx1wBm6JzugdwzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2973,12 +2972,12 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.11.2.tgz",
-      "integrity": "sha512-ebyvHJKRBDgQGNBMxsILt21IwMTjGxQxlr0VNxRJo5rNd5CcuULpx/PPmsBc1gsc/Jx9aUXpT7a9l0UEOc6+jw==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-1zeIZ7yorxr9GLXdPfIEBj3as3rL7BJbcjzP9/nWhIXsCLxo3WGsoIpOAzAzq4JGlRrPuHymbUVRo3QD9FzzNQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/node": "2.11.2"
+        "@remix-run/node": "0.0.0-nightly-24d1b2186-20240830"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2994,12 +2993,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.11.2.tgz",
-      "integrity": "sha512-gRNFM61EOYWNmYgf+pvBt6MrirWlkDz1G6RQsJNowtRqbYoy05AdDe5HiHGF5w8ZMAZVeXnZiwbL0Nt7ykYBCA==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-ETmoseaopSchH+9MqhXtCoExlqb6Lrecz901J2x496SecyV6yi1yyQVPwBWQxsWKVELSwj1R10KA1kr17yxnTQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.11.2",
+        "@remix-run/server-runtime": "0.0.0-nightly-24d1b2186-20240830",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -3020,16 +3019,16 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.11.2.tgz",
-      "integrity": "sha512-SjjuK3aD/9wnIC5r0ZBNCpVSwEwt67YOQM7DCXhHiS8BtCvAxWEC4k4t8CvO9IwBG0gczqxzSqASH7U1RVtWqw==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-frpKy2y+7RNQHEdD9yT3GyA8sZSv1774ppBTmHXm+BMGbPsiKICHK1hy/Dz3i0jutYL8ea4Ag4dLAuGZTXrbzQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.1",
-        "@remix-run/server-runtime": "2.11.2",
-        "react-router": "6.26.1",
-        "react-router-dom": "6.26.1",
-        "turbo-stream": "2.3.0"
+        "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
+        "@remix-run/server-runtime": "0.0.0-nightly-24d1b2186-20240830",
+        "react-router": "0.0.0-experimental-7d87ffb8c",
+        "react-router-dom": "0.0.0-experimental-7d87ffb8c",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3046,27 +3045,27 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
-      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "version": "0.0.0-experimental-7d87ffb8c",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-0.0.0-experimental-7d87ffb8c.tgz",
+      "integrity": "sha512-Vu0Zw3Pm+/tEpE3MFI0ONEQbZEMlMddBCf8JwnYeQGwsaIXYk3oLpv1zE7n8QdF6A+Z7C2ieWMDde+wb+4060g==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.11.2.tgz",
-      "integrity": "sha512-abG6ENj0X3eHqDxqO2thWM2NSEiPnqyt58z1BbiQCv+t8g0Zuqd5QHbB4wzdNvfS0vKhg+jJiigcJneAc4sZzw==",
+      "version": "0.0.0-nightly-24d1b2186-20240830",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-0.0.0-nightly-24d1b2186-20240830.tgz",
+      "integrity": "sha512-HTTPlRee1xkaxuhQkLy0rgIRhKHGAHW2sAUDwnLQVCZOX4aMel1OceDp1bX9UiSyFn0izmLY6g/CBTE5hLKTqQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.1",
+        "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3",
-        "turbo-stream": "2.3.0"
+        "turbo-stream": "2.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3084,6 +3083,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.1.0.tgz",
       "integrity": "sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/web-stream": "^1.1.0",
         "web-encoding": "1.1.5"
@@ -3093,6 +3093,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.4.2.tgz",
       "integrity": "sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/web-blob": "^3.1.0",
         "@remix-run/web-file": "^3.1.0",
@@ -3111,6 +3112,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.1.0.tgz",
       "integrity": "sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/web-blob": "^3.1.0"
       }
@@ -3119,6 +3121,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.1.0.tgz",
       "integrity": "sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==",
+      "license": "MIT",
       "dependencies": {
         "web-encoding": "1.1.5"
       }
@@ -3127,6 +3130,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.1.0.tgz",
       "integrity": "sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==",
+      "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
       }
@@ -3686,7 +3690,8 @@
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -4798,18 +4803,21 @@
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
-      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
       "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
       "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5968,6 +5976,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.1.tgz",
       "integrity": "sha512-78KWk9T26NhzXtuL26cIJ8/qNHANyJ/ZYrmEXFzUmhZdjpBv+DlWlOANRTGBt48YcyslsLrj0bMLFTmXvLRCOw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
       }
@@ -6252,6 +6261,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -7789,6 +7799,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -15597,6 +15608,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
       "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -17351,12 +17363,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
-      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "version": "0.0.0-experimental-7d87ffb8c",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-0.0.0-experimental-7d87ffb8c.tgz",
+      "integrity": "sha512-DWE9pSHTPECV+9RHyzSJTgA1rexfR6tj0LjRzgxBxOVgmojtbNP9tXZc8UrP+5l9LxfGmLtvQu6w4EO3tyRSkw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.1"
+        "@remix-run/router": "0.0.0-experimental-7d87ffb8c"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17366,13 +17378,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
-      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "version": "0.0.0-experimental-7d87ffb8c",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-0.0.0-experimental-7d87ffb8c.tgz",
+      "integrity": "sha512-5l2H4fEjrfJICAUkBwpJHQV4LMYXixTAL7eLqQIoKVI3zqyh3kPhY9CHxEk+5liiVrJhxmhIt4loFycLTAS4Hg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.1",
-        "react-router": "6.26.1"
+        "@remix-run/router": "0.0.0-experimental-7d87ffb8c",
+        "react-router": "0.0.0-experimental-7d87ffb8c"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -18481,15 +18493,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remix": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-2.11.2.tgz",
-      "integrity": "sha512-Z0IJkp3RPBipdUkJcO2IDOeGN90kpzn6IW15XZ6owOLQM9aGEg4kJxB5o7AsYBjVmQu7MEUE18IMm9XHZhflGA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
@@ -18878,9 +18881,10 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.0.tgz",
+      "integrity": "sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.1.1",
@@ -19119,7 +19123,8 @@
     "node_modules/stream-slice": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
-      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA=="
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
+      "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.15.5",
@@ -20064,9 +20069,9 @@
       }
     },
     "node_modules/turbo-stream": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.3.0.tgz",
-      "integrity": "sha512-PhEr9mdexoVv+rJkQ3c8TjrN3DUghX37GNJkSMksoPR4KrXIPnM2MnqRt07sViIqX9IdlhrgtTSyjoVOASq6cg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
       "license": "ISC"
     },
     "node_modules/tween-functions": {
@@ -20219,9 +20224,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.15.0.tgz",
-      "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -20589,6 +20595,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -21983,6 +21990,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
       "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "license": "MIT",
       "dependencies": {
         "util": "^0.12.3"
       },
@@ -22003,6 +22011,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,19 @@
     "test": "vitest",
     "typecheck": "tsc -b"
   },
+  "overrides": {
+    "@remix-run/express": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/node": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/react": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/dev": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/eslint-config": "v0.0.0-nightly-24d1b2186-20240830"
+  },
   "dependencies": {
     "@docsearch/css": "^3.5.2",
     "@docsearch/react": "^3.5.2",
-    "@remix-run/express": "2.11.2",
-    "@remix-run/node": "2.11.2",
-    "@remix-run/react": "2.11.2",
+    "@remix-run/express": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/node": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/react": "v0.0.0-nightly-24d1b2186-20240830",
     "cheerio": "^1.0.0-rc.12",
     "clsx": "^2.1.0",
     "compression": "^1.7.4",
@@ -59,7 +66,6 @@
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
-    "remix": "2.11.2",
     "satori": "^0.10.14",
     "semver": "^7.5.4",
     "shiki": "^0.14.7",
@@ -76,8 +82,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@remix-run/dev": "2.11.2",
-    "@remix-run/eslint-config": "2.11.2",
+    "@remix-run/dev": "v0.0.0-nightly-24d1b2186-20240830",
+    "@remix-run/eslint-config": "v0.0.0-nightly-24d1b2186-20240830",
     "@testing-library/jest-dom": "^6.2.0",
     "@types/follow-redirects": "^1.14.4",
     "@types/gunzip-maybe": "^1.4.2",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,12 +3,21 @@ import { vitePlugin as remix } from "@remix-run/dev";
 import tsconfigPaths from "vite-tsconfig-paths";
 import arraybuffer from "vite-plugin-arraybuffer";
 
+declare module "@remix-run/server-runtime" {
+  interface Future {
+    unstable_singleFetch: true;
+  }
+}
+
 export default defineConfig({
   build: {
     sourcemap: true,
   },
   ssr: {
     noExternal: ["@docsearch/react"],
+  },
+  optimizeDeps: {
+    exclude: ["svg2img"],
   },
   plugins: [
     tsconfigPaths(),


### PR DESCRIPTION
Testing out the latest [Remix nightly release](https://github.com/remix-run/remix/releases/tag/v0.0.0-nightly-24d1b2186-20240830) and running into a few problems

## Optimize Deps unexpected error

When `npm run dev`, I get the following error, and I don't get it on the previous nightly

```sh
Re-optimizing dependencies because lockfile has changed
Express server listening on port 3000 (http://localhost:3000)
✘ [ERROR] Failed to resolve entry for package "jimp". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-pre-bundle]

    node_modules/vite/node_modules/esbuild/lib/main.js:1373:21:
      1373 │         let result = await callback({
           ╵                      ^
```


It's easy to solve by adding the following to the Vite config

```ts
// vite.conf.mts

optimizeDeps: {
	exclude: ["svg2img"],
},
```

However, this took me a second to figure out, and mostly because I knew we'd made some changes to vite dependency optimization stuff. I'm nervous this is going to cause people's apps to break in dev unexpectedly.

## Single Fetch types

With the single fetch types, there seem to be 2 issues

1. The inability to use `interface` still seems to be a problem. Is this expected? I thought this was something that we could resolve with the plugin to `turbo-stream`
2. The return type seems to be wrong, it thinks it's returning an object with a `data` key

I recorded a video walking through these issues

https://github.com/user-attachments/assets/7835126c-3066-4be4-805b-4ffc73435a90


