### PR TITLE
Add shared Remix theme and font stylesheet

### DIFF
--- a/app/assets/document-head-sync.tsx
+++ b/app/assets/document-head-sync.tsx
@@ -57,8 +57,10 @@ function syncTheme(forceTheme?: "dark" | "light") {
 
   if (forceTheme) {
     root.dataset.theme = forceTheme;
+    root.style.colorScheme = forceTheme;
   } else {
     delete root.dataset.theme;
+    root.style.colorScheme = "light dark";
   }
 
   if (typeof window.__remixSyncColorScheme === "function") {

--- a/app/assets/document-head-sync.tsx
+++ b/app/assets/document-head-sync.tsx
@@ -8,7 +8,6 @@ import {
 type DocumentHeadSyncProps = {
   title?: string;
   forceTheme?: "dark" | "light";
-  bodyClassName: string;
   headTags: ManagedHeadTag[];
 };
 
@@ -30,7 +29,6 @@ export let DocumentHeadSync = clientEntry(
 
       syncTitle(latestProps.title);
       syncTheme(latestProps.forceTheme);
-      syncBodyClassName(latestProps.bodyClassName);
       syncManagedHeadTags(latestProps.headTags);
     };
 
@@ -74,10 +72,4 @@ function syncTheme(forceTheme?: "dark" | "light") {
       (forceTheme == null &&
         window.matchMedia("(prefers-color-scheme: dark)").matches),
   );
-}
-
-function syncBodyClassName(bodyClassName: string) {
-  if (document.body.className !== bodyClassName) {
-    document.body.className = bodyClassName;
-  }
 }

--- a/app/controllers/blog/controller.tsx
+++ b/app/controllers/blog/controller.tsx
@@ -7,6 +7,7 @@ import { render } from "../../utils/render.ts";
 import { getBlogPostListings } from "../../data/blog.server.ts";
 import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.server.ts";
+import { styleHrefs } from "../../utils/style-hrefs.ts";
 
 export async function blogHandler() {
   let posts = await getBlogPostListings();
@@ -24,6 +25,7 @@ function Page() {
     <Document
       title="Remix Blog"
       description="Thoughts about building excellent user experiences with Remix."
+      stylesheets={[styleHrefs.app]}
       headTags={getSocialHeadTags({
         title: "Remix Blog",
         description:

--- a/app/controllers/brand.tsx
+++ b/app/controllers/brand.tsx
@@ -6,6 +6,7 @@ import { Header } from "../ui/header.tsx";
 import { render } from "../utils/render.ts";
 import { CACHE_CONTROL } from "../utils/cache-control.ts";
 import { getSocialHeadTags } from "../utils/social-head-tags.server.ts";
+import { styleHrefs } from "../utils/style-hrefs.ts";
 
 export async function brandHandler() {
   return render.document(<Page />, {
@@ -25,6 +26,7 @@ function Page() {
         description:
           "Remix brand assets and guidelines for using the Remix name and logos.",
       })}
+      stylesheets={[styleHrefs.app]}
     >
       <Header />
       <main id="main-content" class="flex flex-1 flex-col" tabIndex={-1}>

--- a/app/controllers/home/controller.test.ts
+++ b/app/controllers/home/controller.test.ts
@@ -55,10 +55,12 @@ describe("home route", () => {
     expect(html).toContain(
       'rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any"',
     );
+    expect(html).toContain('rel="preload" as="style" href="/styles/fonts.css"');
     expect(html).toContain('rel="preload" as="style" href="/styles/app.css"');
     expect(html).toContain('rel="preload" as="style" href="/styles/home.css"');
     expect(html).toContain('rel="preload" as="style" href="/styles/md.css"');
     expect(html).toContain('rel="preload" as="style" href="/styles/jam.css"');
+    expect(html).toContain('rel="stylesheet" href="/styles/fonts.css"');
     expect(html).toContain('rel="stylesheet" href="/styles/home.css"');
     expect(html).not.toContain('rel="stylesheet" href="/styles/app.css"');
     expect(html).not.toContain("fonts.googleapis.com");

--- a/app/controllers/newsletter.tsx
+++ b/app/controllers/newsletter.tsx
@@ -6,6 +6,7 @@ import { NewsletterSubscribeForm } from "../assets/newsletter-subscribe.tsx";
 import { render } from "../utils/render.ts";
 import { CACHE_CONTROL } from "../utils/cache-control.ts";
 import { getSocialHeadTags } from "../utils/social-head-tags.server.ts";
+import { styleHrefs } from "../utils/style-hrefs.ts";
 
 export async function newsletterHandler() {
   return render.document(<Page />, {
@@ -21,6 +22,7 @@ function Page() {
       title="Remix Newsletter"
       description="Stay up-to-date with news, announcements, and releases for our projects like Remix and React Router. We respect your privacy, unsubscribe at any time."
       forceTheme="dark"
+      stylesheets={[styleHrefs.app]}
       headTags={getSocialHeadTags({
         title: "Remix Newsletter",
         description:

--- a/app/controllers/remix3-active-development/controller.tsx
+++ b/app/controllers/remix3-active-development/controller.tsx
@@ -9,6 +9,7 @@ import { TimelineSection } from "./timeline-section/index.tsx";
 import { getSocialHeadTags } from "../../utils/social-head-tags.server.ts";
 import { render } from "../../utils/render.ts";
 import { CACHE_CONTROL } from "../../utils/cache-control.ts";
+import { styleHrefs } from "../../utils/style-hrefs.ts";
 
 export async function remix3ActiveDevelopmentHandler() {
   return render.document(<Remix3ActiveDevelopmentPage />, {
@@ -24,6 +25,7 @@ function Remix3ActiveDevelopmentPage() {
       title="Remix - A Web Framework for Building Anything"
       description="Remix is a batteries-included, ultra-productive, zero dependencies and bundler-free framework, ready to develop with in a agent-first world."
       forceTheme="light"
+      stylesheets={[styleHrefs.app]}
       headTags={getSocialHeadTags({
         title: "Remix - A Web Framework for Building Anything",
         description:

--- a/app/styles/fonts.css
+++ b/app/styles/fonts.css
@@ -1,0 +1,22 @@
+@font-face {
+  font-family: "Inter";
+  font-weight: 100 900;
+  font-display: swap;
+  font-style: normal;
+  src: url("/font/inter-roman-latin-var.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-weight: 100 900;
+  font-display: swap;
+  font-style: italic;
+  src: url("/font/inter-italic-latin-var.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-display: swap;
+  src: url("/font/jet-brains-mono.woff2") format("woff2");
+}

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -1,10 +1,3 @@
-@font-face {
-  font-family: "JetBrains Mono";
-  font-style: normal;
-  font-display: swap;
-  src: url("/font/jet-brains-mono.woff2") format("woff2");
-}
-
 @property --brand-cycle {
   syntax: "<color>";
   inherits: true;

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -2,29 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: "Inter";
-  font-weight: 100 900;
-  font-display: swap;
-  font-style: normal;
-  src: url("/font/inter-roman-latin-var.woff2") format("woff2");
-}
-
-@font-face {
-  font-family: "Inter";
-  font-weight: 100 900;
-  font-display: swap;
-  font-style: italic;
-  src: url("/font/inter-italic-latin-var.woff2") format("woff2");
-}
-
-@font-face {
-  font-family: "JetBrains Mono";
-  font-style: normal;
-  font-display: swap;
-  src: url("/font/jet-brains-mono.woff2") format("woff2");
-}
-
 .dark {
   color-scheme: dark;
 }

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -1,4 +1,5 @@
 import { css, type Handle, type RemixNode } from "remix/ui";
+import { theme } from "remix/ui/theme";
 
 import { DocumentHeadSync } from "../assets/document-head-sync.tsx";
 import { getAssetEntry } from "../middleware/asset-entry.ts";
@@ -87,6 +88,7 @@ export function Document(handle: Handle<DocumentProps>) {
         lang="en"
         data-theme={forceTheme ?? undefined}
         class={forceTheme === "dark" ? "dark" : undefined}
+        style={{ colorScheme: forceTheme ?? "light dark" }}
       >
         <head>
           <meta charset="utf-8" />
@@ -180,20 +182,12 @@ let documentBodyStyle = css({
   width: "100%",
   flexDirection: "column",
   overflowX: "hidden",
-  backgroundColor: "#ffffff",
-  color: "#121212",
+  backgroundColor: theme.surface.lvl0,
+  color: theme.colors.text.primary,
   WebkitFontSmoothing: "antialiased",
   MozOsxFontSmoothing: "grayscale",
   "&::selection": {
-    backgroundColor: "#bce0ff",
-    color: "#000000",
-  },
-  ":root.dark &": {
-    backgroundColor: "#121212",
-    color: "#c8c8c8",
-  },
-  ":root.dark &::selection": {
-    backgroundColor: "#1747b6",
-    color: "#ffffff",
+    backgroundColor: "light-dark(#bce0ff, #1747b6)",
+    color: "light-dark(#000000, #ffffff)",
   },
 });

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -1,10 +1,11 @@
-import type { RemixNode } from "remix/ui";
+import { css, type Handle, type RemixNode } from "remix/ui";
 
 import { DocumentHeadSync } from "../assets/document-head-sync.tsx";
 import { getAssetEntry } from "../middleware/asset-entry.ts";
 import { getManagedHeadTagKey, type ManagedHeadTag } from "./document-head.ts";
 import { assetPaths } from "../utils/asset-paths.ts";
 import { styleHrefs } from "../utils/style-hrefs.ts";
+import { RemixTheme } from "./theme.ts";
 
 let colorSchemeScript = `
   let media = window.matchMedia("(prefers-color-scheme: dark)");
@@ -47,18 +48,20 @@ declare global {
  * Plain stylesheet assets are compiled into `public/styles`.
  * Route code links to them through `app/utils/style-hrefs.ts`.
  */
-export function Document() {
-  return ({
-    title,
-    description,
-    noIndex,
-    forceTheme,
-    headTags = [],
-    stylesheets,
-    children,
-  }: DocumentProps) => {
+export function Document(handle: Handle<DocumentProps>) {
+  return () => {
+    let {
+      title,
+      description,
+      noIndex,
+      forceTheme,
+      headTags = [],
+      stylesheets = [],
+      children,
+    } = handle.props;
     let assetEntry = getAssetEntry();
-    let appliedStylesheets = stylesheets ?? [styleHrefs.app];
+
+    stylesheets = [...new Set([styleHrefs.fonts, ...stylesheets])];
     let managedHeadTags: ManagedHeadTag[] = [
       ...(noIndex
         ? [{ kind: "meta" as const, name: "robots", content: "noindex" }]
@@ -72,21 +75,13 @@ export function Document() {
             },
           ]
         : []),
-      ...appliedStylesheets.map((href) => ({
+      ...stylesheets.map((href) => ({
         kind: "link" as const,
         rel: "stylesheet",
         href,
       })),
       ...headTags,
     ];
-    let bodyClassName = `flex min-h-screen w-full flex-col overflow-x-hidden antialiased selection:bg-blue-200 selection:text-black dark:selection:bg-blue-800 dark:selection:text-white ${
-      forceTheme === "dark"
-        ? "bg-gray-900 text-gray-200"
-        : forceTheme === "light"
-          ? "bg-white text-gray-900"
-          : "bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-200"
-    }`;
-
     return (
       <html
         lang="en"
@@ -100,6 +95,7 @@ export function Document() {
             content="width=device-width,initial-scale=1,viewport-fit=cover"
           />
           <meta name="theme-color" content="#121212" />
+          <RemixTheme.Style />
           {title ? <title>{title}</title> : null}
 
           <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -110,25 +106,6 @@ export function Document() {
             sizes="any"
           />
 
-          {/* Font preloads */}
-          <link
-            rel="preload"
-            as="font"
-            href="/font/inter-roman-latin-var.woff2"
-            crossorigin="anonymous"
-          />
-          <link
-            rel="preload"
-            as="font"
-            href="/font/inter-italic-latin-var.woff2"
-            crossorigin="anonymous"
-          />
-          <link
-            rel="preload"
-            as="font"
-            href="/font/jet-brains-mono.woff2"
-            crossorigin="anonymous"
-          />
           {Object.values(styleHrefs).map((href) => (
             <link key={href} rel="preload" as="style" href={href} />
           ))}
@@ -173,18 +150,19 @@ export function Document() {
           <script innerHTML={colorSchemeScript} />
         </head>
 
-        <body class={bodyClassName}>
+        <body mix={documentBodyStyle}>
           <DocumentHeadSync
             title={title}
             forceTheme={forceTheme}
-            bodyClassName={bodyClassName}
             headTags={managedHeadTags}
           />
           <img
             src={assetPaths.iconsSprite}
             alt=""
             hidden
-            // Preload icons sprite so <use href> references resolve (matches app/root.tsx)
+            // Inline so route-local theme resets emitted later cannot reveal the sprite.
+            style={{ display: "none" }}
+            // Preload icons sprite so <use href> references resolve.
             fetchpriority="high"
           />
           {children}
@@ -193,3 +171,29 @@ export function Document() {
     );
   };
 }
+
+// These values intentionally mirror the old Tailwind body utilities so shared
+// document chrome does not depend on app.css being loaded.
+let documentBodyStyle = css({
+  display: "flex",
+  minHeight: "100vh",
+  width: "100%",
+  flexDirection: "column",
+  overflowX: "hidden",
+  backgroundColor: "#ffffff",
+  color: "#121212",
+  WebkitFontSmoothing: "antialiased",
+  MozOsxFontSmoothing: "grayscale",
+  "&::selection": {
+    backgroundColor: "#bce0ff",
+    color: "#000000",
+  },
+  ":root.dark &": {
+    backgroundColor: "#121212",
+    color: "#c8c8c8",
+  },
+  ":root.dark &::selection": {
+    backgroundColor: "#1747b6",
+    color: "#ffffff",
+  },
+});

--- a/app/ui/footer.tsx
+++ b/app/ui/footer.tsx
@@ -1,55 +1,145 @@
-import cx from "clsx";
+import { css } from "remix/ui";
+import { theme } from "remix/ui/theme";
 import { routes } from "../routes.ts";
 import { assetPaths } from "../utils/asset-paths.ts";
 import { Wordmark } from "./wordmark.tsx";
 
 export function Footer() {
   return () => (
-    <footer
-      class={cx(
-        "flex flex-col items-center justify-center gap-4 px-6 py-12 pb-36 lg:px-12",
-        "text-rmx-muted",
-      )}
-    >
-      <div class="text-rmx-muted flex items-center gap-6">
+    <footer mix={footerStyle}>
+      <div mix={footerTopStyle}>
         <a
           href={routes.remix3ActiveDevelopment.href()}
           aria-label="Remix"
-          class="inline-flex items-center opacity-60 transition hover:opacity-100"
+          mix={footerBrandLinkStyle}
         >
           <Wordmark height={12} aria-hidden />
         </a>
-        <nav
-          class="flex items-center gap-6 [&_a:hover]:opacity-100 [&_a]:opacity-80 [&_a]:transition [&_svg]:size-5"
-          aria-label="Find us on the web"
-        >
-          <a href="https://github.com/remix-run" aria-label="GitHub">
-            <svg aria-hidden="true" fill="none">
+        <nav aria-label="Find us on the web" mix={footerSocialNavStyle}>
+          <a
+            href="https://github.com/remix-run"
+            aria-label="GitHub"
+            mix={footerSocialLinkStyle}
+          >
+            <svg aria-hidden="true" fill="none" mix={footerSocialIconStyle}>
               <use href={`${assetPaths.iconsSprite}#github`} />
             </svg>
           </a>
-          <a href="https://x.com/remix_run" aria-label="X">
-            <svg aria-hidden="true" fill="none">
+          <a
+            href="https://x.com/remix_run"
+            aria-label="X"
+            mix={footerSocialLinkStyle}
+          >
+            <svg aria-hidden="true" fill="none" mix={footerSocialIconStyle}>
               <use href={`${assetPaths.iconsSprite}#x`} />
             </svg>
           </a>
-          <a href="https://youtube.com/remix_run" aria-label="YouTube">
-            <svg aria-hidden="true" fill="none">
+          <a
+            href="https://youtube.com/remix_run"
+            aria-label="YouTube"
+            mix={footerSocialLinkStyle}
+          >
+            <svg aria-hidden="true" fill="none" mix={footerSocialIconStyle}>
               <use href={`${assetPaths.iconsSprite}#youtube`} />
             </svg>
           </a>
-          <a href="https://discord.gg/xwx7mMzVkA" aria-label="Remix">
-            <svg aria-hidden="true" fill="none">
+          <a
+            href="https://discord.gg/xwx7mMzVkA"
+            aria-label="Remix"
+            mix={footerSocialLinkStyle}
+          >
+            <svg aria-hidden="true" fill="none" mix={footerSocialIconStyle}>
               <use href={`${assetPaths.iconsSprite}#discord`} />
             </svg>
           </a>
         </nav>
       </div>
 
-      <div class="text-rmx-muted flex flex-col items-center gap-2 font-mono text-[10px] uppercase leading-[1.6] tracking-[0.05em]">
+      <div mix={footerLegalStyle}>
         <p>docs and examples licensed under mit</p>
         <p>©{new Date().getFullYear()} Shopify, Inc.</p>
       </div>
     </footer>
   );
 }
+
+let footerStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "16px",
+  padding: "48px 24px 144px",
+  color: theme.colors.text.muted,
+  "@media (min-width: 1024px)": {
+    paddingInline: "48px",
+  },
+  ".dark &": {
+    color: "#9aa0a6",
+  },
+});
+
+let footerTopStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "24px",
+  color: "inherit",
+});
+
+let footerBrandLinkStyle = css({
+  display: "inline-flex",
+  alignItems: "center",
+  color: "inherit",
+  opacity: 0.6,
+  transition: "opacity 150ms ease",
+  ":hover": {
+    opacity: 1,
+  },
+  ":focus-visible": {
+    outline: "2px solid currentColor",
+    outlineOffset: "4px",
+  },
+});
+
+let footerSocialNavStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "24px",
+});
+
+let footerSocialLinkStyle = css({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "inherit",
+  opacity: 0.8,
+  transition: "opacity 150ms ease",
+  ":hover": {
+    opacity: 1,
+  },
+  ":focus-visible": {
+    outline: "2px solid currentColor",
+    outlineOffset: "4px",
+  },
+});
+
+let footerSocialIconStyle = css({
+  width: "20px",
+  height: "20px",
+});
+
+let footerLegalStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "8px",
+  color: "inherit",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  fontSize: "10px",
+  lineHeight: "1.6",
+  letterSpacing: "0.05em",
+  textTransform: "uppercase",
+  "p": {
+    margin: 0,
+  },
+});

--- a/app/ui/footer.tsx
+++ b/app/ui/footer.tsx
@@ -74,9 +74,6 @@ let footerStyle = css({
   "@media (min-width: 1024px)": {
     paddingInline: "48px",
   },
-  ".dark &": {
-    color: "#9aa0a6",
-  },
 });
 
 let footerTopStyle = css({
@@ -92,10 +89,10 @@ let footerBrandLinkStyle = css({
   color: "inherit",
   opacity: 0.6,
   transition: "opacity 150ms ease",
-  ":hover": {
+  "&:hover": {
     opacity: 1,
   },
-  ":focus-visible": {
+  "&:focus-visible": {
     outline: "2px solid currentColor",
     outlineOffset: "4px",
   },
@@ -114,10 +111,10 @@ let footerSocialLinkStyle = css({
   color: "inherit",
   opacity: 0.8,
   transition: "opacity 150ms ease",
-  ":hover": {
+  "&:hover": {
     opacity: 1,
   },
-  ":focus-visible": {
+  "&:focus-visible": {
     outline: "2px solid currentColor",
     outlineOffset: "4px",
   },
@@ -134,12 +131,9 @@ let footerLegalStyle = css({
   alignItems: "center",
   gap: "8px",
   color: "inherit",
-  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  fontFamily: theme.fontFamily.mono,
   fontSize: "10px",
   lineHeight: "1.6",
   letterSpacing: "0.05em",
   textTransform: "uppercase",
-  "p": {
-    margin: 0,
-  },
 });

--- a/app/ui/not-found-page.tsx
+++ b/app/ui/not-found-page.tsx
@@ -1,6 +1,7 @@
 import cx from "clsx";
 import { Document } from "./document.tsx";
 import { render } from "../utils/render.ts";
+import { styleHrefs } from "../utils/style-hrefs.ts";
 
 export function renderNotFoundPage(options?: { statusText?: string }) {
   let statusText = options?.statusText ?? "Not Found";
@@ -19,7 +20,12 @@ export function renderNotFoundPage(options?: { statusText?: string }) {
 
 function StatusErrorDocument() {
   return (props: { status: number; statusText: string }) => (
-    <Document title={props.statusText} noIndex forceTheme="dark">
+    <Document
+      title={props.statusText}
+      noIndex
+      forceTheme="dark"
+      stylesheets={[styleHrefs.app]}
+    >
       <main
         id="main-content"
         tabIndex={-1}

--- a/app/ui/theme.ts
+++ b/app/ui/theme.ts
@@ -1,0 +1,120 @@
+import { createTheme } from "remix/ui/theme";
+
+export let RemixTheme = createTheme(
+  {
+    space: {
+      none: "0px",
+      px: "1px",
+      xs: "4px",
+      sm: "8px",
+      md: "12px",
+      lg: "16px",
+      xl: "24px",
+      xxl: "48px",
+    },
+    radius: {
+      none: "0px",
+      sm: "2px",
+      md: "6px",
+      lg: "8px",
+      xl: "12px",
+      full: "9999px",
+    },
+    fontFamily: {
+      sans:
+        '"Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+      mono: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+    },
+    fontSize: {
+      xxxs: "10px",
+      xxs: "11px",
+      xs: "12px",
+      sm: "14px",
+      md: "16px",
+      lg: "18px",
+      xl: "20px",
+      xxl: "30px",
+    },
+    lineHeight: {
+      tight: "1",
+      normal: "1.5",
+      relaxed: "1.6",
+    },
+    letterSpacing: {
+      tight: "0",
+      normal: "0",
+      meta: "0.05em",
+      wide: "0.08em",
+    },
+    fontWeight: {
+      normal: "400",
+      medium: "500",
+      semibold: "600",
+      bold: "700",
+    },
+    control: {
+      height: {
+        sm: "32px",
+        md: "40px",
+        lg: "48px",
+      },
+    },
+    surface: {
+      lvl0: "#ffffff",
+      lvl1: "#f7f7f7",
+      lvl2: "#e3e3e3",
+      lvl3: "#c8c8c8",
+      lvl4: "#121212",
+    },
+    shadow: {
+      xs: "0 1px 1px 1px #00274f59",
+      sm: "0 1px 1px 1px #00274f59, 0 2px 3px 0 #0138701a",
+      md: "0 2px 4px 0 #011d3940, 0 8px 12px 0 #01387014",
+      lg: "0 2px 4px 0 #011d3940, 0 8px 12px 0 #01387014, 0 12px 16px 0 #0138700a",
+      xl: "0 2px 4px 0 #011d3940, 0 8px 12px 0 #01387014, 0 12px 16px 0 #0138700a, 0 16px 20px 0 #0138700a, 0 20px 24px 0 #01387005",
+    },
+    colors: {
+      text: {
+        primary: "#121212",
+        secondary: "#515151",
+        muted: "#a4a4a4",
+        link: "#3992ff",
+      },
+      border: {
+        subtle: "#e3e3e3",
+        default: "#c8c8c8",
+        strong: "#a4a4a4",
+      },
+      focus: {
+        ring: "#3992ff",
+      },
+      overlay: {
+        scrim: "rgb(0 0 0 / 0.7)",
+      },
+      action: {
+        primary: {
+          background: "#3992ff",
+          backgroundHover: "#1b6ef5",
+          backgroundActive: "#1458e1",
+          foreground: "#ffffff",
+          border: "#3992ff",
+        },
+        secondary: {
+          background: "#e3e3e3",
+          backgroundHover: "#c8c8c8",
+          backgroundActive: "#a4a4a4",
+          foreground: "#121212",
+          border: "#c8c8c8",
+        },
+        danger: {
+          background: "#f44250",
+          backgroundHover: "#bd1825",
+          backgroundActive: "#9d1722",
+          foreground: "#ffffff",
+          border: "#f44250",
+        },
+      },
+    },
+  },
+  { reset: false },
+);

--- a/app/ui/theme.ts
+++ b/app/ui/theme.ts
@@ -21,8 +21,7 @@ export let RemixTheme = createTheme(
       full: "9999px",
     },
     fontFamily: {
-      sans:
-        '"Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+      sans: '"Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
       mono: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     },
     fontSize: {
@@ -60,7 +59,7 @@ export let RemixTheme = createTheme(
       },
     },
     surface: {
-      lvl0: "#ffffff",
+      lvl0: "light-dark(#ffffff, #121212)",
       lvl1: "#f7f7f7",
       lvl2: "#e3e3e3",
       lvl3: "#c8c8c8",
@@ -75,9 +74,9 @@ export let RemixTheme = createTheme(
     },
     colors: {
       text: {
-        primary: "#121212",
+        primary: "light-dark(#121212, #c8c8c8)",
         secondary: "#515151",
-        muted: "#a4a4a4",
+        muted: "light-dark(#94989c, #9aa0a6)",
         link: "#3992ff",
       },
       border: {

--- a/app/utils/style-hrefs.ts
+++ b/app/utils/style-hrefs.ts
@@ -1,4 +1,5 @@
 export const styleHrefs = {
+  fonts: "/styles/fonts.css",
   app: "/styles/app.css",
   home: "/styles/home.css",
   md: "/styles/md.css",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "pnpm run build:css && pnpm run typecheck",
     "build:analyze": "pnpm run build",
-    "build:css": "postcss app/styles/app.css app/styles/home.css app/styles/md.css app/styles/jam.css --dir public/styles",
+    "build:css": "postcss app/styles/fonts.css app/styles/app.css app/styles/home.css app/styles/md.css app/styles/jam.css --dir public/styles",
     "dev": "concurrently -k --names css,app \"pnpm run dev:css\" \"pnpm run dev:server\"",
     "dev:css": "pnpm run build:css --watch",
     "dev:server": "cross-env NODE_ENV=development PORT=44100 tsx watch server.ts",


### PR DESCRIPTION
## Summary
- add a no-reset shared Remix UI theme based on the Tailwind token palette
- move local font-face declarations into a shared fonts stylesheet loaded by the document shell
- make the shared document/footer chrome less dependent on the app stylesheet

## Verification
- pnpm run typecheck
- pnpm run build:css