### PR TITLE
Shorten RSC post summary

### DIFF
--- a/data/posts/react-router-and-react-server-components.md
+++ b/data/posts/react-router-and-react-server-components.md
@@ -1,6 +1,6 @@
 ---
 title: "React Router and React Server Components: The Path Forward"
-summary: React Router's RSC support is more than just a new feature. It's a major architectural shift that makes it a much more powerful library while also making Framework Mode less coupled to any particular bundler.
+summary: React Router's RSC support is a major architectural shift, making it a much more powerful library and making Framework Mode less coupled to specific bundlers.
 date: 2025-07-16
 image: /blog-images/headers/rr-rsc-path-forward.jpg
 ogImage: /blog-images/headers/rr-rsc-path-forward.jpg


### PR DESCRIPTION
This summary is much longer than surrounding posts now that it's not at the top, so this just tightens things up a bit.