### PR TITLE
Mitigate duplicated pnpm asset modules

### DIFF
--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -1,10 +1,11 @@
 import * as path from "node:path";
 import { createAssetServer } from "remix/assets";
+import { applyTemporaryPnpmAssetDuplicationFix } from "./temporary-pnpm-asset-duplication-fix.server.ts";
 
 let isDevelopment = process.env.NODE_ENV !== "production";
 let rootDir = path.resolve(import.meta.dirname, "../..");
 
-export let assetServer = createAssetServer({
+let rawAssetServer = createAssetServer({
   basePath: "/assets",
   rootDir,
   fileMap: {
@@ -28,4 +29,16 @@ export let assetServer = createAssetServer({
     },
   },
   watch: false,
+});
+
+/*
+ * TEMPORARY REMIX BUG WORKAROUND.
+ *
+ * Delete this wrapper after upgrading to a Remix release that fixes:
+ * https://github.com/remix-run/remix/issues/11458
+ */
+export let assetServer = applyTemporaryPnpmAssetDuplicationFix(rawAssetServer, {
+  basePath: "/assets",
+  packagePathPrefix: "/npm",
+  rootDir,
 });

--- a/app/utils/temporary-pnpm-asset-duplication-fix.server.test.ts
+++ b/app/utils/temporary-pnpm-asset-duplication-fix.server.test.ts
@@ -1,0 +1,200 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { expect } from "remix/assert";
+import { describe, it } from "remix/test";
+import { assetServer } from "./assets.server.ts";
+import { applyTemporaryPnpmAssetDuplicationFix } from "./temporary-pnpm-asset-duplication-fix.server.ts";
+
+let rootDir = path.resolve(import.meta.dirname, "../..");
+let landingEnhancementsEntry = path.join(
+  rootDir,
+  "app/assets/remix-landing/landing-enhancements.tsx",
+);
+let servedAssetHrefPattern = /\/assets\/(?:app|npm)\/[^\s"'<>`)]+/g;
+
+describe("TEMPORARY pnpm asset duplication fix", () => {
+  it("canonicalizes duplicated pnpm URLs for top-level packages in the app graph", async () => {
+    let hrefs = await collectServedAssetHrefs([landingEnhancementsEntry]);
+    let pnpmThreeHrefs = hrefs.filter(
+      (href) =>
+        href.includes("/.pnpm/three@") && href.includes("/node_modules/three/"),
+    );
+
+    expect(hrefs).toContain("/assets/npm/three/build/three.core.js");
+    expect(hrefs).toContain("/assets/npm/three/build/three.module.js");
+    expect(pnpmThreeHrefs).toEqual([]);
+  });
+
+  it("canonicalizes hrefs, preloads, JS imports, and direct requests", async () => {
+    await withFixture(async (fixtureRootDir) => {
+      let pnpmHref =
+        "/assets/npm/.pnpm/three@1.0.0/node_modules/three/build/three.module.js";
+      let cleanHref = "/assets/npm/three/build/three.module.js";
+
+      await write(
+        fixtureRootDir,
+        "node_modules/.pnpm/three@1.0.0/node_modules/three/build/three.module.js",
+        "export const three = true;",
+      );
+      await symlinkDirectory(
+        path.join(
+          fixtureRootDir,
+          "node_modules/.pnpm/three@1.0.0/node_modules/three",
+        ),
+        path.join(fixtureRootDir, "node_modules/three"),
+      );
+
+      let temporaryAssetServer = createWrappedAssetServer(fixtureRootDir, {
+        href: pnpmHref,
+        preloads: [cleanHref, pnpmHref],
+        responseBody: `import "${pnpmHref}";`,
+      });
+
+      expect(await temporaryAssetServer.getHref("entry")).toBe(cleanHref);
+      expect(await temporaryAssetServer.getPreloads("entry")).toEqual([
+        cleanHref,
+      ]);
+
+      let rewrittenResponse = await temporaryAssetServer.fetch(
+        new Request("http://localhost/assets/app/entry.js"),
+      );
+      expect(await rewrittenResponse?.text()).toBe(`import "${cleanHref}";`);
+
+      let redirectResponse = await temporaryAssetServer.fetch(
+        new Request(`http://localhost${pnpmHref}?module`),
+      );
+      expect(redirectResponse?.status).toBe(302);
+      expect(redirectResponse?.headers.get("location")).toBe(
+        `http://localhost${cleanHref}?module`,
+      );
+    });
+  });
+
+  it("keeps pnpm URLs for dependencies without a matching clean package URL", async () => {
+    await withFixture(async (fixtureRootDir) => {
+      let href =
+        "/assets/npm/.pnpm/remix@1.0.0/node_modules/@remix-run/ui/dist/index.js";
+
+      await write(
+        fixtureRootDir,
+        "node_modules/.pnpm/remix@1.0.0/node_modules/@remix-run/ui/dist/index.js",
+        "export const ui = true;",
+      );
+
+      let temporaryAssetServer = createWrappedAssetServer(fixtureRootDir, {
+        href,
+        preloads: [href],
+        responseBody: `import "${href}";`,
+      });
+
+      expect(await temporaryAssetServer.getHref("entry")).toBe(href);
+      expect(await temporaryAssetServer.getPreloads("entry")).toEqual([href]);
+
+      let response = await temporaryAssetServer.fetch(
+        new Request(`http://localhost${href}`),
+      );
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("location")).toBe(null);
+    });
+  });
+});
+
+async function collectServedAssetHrefs(modulePaths: string[]) {
+  let hrefs = new Set<string>();
+  let queue = await Promise.all(
+    modulePaths.map((modulePath) => assetServer.getHref(modulePath)),
+  );
+
+  while (queue.length > 0) {
+    let href = queue.shift();
+    if (!href || hrefs.has(href)) continue;
+
+    hrefs.add(href);
+
+    let response = await assetServer.fetch(
+      new Request(new URL(href, "http://localhost")),
+    );
+    if (!response) continue;
+
+    let location = response.headers.get("location");
+    if (location && response.status >= 300 && response.status < 400) {
+      let redirectHref = formatAssetHref(new URL(location, "http://localhost"));
+      if (!hrefs.has(redirectHref)) queue.push(redirectHref);
+      continue;
+    }
+
+    let contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.includes("javascript")) continue;
+
+    let source = await response.text();
+    for (let match of source.matchAll(servedAssetHrefPattern)) {
+      if (!hrefs.has(match[0])) queue.push(match[0]);
+    }
+  }
+
+  return Array.from(hrefs).sort();
+}
+
+function createWrappedAssetServer(
+  fixtureRootDir: string,
+  response: {
+    href: string;
+    preloads: string[];
+    responseBody: string;
+  },
+) {
+  return applyTemporaryPnpmAssetDuplicationFix(
+    {
+      close() {},
+      async fetch() {
+        return new Response(response.responseBody, {
+          headers: { "content-type": "application/javascript; charset=utf-8" },
+        });
+      },
+      async getHref() {
+        return response.href;
+      },
+      async getPreloads() {
+        return response.preloads;
+      },
+    },
+    {
+      basePath: "/assets",
+      packagePathPrefix: "/npm",
+      rootDir: fixtureRootDir,
+    },
+  );
+}
+
+async function withFixture(test: (rootDir: string) => Promise<void>) {
+  let fixtureRootDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "remix-temporary-pnpm-assets-"),
+  );
+
+  try {
+    await test(fixtureRootDir);
+  } finally {
+    await fs.rm(fixtureRootDir, { force: true, recursive: true });
+  }
+}
+
+async function write(rootDir: string, relativePath: string, contents: string) {
+  let filePath = path.join(rootDir, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents);
+}
+
+async function symlinkDirectory(target: string, link: string) {
+  await fs.mkdir(path.dirname(link), { recursive: true });
+  await fs.rm(link, { force: true, recursive: true });
+  await fs.symlink(
+    target,
+    link,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+}
+
+function formatAssetHref(url: URL) {
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/app/utils/temporary-pnpm-asset-duplication-fix.server.ts
+++ b/app/utils/temporary-pnpm-asset-duplication-fix.server.ts
@@ -1,0 +1,271 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/*
+ * TEMPORARY REMIX BUG WORKAROUND.
+ *
+ * Remove this file and the wrapper call in `assets.server.ts` after upgrading
+ * to a Remix release that fixes https://github.com/remix-run/remix/issues/11458.
+ */
+
+interface TemporaryAssetServer {
+  close(): Promise<void> | void;
+  fetch(request: Request): Promise<Response | null>;
+  getHref(entry: string): Promise<string>;
+  getPreloads(entry: string | readonly string[]): Promise<string[]>;
+}
+
+interface TemporaryFixOptions {
+  basePath: string;
+  packagePathPrefix: string;
+  rootDir: string;
+}
+
+export function applyTemporaryPnpmAssetDuplicationFix(
+  assetServer: TemporaryAssetServer,
+  options: TemporaryFixOptions,
+): TemporaryAssetServer {
+  let canonicalizer = createPnpmAssetCanonicalizer(options);
+
+  return {
+    close() {
+      return assetServer.close();
+    },
+
+    async fetch(request) {
+      let redirectHref = canonicalizer.getRedirectHref(request);
+      if (redirectHref) return Response.redirect(redirectHref, 302);
+
+      let response = await assetServer.fetch(request);
+      if (!response) return response;
+      return canonicalizer.canonicalizeResponse(response);
+    },
+
+    async getHref(entry) {
+      return canonicalizer.canonicalizeHref(await assetServer.getHref(entry));
+    },
+
+    async getPreloads(entry) {
+      return canonicalizer.canonicalizeHrefs(
+        await assetServer.getPreloads(entry),
+      );
+    },
+  };
+}
+
+function createPnpmAssetCanonicalizer(options: TemporaryFixOptions) {
+  let canonicalPathnameCache = new Map<string, string>();
+  let packageRootPathname = joinUrlPath(
+    options.basePath,
+    options.packagePathPrefix,
+  );
+  let pnpmPackageRootPathname = `${packageRootPathname}/.pnpm`;
+  let pnpmAssetHrefPattern = new RegExp(
+    `${escapeRegExp(pnpmPackageRootPathname)}/[^\\s"'<>\\\`]+`,
+    "g",
+  );
+
+  function canonicalizeHref(href: string) {
+    let parsed = parseHref(href);
+    if (!parsed) return href;
+
+    let canonicalPathname = canonicalizePathname(parsed.url.pathname);
+    if (canonicalPathname === parsed.url.pathname) return href;
+
+    parsed.url.pathname = canonicalPathname;
+    return parsed.isAbsoluteUrl
+      ? parsed.url.toString()
+      : formatRootRelativeHref(parsed.url);
+  }
+
+  function canonicalizeHrefs(hrefs: string[]) {
+    let seen = new Set<string>();
+    let canonicalHrefs: string[] = [];
+
+    for (let href of hrefs) {
+      let canonicalHref = canonicalizeHref(href);
+      if (seen.has(canonicalHref)) continue;
+      seen.add(canonicalHref);
+      canonicalHrefs.push(canonicalHref);
+    }
+
+    return canonicalHrefs;
+  }
+
+  function canonicalizeScript(source: string) {
+    if (!source.includes(pnpmPackageRootPathname)) return source;
+    return source.replace(pnpmAssetHrefPattern, (href) =>
+      canonicalizeHref(href),
+    );
+  }
+
+  function getRedirectHref(request: Request) {
+    let url = new URL(request.url);
+    let canonicalPathname = canonicalizePathname(url.pathname);
+    if (canonicalPathname === url.pathname) return null;
+
+    url.pathname = canonicalPathname;
+    return url.toString();
+  }
+
+  async function canonicalizeResponse(response: Response) {
+    if (!isJavaScriptResponse(response)) return response;
+
+    let source = await response.text();
+    let canonicalSource = canonicalizeScript(source);
+    let headers = new Headers(response.headers);
+    headers.delete("content-length");
+
+    return new Response(canonicalSource, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+
+  function canonicalizePathname(pathname: string) {
+    let cachedPathname = canonicalPathnameCache.get(pathname);
+    if (cachedPathname) return cachedPathname;
+
+    let canonicalPathname = findCanonicalPathname(pathname) ?? pathname;
+    canonicalPathnameCache.set(pathname, canonicalPathname);
+    return canonicalPathname;
+  }
+
+  function findCanonicalPathname(pathname: string) {
+    if (!pathname.startsWith(`${pnpmPackageRootPathname}/`)) return null;
+
+    let virtualStoreSegments = pathname
+      .slice(pnpmPackageRootPathname.length + 1)
+      .split("/");
+    let nodeModulesIndex = virtualStoreSegments.indexOf("node_modules");
+    if (nodeModulesIndex === -1) return null;
+
+    let packageSegments = virtualStoreSegments.slice(nodeModulesIndex + 1);
+    let packageNameSegmentCount = getPackageNameSegmentCount(packageSegments);
+    if (!packageNameSegmentCount) return null;
+
+    let decodedVirtualStoreSegments =
+      decodeSafePathSegments(virtualStoreSegments);
+    let decodedPackageSegments = decodeSafePathSegments(packageSegments);
+    if (!decodedVirtualStoreSegments || !decodedPackageSegments) return null;
+
+    let pnpmPackageFilePath = path.join(
+      options.rootDir,
+      "node_modules",
+      ".pnpm",
+      ...decodedVirtualStoreSegments,
+    );
+    let cleanPackageFilePath = path.join(
+      options.rootDir,
+      "node_modules",
+      ...decodedPackageSegments,
+    );
+
+    if (!isSameRealPath(pnpmPackageFilePath, cleanPackageFilePath)) return null;
+
+    return `${packageRootPathname}/${packageSegments.join("/")}`;
+  }
+
+  return {
+    canonicalizeHref,
+    canonicalizeHrefs,
+    canonicalizeResponse,
+    getRedirectHref,
+  };
+}
+
+function getPackageNameSegmentCount(segments: string[]) {
+  if (segments.length === 0) return 0;
+  return segments[0]?.startsWith("@") ? (segments.length >= 2 ? 2 : 0) : 1;
+}
+
+function decodeSafePathSegments(segments: string[]) {
+  let decodedSegments: string[] = [];
+
+  for (let segment of segments) {
+    let decodedSegment: string;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+      return null;
+    }
+
+    if (
+      decodedSegment.length === 0 ||
+      decodedSegment === "." ||
+      decodedSegment === ".." ||
+      decodedSegment.includes("/") ||
+      decodedSegment.includes("\\")
+    ) {
+      return null;
+    }
+
+    decodedSegments.push(decodedSegment);
+  }
+
+  return decodedSegments;
+}
+
+function isSameRealPath(left: string, right: string) {
+  let leftRealPath = resolveRealPath(left);
+  let rightRealPath = resolveRealPath(right);
+  return (
+    leftRealPath !== null &&
+    rightRealPath !== null &&
+    leftRealPath === rightRealPath
+  );
+}
+
+function resolveRealPath(filePath: string) {
+  try {
+    return path.normalize(fs.realpathSync(filePath));
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown) {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    ((error as NodeJS.ErrnoException).code === "ENOENT" ||
+      (error as NodeJS.ErrnoException).code === "ENOTDIR")
+  );
+}
+
+function isJavaScriptResponse(response: Response) {
+  let contentType = response.headers.get("content-type")?.toLowerCase();
+  return (
+    contentType?.includes("javascript") === true ||
+    contentType?.includes("ecmascript") === true
+  );
+}
+
+function parseHref(href: string) {
+  try {
+    let isAbsoluteUrl = /^[a-z][a-z\d+.-]*:/i.test(href);
+    return {
+      isAbsoluteUrl,
+      url: new URL(href, "http://remix.local"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatRootRelativeHref(url: URL) {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function joinUrlPath(...parts: string[]) {
+  let segments = parts
+    .flatMap((part) => part.split("/"))
+    .filter((segment) => segment.length > 0);
+  return `/${segments.join("/")}`;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- add a clearly temporary wrapper around the Remix asset server for remix-run/remix#11458
- canonicalize duplicate pnpm virtual-store asset URLs back to clean package URLs when they point at the same real file
- keep all workaround logic and coverage isolated in temporary-pnpm-asset-duplication-fix.server.* so it can be deleted after upstream fixes the issue

<img width="5120" height="2880" alt="Screenshot 2026-05-21 at 10 07 35 AM" src="https://github.com/user-attachments/assets/0f403312-59a1-47ef-8f4f-f6a924d21101" />