### PR TITLE
chore(resources.yaml): add auth-remix to Remix resources

### DIFF
--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -244,3 +244,9 @@
   imgSrc: "https://camo.githubusercontent.com/076066f43ba75163106f304fc42750445f55343abb62e10429d554b4f227d942/68747470733a2f2f6765746a757374642e636f6d2f6f70656e67726170682d696d6167652e706e673f763d31"
   initCommand: "npx create-remix@latest --template justdlabs/remix"
   category: "templates"
+
+- title: "auth-remix"
+  repoUrl: "https://github.com/hambergerpls/auth-remix"
+  imgSrc: "https://opengraph.githubassets.com/1/hambergerpls/auth-remix"
+  initCommand: "npm install auth-remix"
+  category: "libraries"


### PR DESCRIPTION
Hi, I'm the maintainer of [auth-remix](https://github.com/hambergerpls/auth-remix), an [Auth.js](https://authjs.dev) integration framework for Remix.

This is not an official integration framework of Auth.js. I created this because the official PR has not been merged since 2023. So instead of waiting, I decided to create my own.

I hope this will benefit the Remix community who wants to use Auth.js in their Remix app.