### PR TITLE
Enable fingerprinted asset loader URLs

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: flyctl deploy --remote-only --config ./fly.production.toml --strategy rolling
+        run: flyctl deploy --remote-only --config ./fly.production.toml --strategy rolling --build-arg ASSET_BUILD_ID=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -52,6 +52,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@1.5
 
       - name: 🚀 Deploy Staging
-        run: flyctl deploy --remote-only --config ./fly.staging.toml --strategy bluegreen
+        run: flyctl deploy --remote-only --config ./fly.staging.toml --strategy bluegreen --build-arg ASSET_BUILD_ID=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ RUN corepack enable && pnpm run build
 
 # Finally, build the production image with minimal footprint
 FROM base
+ARG ASSET_BUILD_ID=local-build
 
 ENV PORT="8080"
 ENV NODE_ENV="production"
+ENV ASSET_BUILD_ID="${ASSET_BUILD_ID}"
 
 WORKDIR /remixapp
 

--- a/app/utils/assets.server.test.ts
+++ b/app/utils/assets.server.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { assetServer } from "./assets.server";
+import { assetServer, createAppAssetServer } from "./assets.server";
 
 let rootDir = path.resolve(import.meta.dirname, "../..");
 let appDir = path.join(rootDir, "app");
@@ -24,6 +24,37 @@ describe("browser asset module graph", () => {
     }
 
     expect(failures).toEqual([]);
+  });
+
+  it("fingerprints production asset URLs for immutable caching", async () => {
+    let server = createAppAssetServer({
+      buildId: "test-build",
+      isDevelopment: false,
+    });
+
+    try {
+      let href = await server.getHref(rootBrowserEntry);
+      expect(href).toMatch(
+        /^\/assets\/app\/assets\/entry\.@[A-Za-z0-9_-]{6}\.ts$/,
+      );
+
+      let response = await server.fetch(
+        new Request(new URL(href, "http://localhost")),
+      );
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("Cache-Control")).toBe(
+        "public, max-age=31536000, immutable",
+      );
+
+      let stableResponse = await server.fetch(
+        new Request(
+          new URL("/assets/app/assets/entry.ts", "http://localhost"),
+        ),
+      );
+      expect(stableResponse).toBeNull();
+    } finally {
+      await server.close();
+    }
   });
 });
 

--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -4,9 +4,13 @@ import { createAssetServer } from "remix/assets";
 let isDevelopment = process.env.NODE_ENV !== "production";
 let rootDir = path.resolve(import.meta.dirname, "../..");
 let buildId =
-  process.env.ASSET_BUILD_ID ??
-  process.env.GITHUB_SHA ??
-  new Date().toISOString();
+  process.env.ASSET_BUILD_ID ?? process.env.GITHUB_SHA ?? String(Date.now());
+
+console.log({
+  assetBuildId: process.env.ASSET_BUILD_ID,
+  githubSha: process.env.GITHUB_SHA,
+  buildId: buildId,
+});
 
 export let assetServer = createAppAssetServer({ buildId, isDevelopment });
 

--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -6,12 +6,6 @@ let rootDir = path.resolve(import.meta.dirname, "../..");
 let buildId =
   process.env.ASSET_BUILD_ID ?? process.env.GITHUB_SHA ?? String(Date.now());
 
-console.log({
-  assetBuildId: process.env.ASSET_BUILD_ID,
-  githubSha: process.env.GITHUB_SHA,
-  buildId: buildId,
-});
-
 export let assetServer = createAppAssetServer({ buildId, isDevelopment });
 
 export function createAppAssetServer({

--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -3,28 +3,41 @@ import { createAssetServer } from "remix/assets";
 
 let isDevelopment = process.env.NODE_ENV !== "production";
 let rootDir = path.resolve(import.meta.dirname, "../..");
+let buildId =
+  process.env.ASSET_BUILD_ID ?? process.env.GITHUB_SHA ?? "local-build";
 
-export let assetServer = createAssetServer({
-  rootDir,
-  fileMap: {
-    "/assets/app/*path": "app/*path",
-    "/assets/npm/*path": "node_modules/*path",
-  },
-  allow: [path.join(rootDir, "app"), path.join(rootDir, "node_modules")],
-  deny: [
-    "app/**/*.server.*",
-    "app/**/*.test.*",
-    "app/data/**",
-    "app/middleware/**",
-  ],
-  sourceMaps: isDevelopment ? "external" : undefined,
-  minify: !isDevelopment,
-  scripts: {
-    define: {
-      "process.env.NODE_ENV": JSON.stringify(
-        process.env.NODE_ENV ?? "development",
-      ),
+export let assetServer = createAppAssetServer({ buildId, isDevelopment });
+
+export function createAppAssetServer({
+  buildId,
+  isDevelopment,
+}: {
+  buildId: string;
+  isDevelopment: boolean;
+}) {
+  return createAssetServer({
+    rootDir,
+    fileMap: {
+      "/assets/app/*path": "app/*path",
+      "/assets/npm/*path": "node_modules/*path",
     },
-  },
-  watch: false,
-});
+    allow: [path.join(rootDir, "app"), path.join(rootDir, "node_modules")],
+    deny: [
+      "app/**/*.server.*",
+      "app/**/*.test.*",
+      "app/data/**",
+      "app/middleware/**",
+    ],
+    fingerprint: isDevelopment ? undefined : { buildId },
+    sourceMaps: isDevelopment ? "external" : undefined,
+    minify: !isDevelopment,
+    scripts: {
+      define: {
+        "process.env.NODE_ENV": JSON.stringify(
+          process.env.NODE_ENV ?? "development",
+        ),
+      },
+    },
+    watch: false,
+  });
+}

--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -4,7 +4,9 @@ import { createAssetServer } from "remix/assets";
 let isDevelopment = process.env.NODE_ENV !== "production";
 let rootDir = path.resolve(import.meta.dirname, "../..");
 let buildId =
-  process.env.ASSET_BUILD_ID ?? process.env.GITHUB_SHA ?? "local-build";
+  process.env.ASSET_BUILD_ID ??
+  process.env.GITHUB_SHA ??
+  new Date().toISOString();
 
 export let assetServer = createAppAssetServer({ buildId, isDevelopment });
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:css": "pnpm run build:css --watch",
     "dev:server": "cross-env NODE_ENV=development PORT=44100 tsx watch server.ts",
     "format": "prettier --write ./",
-    "deploy": "flyctl deploy --build-arg REMIX_TOKEN=${REMIX_TOKEN}",
+    "deploy": "flyctl deploy --build-arg REMIX_TOKEN=${REMIX_TOKEN} --build-arg ASSET_BUILD_ID=$(git rev-parse HEAD)",
     "push:stage": "git tag -f stage && git push origin stage -f",
     "start": "cross-env NODE_ENV=production node --import tsx server.ts",
     "preview": "cross-env NODE_ENV=production node --env-file=.env --import tsx server.ts",


### PR DESCRIPTION
## Summary
- Enables production asset-server fingerprinting so browser-loaded scripts/styles get immutable cache headers.
- Passes the current GitHub SHA into Fly builds as `ASSET_BUILD_ID` so fingerprints invalidate together per deploy.
- Adds coverage for fingerprinted href generation, immutable cache headers, and rejection of stable URLs in production mode.

## Test plan
- `pnpm test -- app/utils/assets.server.test.ts`
- `pnpm run build`
- `pnpm run lint`