### PR TITLE
Fix URL: fog-of-war => lazy-route-discovery

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -62,3 +62,4 @@
 /docs/future/server-bundles           /docs/guides/server-bundles          302
 /docs/future/spa-mode                 /docs/guides/spa-mode                302
 /docs/future/vite                     /docs/guides/vite                    302
+/docs/guides/fog-of-war               /docs/guides/lazy-route-discovery    302

--- a/_redirects
+++ b/_redirects
@@ -62,4 +62,3 @@
 /docs/future/server-bundles           /docs/guides/server-bundles          302
 /docs/future/spa-mode                 /docs/guides/spa-mode                302
 /docs/future/vite                     /docs/guides/vite                    302
-/docs/guides/fog-of-war               /docs/guides/lazy-route-discovery    302

--- a/data/posts/fog-of-war.md
+++ b/data/posts/fog-of-war.md
@@ -196,7 +196,7 @@ This ability to implement async logic also lends itself very well to Micro Front
 We'd also like to give a huge shout-out to [Shane Walker][twitter-swalker326] for working with us during the initial release to put together a [great example][rr-mf-example] of using this new API in a federated `rsbuild` React Router application. Make sure to give it a look if you're interested in using Module Federation in your React Router app!
 
 [rr-patch-routes-on-miss]: https://reactrouter.com/en/main/routers/create-browser-router#optsunstable_patchroutesonmiss
-[remix-fog-of-war]: https://remix.run/docs/en/main/guides/fog-of-war
+[remix-fog-of-war]: https://remix.run/docs/en/main/guides/lazy-route-discovery
 [when-to-fetch]: https://www.youtube.com/watch?v=95B8mnhzoCM
 [remixing-rr]: https://remix.run/blog/remixing-react-router
 [streaming]: https://remix.run/docs/en/main/guides/streaming


### PR DESCRIPTION
The first link in [Matt's blogpost](https://remix.run/blog/fog-of-war) is [currently 404'ing](https://remix.run/docs/en/main/guides/fog-of-war). This PR:

- Updates the link to point to the ["Lazy Route Discovery" guide in the docs](https://remix.run/docs/en/main/guides/lazy-route-discovery)
- Adds a redirect from the `fog-of-war` URL to the `lazy-route-discovery` URL. I appended it to the bottom of the file, but perhaps it should be moved elsewhere? Or maybe not necessary at all? 🤷‍♂️