### PR TITLE
Layer global preflight reset

### DIFF
--- a/app/assets/remix-landing/components/landing-hero.tsx
+++ b/app/assets/remix-landing/components/landing-hero.tsx
@@ -4,6 +4,7 @@ import { CodeSnippet } from "./code-snippet.tsx";
 
 const shellStyles = css({
   minHeight: "100vh",
+  boxSizing: "content-box",
   position: "relative",
   display: "flex",
   alignItems: "flex-start",

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -20,3 +20,255 @@
   font-display: swap;
   src: url("/font/jet-brains-mono.woff2") format("woff2");
 }
+
+@layer reset {
+  /*
+   * Adapted from Tailwind CSS Preflight v3.4.19.
+   * Tailwind's generated Preflight is disabled in `tailwind.config.mjs` so this
+   * always-loaded stylesheet is the single source for global base styles.
+   * Keep these reset rules layered so route/component styles in later layers can
+   * override base element defaults.
+   * https://tailwindcss.com/docs/preflight
+   */
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border: 0 solid #c8c8c8;
+  }
+
+  ::before,
+  ::after {
+    --tw-content: "";
+  }
+
+  html,
+  :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    font-family:
+      "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    tab-size: 4;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  body {
+    margin: 0;
+    line-height: inherit;
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  abbr:where([title]) {
+    text-decoration: underline dotted;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family:
+      "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    font-feature-settings: normal;
+    font-variation-settings: normal;
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    font-size: 100%;
+    font-weight: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  button,
+  select {
+    text-transform: none;
+  }
+
+  button,
+  input:where([type="button"]),
+  input:where([type="reset"]),
+  input:where([type="submit"]) {
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  :-moz-focusring {
+    outline: auto;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [type="search"] {
+    appearance: textfield;
+    outline-offset: -2px;
+  }
+
+  ::-webkit-search-decoration {
+    appearance: none;
+  }
+
+  ::-webkit-file-upload-button {
+    appearance: button;
+    font: inherit;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
+
+  legend {
+    padding: 0;
+  }
+
+  ol,
+  ul,
+  menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  dialog {
+    padding: 0;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    opacity: 1;
+    color: #818181;
+  }
+
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  :disabled {
+    cursor: default;
+  }
+
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none;
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,6 +7,9 @@ import defaultTheme from "tailwindcss/defaultTheme";
 export default {
   content: ["./app/**/*.{ts,tsx}", "./data/**/*.md"],
   darkMode: "selector",
+  corePlugins: {
+    preflight: false,
+  },
   plugins: [selectedVariantPlugin, expandedVariantPlugin],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- restore the global Tailwind Preflight reset while keeping Tailwind's generated Preflight disabled
- wrap the copied reset in a native lower-priority cascade layer so Remix UI generated layers can still override base element rules
- preserve the homepage hero's previous viewport height by opting its shell back into content-box sizing

## Test plan
- pnpm run build
- browser computed-style audit for homepage typography, form controls, code blocks, and hydrated nav under the global reset
- desktop/mobile screenshot check with the loading overlay hidden