### PR TITLE
Refine Remix Jam 2026 experience

### DIFF
--- a/app/assets/jam/2026/header.tsx
+++ b/app/assets/jam/2026/header.tsx
@@ -250,7 +250,7 @@ export let Jam2026Header = clientEntry(
               FAQ
             </a>
             <a
-              href={routes.jam.y2026.ticket.href()}
+              href={routes.jam.y2026.ticket.index.href()}
               mix={jam2026TicketLinkStyle}
               rmx-reset-scroll="false"
               rmx-target={ticketModalConfig.frameName}

--- a/app/assets/jam/2026/newsletter-signup.tsx
+++ b/app/assets/jam/2026/newsletter-signup.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../newsletter-request.ts";
 import { jamTheme } from "../../../controllers/jam/2026/theme.ts";
 import { routes } from "../../../routes.ts";
+import { breakpointMedia } from "../../../ui/theme.ts";
 
 const REMIX_JAM_UPDATES_TAG_ID = "19736081";
 
@@ -23,8 +24,12 @@ export let Jam2026NewsletterSignup = clientEntry(
       >
         <div mix={newsletterContentStyle}>
           <h2 id="newsletter-heading" mix={newsletterHeadingStyle}>
-            Sign up for our newsletter for the latest Remix Jam news and updates
+            Get notified
           </h2>
+          <p>
+            Sign up for our newsletter to receive any updates, announcements,
+            and speaker line up for Remix Jam 2026.
+          </p>
           <form
             action={routes.actions.newsletter.href()}
             method="post"
@@ -114,7 +119,7 @@ export let Jam2026NewsletterSignup = clientEntry(
 let newsletterSectionStyle = css({
   position: "relative",
   zIndex: 1,
-  paddingBlock: "clamp(64px, 9vw, 120px) 48px",
+  paddingBlock: "36px",
   paddingInline: theme.space.lg,
   backgroundColor: jamTheme.surfaceRaised,
   color: jamTheme.ink,
@@ -124,29 +129,52 @@ let newsletterContentStyle = css({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  gap: "40px",
-  maxWidth: "640px",
+  gap: "20px",
+  width: "100%",
   marginInline: "auto",
+  [breakpointMedia.md]: {
+    width: "35%",
+  },
+  "& > p": {
+    margin: 0,
+    color: jamTheme.ink,
+    fontFamily: theme.fontFamily.sans,
+    fontSize: "16px",
+    fontWeight: theme.fontWeight.normal,
+    letterSpacing: "-0.01em",
+    lineHeight: "1.6em",
+    textAlign: "center",
+    textWrap: "balance",
+    "@supports (text-box-trim: trim-both)": {
+      textBoxTrim: "trim-both",
+      textBoxEdge: "cap alphabetic",
+    },
+  },
 });
 
 let newsletterHeadingStyle = css({
   margin: 0,
-  maxWidth: "620px",
   color: jamTheme.ink,
-  fontFamily: theme.fontFamily.sans,
-  fontSize: "clamp(28px, 4.2vw, 40px)",
+  fontFamily: theme.fontFamily.mono,
+  fontSize: "16px",
   fontWeight: theme.fontWeight.bold,
-  letterSpacing: 0,
-  lineHeight: 1.12,
+  letterSpacing: "0.48px",
+  lineHeight: "normal",
   textAlign: "center",
+  textTransform: "uppercase",
+  "@supports (text-box-trim: trim-both)": {
+    textBoxTrim: "trim-both",
+    textBoxEdge: "cap alphabetic",
+  },
 });
 
 let newsletterFormStyle = css({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  gap: "14px",
-  width: "100%",
+  gap: "9px",
+  width: "240px",
+  maxWidth: "100%",
   minWidth: 0,
   transition: "opacity 160ms ease",
   "&[data-state='submitting']": {
@@ -157,26 +185,31 @@ let newsletterFormStyle = css({
 let labelStyle = css({
   color: jamTheme.brandRed,
   fontFamily: theme.fontFamily.mono,
-  fontSize: "0.78rem",
-  fontWeight: theme.fontWeight.bold,
-  letterSpacing: 0,
-  lineHeight: 1,
+  fontSize: "11px",
+  fontWeight: theme.fontWeight.normal,
+  letterSpacing: "0.24px",
+  lineHeight: "normal",
   textTransform: "uppercase",
+  "@supports (text-box-trim: trim-both)": {
+    textBoxTrim: "trim-both",
+    textBoxEdge: "cap alphabetic",
+  },
 });
 
 let newsletterInputStyle = css({
   width: "100%",
-  maxWidth: "420px",
-  minHeight: "56px",
+  minHeight: 0,
   minWidth: 0,
   border: 0,
-  borderRadius: "8px",
-  backgroundColor: jamTheme.surface,
-  color: jamTheme.ink,
-  font: "inherit",
-  fontSize: "1rem",
-  lineHeight: 1.2,
-  padding: "0 18px",
+  borderRadius: "6px",
+  backgroundColor: jamTheme.inkWash,
+  color: jamTheme.inkMuted,
+  fontFamily: theme.fontFamily.sans,
+  fontSize: "16px",
+  fontWeight: theme.fontWeight.normal,
+  letterSpacing: "-0.01em",
+  lineHeight: "1.6em",
+  padding: "12px 16px",
   textAlign: "center",
   "&::placeholder": {
     color: jamTheme.textMuted,
@@ -193,18 +226,19 @@ let newsletterInputStyle = css({
 
 let newsletterButtonStyle = css({
   width: "100%",
-  maxWidth: "420px",
-  minHeight: "56px",
+  minHeight: 0,
   border: 0,
-  borderRadius: "8px",
+  borderRadius: "6px",
   backgroundColor: jamTheme.accent,
   color: jamTheme.onAccent,
   cursor: "pointer",
-  fontFamily: theme.fontFamily.sans,
-  fontSize: "1rem",
+  fontFamily: theme.fontFamily.mono,
+  fontSize: "11px",
   fontWeight: theme.fontWeight.bold,
-  lineHeight: 1,
-  paddingInline: "24px",
+  letterSpacing: "0.33px",
+  lineHeight: "normal",
+  padding: "12px 16px",
+  textTransform: "uppercase",
   transition: "background-color 160ms ease, transform 160ms ease",
   whiteSpace: "nowrap",
   "&:hover": {
@@ -231,10 +265,10 @@ let newsletterButtonStyle = css({
 });
 
 let newsletterMessageStyle = css({
-  maxWidth: "420px",
+  maxWidth: "240px",
   minHeight: "24px",
   color: jamTheme.brandRed,
-  fontSize: "0.95rem",
+  fontSize: "12px",
   lineHeight: 1.4,
   textAlign: "center",
   "& p": {

--- a/app/assets/jam/2026/tickets-modal.test.browser.tsx
+++ b/app/assets/jam/2026/tickets-modal.test.browser.tsx
@@ -11,17 +11,13 @@ import { routes } from "../../../routes.ts";
 describe("Jam2026TicketsModal", () => {
   it("applies modal effects and renders frame navigation controls", async (t) => {
     let homeHref = routes.jam.y2026.index.href();
-    let ticketHref = routes.jam.y2026.ticket.href();
     let previousOverflow = document.documentElement.style.overflow;
     let previousScrollbarGutter =
       document.documentElement.style.scrollbarGutter;
 
-    window.history.replaceState(window.history.state, "", ticketHref);
-
     t.after(() => {
       document.documentElement.style.overflow = previousOverflow;
       document.documentElement.style.scrollbarGutter = previousScrollbarGutter;
-      window.history.replaceState(window.history.state, "", homeHref);
     });
 
     let result = render(
@@ -125,6 +121,11 @@ describe("Jam2026TicketsModal", () => {
       result.container.querySelector<HTMLInputElement>(
         "input[name='quantity']",
       )!;
+    let getProductInput = () =>
+      result.container.querySelector<HTMLInputElement>(
+        "input[name='productId']",
+      )!;
+    let form = result.container.querySelector<HTMLFormElement>("form")!;
     let getIncreaseButton = () =>
       result.container.querySelector<HTMLButtonElement>(
         "button[aria-label='Increase quantity']",
@@ -144,6 +145,15 @@ describe("Jam2026TicketsModal", () => {
     expect(result.container.textContent).toContain(
       `$${remixJam2026Ticket.originalPrice}`,
     );
+    expect(form.getAttribute("action")).toBe(
+      routes.jam.y2026.ticket.action.href(),
+    );
+    expect(
+      result.container.querySelector<HTMLInputElement>(
+        "input[name='ticketType']",
+      )?.value,
+    ).toBe(remixJam2026Ticket.type);
+    expect(getProductInput().value).toBe("");
     expect(checkoutButton.disabled).toBe(true);
     expect(getQuantityValue()).toBe("1");
     expect(getQuantityInput().value).toBe("1");
@@ -170,6 +180,83 @@ describe("Jam2026TicketsModal", () => {
       String(remixJam2026Ticket.maxQuantity),
     );
     expect(getIncreaseButton().disabled).toBe(true);
+  });
+
+  it("enables checkout when the server provides an available ticket variant", async (t) => {
+    let result = render(
+      <Jam2026TicketsModalFrame
+        open
+        ticketCheckout={{
+          availableForSale: true,
+          initialQuantity: 1,
+          maxQuantity: remixJam2026Ticket.maxQuantity,
+          productId: "gid://shopify/ProductVariant/2026",
+        }}
+      />,
+    );
+    t.after(result.cleanup);
+
+    await result.act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+
+    let checkoutButton = result.container.querySelector<HTMLButtonElement>(
+      "button[type='submit']",
+    )!;
+    let productInput = result.container.querySelector<HTMLInputElement>(
+      "input[name='productId']",
+    )!;
+
+    expect(checkoutButton.disabled).toBe(false);
+    expect(checkoutButton.textContent).toBe("Check out");
+    expect(productInput.value).toBe("gid://shopify/ProductVariant/2026");
+  });
+
+  it("shows a pending checkout state after submit", async (t) => {
+    let result = render(
+      <Jam2026TicketsModalFrame
+        open
+        ticketCheckout={{
+          availableForSale: true,
+          initialQuantity: 1,
+          maxQuantity: remixJam2026Ticket.maxQuantity,
+          productId: "gid://shopify/ProductVariant/2026",
+        }}
+      />,
+    );
+    t.after(result.cleanup);
+
+    await result.act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+
+    let form = result.container.querySelector<HTMLFormElement>("form")!;
+    form.addEventListener("submit", (event) => event.preventDefault());
+
+    let checkoutButton = result.container.querySelector<HTMLButtonElement>(
+      "button[type='submit']",
+    )!;
+    let increaseButton = result.container.querySelector<HTMLButtonElement>(
+      "button[aria-label='Increase quantity']",
+    )!;
+
+    await result.act(() => checkoutButton.click());
+
+    expect(form.getAttribute("aria-busy")).toBe("true");
+    expect(form.getAttribute("data-pending")).toBe("true");
+    expect(checkoutButton.disabled).toBe(true);
+    expect(checkoutButton.textContent).toBe("Checking out...");
+    expect(increaseButton.disabled).toBe(true);
+
+    await result.act(() => {
+      window.dispatchEvent(
+        new PageTransitionEvent("pageshow", {
+          persisted: true,
+        }),
+      );
+    });
+
+    expect(form.hasAttribute("aria-busy")).toBe(false);
+    expect(form.getAttribute("data-pending")).toBe("false");
+    expect(checkoutButton.disabled).toBe(false);
+    expect(checkoutButton.textContent).toBe("Check out");
+    expect(increaseButton.disabled).toBe(false);
   });
 
   it("releases modal page effects when closing animation starts", async (t) => {

--- a/app/assets/jam/2026/tickets-modal.tsx
+++ b/app/assets/jam/2026/tickets-modal.tsx
@@ -1,4 +1,11 @@
-import { clientEntry, css, navigate, on, type Handle } from "remix/ui";
+import {
+  addEventListeners,
+  clientEntry,
+  css,
+  navigate,
+  on,
+  type Handle,
+} from "remix/ui";
 import { animateEntrance, spring } from "remix/ui/animation";
 import { theme } from "remix/ui/theme";
 
@@ -17,6 +24,15 @@ import { createJam2026TicketsModalEffects } from "./tickets-modal-effects.ts";
 type Jam2026TicketsModalProps = {
   animateEntrance?: boolean;
   open?: boolean;
+  ticketCheckout?: Jam2026TicketCheckoutState;
+};
+
+type Jam2026TicketCheckoutState = {
+  availableForSale: boolean;
+  error?: string;
+  initialQuantity: number;
+  maxQuantity: number;
+  productId?: string;
 };
 
 let usdFormatter = new Intl.NumberFormat("en-US", {
@@ -42,14 +58,19 @@ export let Jam2026TicketsModalFrame = clientEntry(
     let modalClosing = false;
     let closeNavigationTimer: ReturnType<typeof setTimeout> | undefined;
     let modalEffects = createJam2026TicketsModalEffects(handle, {
-      isActive: () => Boolean(handle.props.open) && !modalClosing,
+      isActive: () => isOpen() && !modalClosing,
       requestClose,
     });
     let headSyncQueued = false;
+    let navigationEntrySyncQueued = false;
+
+    function isOpen() {
+      return Boolean(handle.props.open);
+    }
 
     function requestClose(event?: Event) {
       event?.preventDefault();
-      if (modalClosing || !handle.props.open) return;
+      if (modalClosing || !isOpen()) return;
 
       modalClosing = true;
       handle.update();
@@ -85,7 +106,7 @@ export let Jam2026TicketsModalFrame = clientEntry(
       handle.queueTask(() => {
         headSyncQueued = false;
         let head = getJam2026HeadContent({
-          ticketsModalOpen: Boolean(handle.props.open),
+          ticketsModalOpen: isOpen(),
         });
 
         syncDocumentHead(
@@ -98,21 +119,36 @@ export let Jam2026TicketsModalFrame = clientEntry(
       });
     }
 
+    function queueNavigationEntrySync(open: boolean) {
+      if (navigationEntrySyncQueued) return;
+      navigationEntrySyncQueued = true;
+
+      handle.queueTask(() => {
+        navigationEntrySyncQueued = false;
+        if (handle.frame === handle.frames.top) return;
+        syncTicketModalNavigationEntry(open);
+      });
+    }
+
     return () => {
-      if (!handle.props.open) modalClosing = false;
+      let open = isOpen();
+
+      if (!open) modalClosing = false;
 
       modalEffects.queueStateSync();
+      queueNavigationEntrySync(open);
       queueHeadSync();
 
       // The frame runtime needs a stable child when toggling between empty
       // frame content and the hydrated modal.
       return (
         <div>
-          {handle.props.open ? (
+          {open ? (
             <Jam2026TicketsModalContent
               animateEntrance={handle.props.animateEntrance ?? true}
               closing={modalClosing}
               onRequestClose={requestClose}
+              ticketCheckout={handle.props.ticketCheckout}
             />
           ) : null}
         </div>
@@ -121,24 +157,88 @@ export let Jam2026TicketsModalFrame = clientEntry(
   },
 );
 
+function syncTicketModalNavigationEntry(open: boolean) {
+  let navigation = window.navigation;
+  if (!navigation?.currentEntry) return;
+
+  let homeHref = routes.jam.y2026.index.href();
+  let ticketHref = routes.jam.y2026.ticket.index.href();
+  let pathname = window.location.pathname;
+
+  if (pathname !== homeHref && pathname !== ticketHref) return;
+
+  // Direct document loads start with top-frame history state. Once the named
+  // modal frame hydrates, mark Jam ticket entries as frame-owned so browser
+  // Back closes the modal without remounting the animated page.
+  let state = {
+    $rmx: true,
+    resetScroll: false,
+    src: new URL(open ? ticketHref : homeHref, window.location.href).href,
+    target: ticketModalConfig.frameName,
+  };
+  let currentState = navigation.currentEntry.getState();
+
+  if (
+    isRecord(currentState) &&
+    currentState.$rmx === state.$rmx &&
+    currentState.resetScroll === state.resetScroll &&
+    currentState.src === state.src &&
+    currentState.target === state.target
+  ) {
+    return;
+  }
+
+  navigation.updateCurrentEntry({ state });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 type Jam2026TicketsModalContentProps = {
   animateEntrance?: boolean;
   closing?: boolean;
   onRequestClose: (event: Event) => void;
+  ticketCheckout?: Jam2026TicketCheckoutState;
 };
 
 export function Jam2026TicketsModalContent(
   handle: Handle<Jam2026TicketsModalContentProps>,
 ) {
   let ticket = remixJam2026Ticket;
-  let quantity = 1;
+  let quantity = handle.props.ticketCheckout?.initialQuantity ?? 1;
+  let submitting = false;
 
-  function setQuantity(nextQuantity: number) {
-    quantity = Math.min(ticket.maxQuantity, Math.max(1, nextQuantity));
+  function resetSubmitting() {
+    if (!submitting) return;
+    submitting = false;
     handle.update();
   }
 
+  handle.queueTask(() => {
+    addEventListeners(window, handle.signal, {
+      pageshow(event) {
+        if (event.persisted) resetSubmitting();
+      },
+    });
+  });
+
+  function setQuantity(nextQuantity: number) {
+    quantity = Math.min(getMaxQuantity(), Math.max(1, nextQuantity));
+    handle.update();
+  }
+
+  function getMaxQuantity() {
+    return handle.props.ticketCheckout?.maxQuantity ?? ticket.maxQuantity;
+  }
+
   return () => {
+    let ticketCheckout = handle.props.ticketCheckout;
+    let maxQuantity = getMaxQuantity();
+    let checkoutEnabled = Boolean(
+      ticketCheckout?.availableForSale && ticketCheckout.productId,
+    );
+    let checkoutDisabled = !checkoutEnabled || submitting;
     let useEntranceMotion = shouldAnimateEntrance(handle.props.animateEntrance);
     let scrimMix = useEntranceMotion
       ? [
@@ -248,8 +348,30 @@ export function Jam2026TicketsModalContent(
                     Conference and afterparty. Food and drinks included.
                   </span>
                 </article>
-                <form method="post" mix={ticketsModalCheckoutStyle}>
-                  <input type="hidden" name="ticket" value={ticket.handle} />
+                <form
+                  aria-busy={submitting ? "true" : undefined}
+                  action={routes.jam.y2026.ticket.action.href()}
+                  data-pending={String(submitting)}
+                  method="post"
+                  mix={[
+                    ticketsModalCheckoutStyle,
+                    on("submit", (event) => {
+                      if (!checkoutEnabled || submitting) {
+                        event.preventDefault();
+                        return;
+                      }
+
+                      submitting = true;
+                      handle.update();
+                    }),
+                  ]}
+                >
+                  <input type="hidden" name="ticketType" value={ticket.type} />
+                  <input
+                    type="hidden"
+                    name="productId"
+                    value={ticketCheckout?.productId ?? ""}
+                  />
                   <input
                     type="hidden"
                     name="quantity"
@@ -260,7 +382,7 @@ export function Jam2026TicketsModalContent(
                     <div mix={ticketsModalQuantityStyle}>
                       <button
                         aria-label="Decrease quantity"
-                        disabled={quantity <= 1}
+                        disabled={submitting || quantity <= 1}
                         type="button"
                         mix={[
                           ticketsModalQuantityButtonStyle,
@@ -289,12 +411,12 @@ export function Jam2026TicketsModalContent(
                       </span>
                       <button
                         aria-label="Increase quantity"
-                        disabled={quantity >= ticket.maxQuantity}
+                        disabled={submitting || quantity >= maxQuantity}
                         type="button"
                         mix={[
                           ticketsModalQuantityButtonStyle,
                           on("click", () => {
-                            if (quantity >= ticket.maxQuantity) return;
+                            if (quantity >= maxQuantity) return;
                             setQuantity(quantity + 1);
                           }),
                         ]}
@@ -323,12 +445,29 @@ export function Jam2026TicketsModalContent(
                     </div>
                   </div>
                   <button
-                    disabled
+                    disabled={checkoutDisabled}
                     type="submit"
                     mix={ticketsModalCheckoutButtonStyle}
                   >
-                    Check out
+                    {submitting ? (
+                      <>
+                        <span
+                          aria-hidden="true"
+                          mix={ticketsModalBusyDotStyle}
+                        />
+                        <span>Checking out...</span>
+                      </>
+                    ) : checkoutEnabled ? (
+                      "Check out"
+                    ) : (
+                      "Unavailable"
+                    )}
                   </button>
+                  {ticketCheckout?.error ? (
+                    <p role="alert" mix={ticketsModalCheckoutErrorStyle}>
+                      {ticketCheckout.error}
+                    </p>
+                  ) : null}
                 </form>
               </div>
             </div>
@@ -725,14 +864,18 @@ let ticketsModalSubtotalCurrencyStyle = css({
 
 let ticketsModalCheckoutButtonStyle = css({
   appearance: "none",
+  alignItems: "center",
   background: jamTheme.brandRed,
   border: 0,
   borderRadius: "6px",
   color: jamTheme.onAccent,
   cursor: "pointer",
+  display: "inline-flex",
   fontFamily: theme.fontFamily.mono,
   fontSize: "11px",
   fontWeight: theme.fontWeight.bold,
+  gap: "8px",
+  justifyContent: "center",
   justifySelf: "end",
   letterSpacing: "0.06em",
   lineHeight: 1,
@@ -767,4 +910,40 @@ let ticketsModalCheckoutButtonStyle = css({
     minWidth: 0,
     width: "100%",
   },
+});
+
+let ticketsModalBusyDotStyle = css({
+  animation: "jam-2026-ticket-checkout-pulse 720ms ease-in-out infinite",
+  background: "currentColor",
+  borderRadius: "50%",
+  display: "inline-block",
+  flexShrink: 0,
+  height: "7px",
+  opacity: 0.78,
+  width: "7px",
+  "@keyframes jam-2026-ticket-checkout-pulse": {
+    "0%, 100%": {
+      opacity: 0.4,
+      transform: "scale(0.72)",
+    },
+    "50%": {
+      opacity: 1,
+      transform: "scale(1)",
+    },
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    animation: "none",
+    opacity: 1,
+  },
+});
+
+let ticketsModalCheckoutErrorStyle = css({
+  color: jamTheme.brandRed,
+  fontFamily: theme.fontFamily.sans,
+  fontSize: "12px",
+  fontWeight: theme.fontWeight.bold,
+  gridColumn: "1 / -1",
+  lineHeight: 1.35,
+  margin: 0,
+  width: "100%",
 });

--- a/app/assets/remix-landing/components/landing-nav.tsx
+++ b/app/assets/remix-landing/components/landing-nav.tsx
@@ -150,7 +150,7 @@ const NAV_ITEMS = [
     external: true,
   },
   { key: "B", label: "blog", href: routes.blog.href() },
-  { key: "J", label: "jam", href: routes.jam.y2025.index.href() },
+  { key: "J", label: "jam", href: routes.jam.y2026.index.href() },
   { key: "S", label: "store", href: "https://shop.remix.run/", external: true },
 ];
 

--- a/app/controllers/jam/2026/controller.test.ts
+++ b/app/controllers/jam/2026/controller.test.ts
@@ -1,20 +1,28 @@
+import { createController } from "remix/router";
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
 import { routes } from "../../../routes.ts";
+import { parseProduct } from "../../../data/jam-storefront.server.ts";
 import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
 import { createRouteTestRouter } from "../../../../test/setup.ts";
 import { jam2026Controller } from "../controller.ts";
+import {
+  createJam2026PageHandler,
+  createJam2026TicketAction,
+} from "./controller.tsx";
+import { remixJam2026Ticket } from "./ticket-data.ts";
 import { ticketModalConfig } from "./tickets-modal-contract.ts";
 import {
   getJam2026ThemePreference,
   serializeJam2026ThemePreference,
 } from "./theme-preference.server.ts";
 
+type TestStorefront = Parameters<typeof createJam2026PageHandler>[0];
+
 describe("Remix Jam 2026 routes", () => {
   it("renders the homepage as the full Jam page with ticket frame navigation", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
 
     let response = await router.fetch("http://localhost:3000/jam/2026");
 
@@ -44,8 +52,7 @@ describe("Remix Jam 2026 routes", () => {
   });
 
   it("renders the ticket route as the full Jam page with the ticket modal open", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
 
     let response = await router.fetch("http://localhost:3000/jam/2026/ticket");
 
@@ -71,8 +78,7 @@ describe("Remix Jam 2026 routes", () => {
   });
 
   it("renders the saved theme on the first document paint", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
     let cookie = await serializeJam2026ThemePreference("dark");
 
     let response = await router.fetch(
@@ -139,8 +145,7 @@ describe("Remix Jam 2026 routes", () => {
   });
 
   it("renders the ticket route as modal-only frame content for the tickets frame", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
 
     let response = await router.fetch(
       new Request("http://localhost:3000/jam/2026/ticket", {
@@ -166,8 +171,7 @@ describe("Remix Jam 2026 routes", () => {
   });
 
   it("skips ticket modal entrance animation for server-resolved frame requests", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
 
     let response = await router.fetch(
       new Request("http://localhost:3000/jam/2026/ticket", {
@@ -188,8 +192,7 @@ describe("Remix Jam 2026 routes", () => {
   });
 
   it("renders the homepage route as closed modal frame content for the tickets frame", async () => {
-    let router = createRouteTestRouter();
-    router.map(routes.jam.y2026, jam2026Controller);
+    let router = createJam2026TestRouter();
 
     let response = await router.fetch(
       new Request("http://localhost:3000/jam/2026", {
@@ -210,4 +213,96 @@ describe("Remix Jam 2026 routes", () => {
     expect(html).not.toContain('role="dialog"');
     expect(html).not.toContain('aria-label="Page navigation"');
   });
+
+  it("rejects invalid ticket submissions with no-store modal errors", async () => {
+    let router = createJam2026TestRouter();
+    let formData = new FormData();
+    formData.set("ticketType", "side-stage");
+    formData.set("productId", "not-the-ticket");
+    formData.set("quantity", "1");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        body: formData,
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    let html = await response.text();
+
+    expect(html).toContain("Invalid ticket request");
+    expect(html).toContain('role="alert"');
+  });
+
+  it("creates a Shopify cart and redirects to checkout", async () => {
+    let router = createJam2026TestRouter(availableStorefront);
+    let formData = new FormData();
+    formData.set("ticketType", remixJam2026Ticket.type);
+    formData.set("productId", "gid://shopify/ProductVariant/2026");
+    formData.set("quantity", "2");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        body: formData,
+        method: "POST",
+        redirect: "manual",
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Location")).toBe(
+      "https://jam.remix.run/checkouts/2026",
+    );
+  });
 });
+
+let unavailableStorefront = {
+  createCart: async () => ({
+    error: "Ticket checkout is unavailable right now",
+  }),
+  getProduct: async () =>
+    parseProduct({
+      id: "unavailable",
+      price: "399.00",
+      productId: "unavailable",
+      availableForSale: false,
+      unavailableReason: "storefront",
+    }),
+};
+
+let availableStorefront = {
+  createCart: async () => ({
+    id: "gid://shopify/Cart/2026",
+    checkoutUrl: "https://jam.remix.run/checkouts/2026",
+  }),
+  getProduct: async () =>
+    parseProduct({
+      id: "gid://shopify/Product/2026",
+      price: "299.00",
+      productId: "gid://shopify/ProductVariant/2026",
+      availableForSale: true,
+    }),
+};
+
+function createJam2026TestRouter(
+  storefront: TestStorefront = unavailableStorefront,
+) {
+  let pageHandler = createJam2026PageHandler(storefront);
+  let ticketAction = createJam2026TicketAction(storefront);
+  let router = createRouteTestRouter();
+  router.map(
+    routes.jam.y2026.ticket,
+    createController(routes.jam.y2026.ticket, {
+      actions: {
+        index: pageHandler,
+        action: ticketAction,
+      },
+    }),
+  );
+  router.map(routes.jam.y2026, jam2026Controller);
+  return router;
+}

--- a/app/controllers/jam/2026/controller.tsx
+++ b/app/controllers/jam/2026/controller.tsx
@@ -1,32 +1,103 @@
 import * as f from "remix/data-schema/form-data";
 import * as s from "remix/data-schema";
+import * as c from "remix/data-schema/checks";
+import * as coerce from "remix/data-schema/coerce";
 import { SuperHeaders } from "remix/headers";
 import { getContext } from "remix/middleware/async-context";
 
+import {
+  createCart,
+  getProduct,
+  MAX_QUANTITY,
+} from "../../../data/jam-storefront.server.ts";
 import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
 import { render } from "../../../utils/render.ts";
 import { getRequestContext } from "../../../utils/request-context.ts";
 import { routes } from "../../../routes.ts";
 import { Jam2026TicketsModalFrame } from "../../../assets/jam/2026/tickets-modal.tsx";
 import { Jam2026HomePage } from "./ui/home-page.tsx";
+import { remixJam2026Ticket } from "./ticket-data.ts";
 import { ticketModalConfig } from "./tickets-modal-contract.ts";
 import {
   getJam2026ThemePreference,
   serializeJam2026ThemePreference,
 } from "./theme-preference.server.ts";
 
-export async function jam2026Handler() {
+type Jam2026Storefront = {
+  createCart: typeof createCart;
+  getProduct: typeof getProduct;
+};
+
+type Jam2026StorefrontProduct = Awaited<ReturnType<typeof getProduct>>;
+
+export let jam2026Handler = createJam2026PageHandler();
+export let jam2026TicketAction = createJam2026TicketAction();
+
+export function createJam2026PageHandler(
+  storefront: Jam2026Storefront = { createCart, getProduct },
+) {
+  return async function jam2026Handler() {
+    return renderJam2026Page({ storefront });
+  };
+}
+
+export function createJam2026TicketAction(
+  storefront: Jam2026Storefront = { createCart, getProduct },
+) {
+  return async function jam2026TicketAction() {
+    let { request } = getRequestContext();
+    let formData = getContext().get(FormData) ?? (await request.formData());
+    let product = await storefront.getProduct(remixJam2026Ticket.handle);
+    let result = await handleTicketCheckoutPost({
+      formData,
+      product,
+      storefront,
+    });
+
+    if (result instanceof Response) return result;
+
+    return renderJam2026Page({
+      cacheControl: "no-store",
+      status: result.status,
+      storefront,
+      ticketCheckout: result.ticketCheckout,
+    });
+  };
+}
+
+async function renderJam2026Page({
+  cacheControl = CACHE_CONTROL.DEFAULT,
+  status = 200,
+  storefront,
+  ticketCheckout,
+}: {
+  cacheControl?: string;
+  status?: number;
+  storefront: Jam2026Storefront;
+  ticketCheckout?: ReturnType<typeof createTicketCheckoutState>;
+}) {
   let { request } = getRequestContext();
   let requestUrl = new URL(request.url);
-  let ticketsModalOpen = requestUrl.pathname === routes.jam.y2026.ticket.href();
+  let ticketsModalOpen =
+    requestUrl.pathname === routes.jam.y2026.ticket.index.href();
   let isTicketsFrameRequest =
     request.headers.get("x-remix-target") === ticketModalConfig.frameName;
   let isServerResolvedFrame =
     request.headers.get("x-remix-ssr-frame") === "true";
   let theme = await getJam2026ThemePreference(request.headers.get("cookie"));
+  let product = ticketsModalOpen
+    ? await storefront.getProduct(remixJam2026Ticket.handle)
+    : null;
+  ticketCheckout ??= product
+    ? createTicketCheckoutState({
+        product,
+      })
+    : undefined;
+
   let responseInit = {
+    status,
     headers: new SuperHeaders({
-      cacheControl: CACHE_CONTROL.DEFAULT,
+      cacheControl,
       vary: ["Cookie", "x-remix-target", "x-remix-ssr-frame"],
     }),
   };
@@ -36,13 +107,18 @@ export async function jam2026Handler() {
       <Jam2026TicketsModalFrame
         animateEntrance={!isServerResolvedFrame}
         open={ticketsModalOpen}
+        ticketCheckout={ticketCheckout}
       />,
       responseInit,
     );
   }
 
   return render.document(
-    <Jam2026HomePage ticketsModalOpen={ticketsModalOpen} theme={theme} />,
+    <Jam2026HomePage
+      ticketsModalOpen={ticketsModalOpen}
+      theme={theme}
+      ticketCheckout={ticketCheckout}
+    />,
     responseInit,
   );
 }
@@ -74,3 +150,160 @@ export async function jam2026ThemeAction() {
 let jam2026ThemeSubmissionSchema = f.object({
   theme: f.field(s.enum_(["light", "dark"])),
 });
+
+let ticketCheckoutSubmissionSchema = f.object({
+  ticketType: f.field(s.enum_([remixJam2026Ticket.type])),
+  productId: f.field(s.string()),
+  quantity: f.field(
+    coerce.number().pipe(c.min(1), c.max(remixJam2026Ticket.maxQuantity)),
+  ),
+});
+
+async function handleTicketCheckoutPost({
+  formData,
+  product,
+  storefront,
+}: {
+  formData: FormData;
+  product: Jam2026StorefrontProduct | null;
+  storefront: Jam2026Storefront;
+}) {
+  let submission = parseTicketCheckoutSubmission(formData);
+  if (!submission.success) {
+    return {
+      status: 400,
+      ticketCheckout: createTicketCheckoutState({
+        error: submission.error,
+        product,
+      }),
+    };
+  }
+
+  let { productId, quantity } = submission.value;
+  let checkoutError = getTicketCheckoutError({ product, productId, quantity });
+  if (checkoutError) {
+    return {
+      status: checkoutError.invalidInput ? 400 : 200,
+      ticketCheckout: createTicketCheckoutState({
+        error: checkoutError.message,
+        initialQuantity: quantity,
+        product,
+      }),
+    };
+  }
+
+  let cart = await storefront.createCart({ productId, quantity });
+  if ("error" in cart) {
+    return {
+      status: 200,
+      ticketCheckout: createTicketCheckoutState({
+        error: cart.error,
+        initialQuantity: quantity,
+        product,
+      }),
+    };
+  }
+
+  return new Response(null, {
+    status: 303,
+    headers: {
+      "Cache-Control": "no-store",
+      Location: cart.checkoutUrl,
+    },
+  });
+}
+
+function parseTicketCheckoutSubmission(formData: FormData) {
+  let result = s.parseSafe(ticketCheckoutSubmissionSchema, formData);
+  if (!result.success) {
+    return { success: false as const, error: "Invalid ticket request" };
+  }
+
+  if (!Number.isInteger(result.value.quantity)) {
+    return { success: false as const, error: "Invalid quantity" };
+  }
+
+  return {
+    success: true as const,
+    value: {
+      productId: result.value.productId,
+      quantity: result.value.quantity,
+    },
+  };
+}
+
+function getTicketCheckoutError({
+  product,
+  productId,
+  quantity,
+}: {
+  product: Jam2026StorefrontProduct | null;
+  productId: string;
+  quantity: number;
+}) {
+  if (!product || product.unavailableReason === "storefront") {
+    return {
+      message: "Ticket checkout is unavailable right now",
+      invalidInput: false,
+    };
+  }
+
+  if (product.unavailableReason === "product") {
+    return { message: "Tickets are not available yet", invalidInput: false };
+  }
+
+  if (productId !== product.productId) {
+    return { message: "Invalid ticket selection", invalidInput: true };
+  }
+
+  if (!product.availableForSale) {
+    return {
+      message: "Tickets are sold out or unavailable",
+      invalidInput: false,
+    };
+  }
+
+  if (!isQuantityAllowed(quantity, product)) {
+    return { message: "Invalid quantity", invalidInput: true };
+  }
+}
+
+function createTicketCheckoutState({
+  error,
+  initialQuantity = 1,
+  product,
+}: {
+  error?: string;
+  initialQuantity?: number;
+  product: Jam2026StorefrontProduct | null;
+}) {
+  let maxQuantity = getMaxQuantity(product);
+
+  return {
+    availableForSale: Boolean(product?.availableForSale),
+    error,
+    initialQuantity: Math.min(Math.max(1, initialQuantity), maxQuantity),
+    maxQuantity,
+    productId: product?.productId === "unavailable" ? "" : product?.productId,
+  };
+}
+
+function getMaxQuantity(product: Jam2026StorefrontProduct | null) {
+  let productMaximum = product?.quantityRule?.maximum;
+  if (typeof productMaximum !== "number") return MAX_QUANTITY;
+  return Math.max(1, Math.min(MAX_QUANTITY, productMaximum));
+}
+
+function isQuantityAllowed(
+  quantity: number,
+  product: Jam2026StorefrontProduct,
+) {
+  let quantityRule = product.quantityRule;
+  if (!quantityRule) return quantity >= 1 && quantity <= MAX_QUANTITY;
+
+  return (
+    quantity >= quantityRule.minimum &&
+    quantity <= getMaxQuantity(product) &&
+    (quantity - quantityRule.minimum) % quantityRule.increment === 0
+  );
+}

--- a/app/controllers/jam/2026/ticket-data.ts
+++ b/app/controllers/jam/2026/ticket-data.ts
@@ -1,5 +1,6 @@
 export const remixJam2026Ticket = {
   handle: "remix-jam-2026",
+  type: "general-admission",
   label: "Remix Jam 2026 Ticket",
   price: 299,
   originalPrice: 399,

--- a/app/controllers/jam/2026/ui/floating-ticket-cta.tsx
+++ b/app/controllers/jam/2026/ui/floating-ticket-cta.tsx
@@ -50,6 +50,7 @@ let floatingCtaRegionStyle = css({
 
 let floatingCtaLinkStyle = css({
   "--ticket-ring-animation-play-state": "running",
+  "--ticket-ring-scale": "1",
   cursor: "pointer",
   display: "block",
   height: "170px",
@@ -68,6 +69,9 @@ let floatingCtaLinkStyle = css({
   "&:hover, &:focus-visible": {
     "--ticket-ring-animation-play-state": "paused",
   },
+  "&:hover": {
+    "--ticket-ring-scale": "1.05",
+  },
   [breakpointMedia.lg]: {
     right: "10.2%",
     transform: "none",
@@ -81,6 +85,9 @@ let floatingCtaRingFrameStyle = css({
   position: "absolute",
   right: 0,
   top: 0,
+  transform: "scale(var(--ticket-ring-scale))",
+  transformOrigin: "center",
+  transition: "transform 180ms ease",
   width: "170px",
 });
 

--- a/app/controllers/jam/2026/ui/floating-ticket-cta.tsx
+++ b/app/controllers/jam/2026/ui/floating-ticket-cta.tsx
@@ -12,7 +12,7 @@ export function Jam2026FloatingTicketCta() {
   return () => (
     <div mix={floatingCtaRegionStyle}>
       <a
-        href={routes.jam.y2026.ticket.href()}
+        href={routes.jam.y2026.ticket.index.href()}
         mix={floatingCtaLinkStyle}
         rmx-reset-scroll="false"
         rmx-target={ticketModalConfig.frameName}

--- a/app/controllers/jam/2026/ui/hero.tsx
+++ b/app/controllers/jam/2026/ui/hero.tsx
@@ -324,10 +324,11 @@ let storyStyle = css({
   display: "grid",
   gridTemplateColumns:
     "minmax(32px, 0.47fr) minmax(0, 2.12fr) minmax(24px, 0.71fr) minmax(0, 2.53fr) minmax(24px, 0.71fr) minmax(0, 2.12fr) minmax(32px, 0.47fr)",
-  paddingBlock: "88px 96px",
+  paddingBlock: "88px 120px",
   [storyNarrowMedia]: {
     display: "block",
-    padding: "64px 24px",
+    paddingBlock: "64px 88px",
+    paddingInline: "24px",
   },
   [storyTabletMedia]: {
     display: "grid",

--- a/app/controllers/jam/2026/ui/home-page.tsx
+++ b/app/controllers/jam/2026/ui/home-page.tsx
@@ -103,6 +103,7 @@ let mainStyle = css({
 let footerStyle = css({
   position: "relative",
   zIndex: 1,
+  paddingTop: "40px",
   backgroundColor: jamTheme.surfaceRaised,
   color: jamTheme.ink,
 });

--- a/app/controllers/jam/2026/ui/home-page.tsx
+++ b/app/controllers/jam/2026/ui/home-page.tsx
@@ -5,6 +5,7 @@ import { Jam2026CloudBackdrop } from "../../../../assets/jam/2026/cloud-backdrop
 import { Jam2026Header } from "../../../../assets/jam/2026/header.tsx";
 import { Jam2026NewsletterSignup } from "../../../../assets/jam/2026/newsletter-signup.tsx";
 import { Jam2026PhotoMoments } from "../../../../assets/jam/2026/photo-moments.tsx";
+import { Jam2026TicketsModalFrame } from "../../../../assets/jam/2026/tickets-modal.tsx";
 import { routes } from "../../../../routes.ts";
 import { Document } from "../../../../ui/document.tsx";
 import { Footer } from "../../../../ui/footer.tsx";
@@ -18,6 +19,13 @@ import { Jam2026Hero } from "./hero.tsx";
 
 type Jam2026HomePageProps = {
   ticketsModalOpen?: boolean;
+  ticketCheckout?: {
+    availableForSale: boolean;
+    error?: string;
+    initialQuantity: number;
+    maxQuantity: number;
+    productId?: string;
+  };
   theme?: Jam2026ThemeMode;
 };
 
@@ -52,14 +60,22 @@ export function Jam2026HomePage(handle: Handle<Jam2026HomePageProps>) {
             </main>
             <Footer mix={footerStyle} />
           </div>
-          <Frame
-            name={ticketModalConfig.frameName}
-            src={
-              ticketsModalOpen
-                ? routes.jam.y2026.ticket.href()
-                : routes.jam.y2026.index.href()
-            }
-          />
+          {ticketsModalOpen && handle.props.ticketCheckout?.error ? (
+            <Jam2026TicketsModalFrame
+              animateEntrance={false}
+              open
+              ticketCheckout={handle.props.ticketCheckout}
+            />
+          ) : (
+            <Frame
+              name={ticketModalConfig.frameName}
+              src={
+                ticketsModalOpen
+                  ? routes.jam.y2026.ticket.index.href()
+                  : routes.jam.y2026.index.href()
+              }
+            />
+          )}
         </div>
       </Document>
     );

--- a/app/controllers/jam/controller.ts
+++ b/app/controllers/jam/controller.ts
@@ -9,7 +9,11 @@ import { jam2025GalleryDownloadHandler } from "./2025/gallery/download.ts";
 import { jam2025LineupHandler } from "./2025/lineup.tsx";
 import { jam2025TicketHandler } from "./2025/ticket.tsx";
 import { jam2025Handler } from "./2025/controller.tsx";
-import { jam2026Handler, jam2026ThemeAction } from "./2026/controller.tsx";
+import {
+  jam2026Handler,
+  jam2026ThemeAction,
+  jam2026TicketAction,
+} from "./2026/controller.tsx";
 
 export async function jamRedirectHandler() {
   let requestUrl = getRequestContext().request.url;
@@ -47,6 +51,12 @@ export let jam2026Controller = createController(routes.jam.y2026, {
   actions: {
     index: jam2026Handler,
     theme: jam2026ThemeAction,
-    ticket: jam2026Handler,
+  },
+});
+
+export let jam2026TicketController = createController(routes.jam.y2026.ticket, {
+  actions: {
+    index: jam2026Handler,
+    action: jam2026TicketAction,
   },
 });

--- a/app/controllers/jam/controller.ts
+++ b/app/controllers/jam/controller.ts
@@ -11,9 +11,9 @@ import { jam2025TicketHandler } from "./2025/ticket.tsx";
 import { jam2025Handler } from "./2025/controller.tsx";
 import { jam2026Handler, jam2026ThemeAction } from "./2026/controller.tsx";
 
-export async function jam2025RedirectHandler() {
+export async function jamRedirectHandler() {
   let requestUrl = getRequestContext().request.url;
-  let location = new URL(routes.jam.y2025.index.href(), requestUrl);
+  let location = new URL(routes.jam.y2026.index.href(), requestUrl);
   return Response.redirect(location, 302);
 }
 

--- a/app/data/jam-storefront.server.ts
+++ b/app/data/jam-storefront.server.ts
@@ -29,6 +29,14 @@ const ProductSchema = s.object({
   price: s.string(),
   productId: s.string(),
   availableForSale: s.boolean(),
+  quantityRule: s.optional(
+    s.object({
+      minimum: s.number(),
+      maximum: s.optional(s.number()),
+      increment: s.number(),
+    }),
+  ),
+  unavailableReason: s.optional(s.enum_(["storefront", "product"])),
 });
 
 const CartSchema = s.object({
@@ -62,12 +70,7 @@ export function parseCart(raw: unknown): Cart {
 export async function getProduct(handle: string): Promise<Product> {
   let storefrontClient = getClient();
   if (!storefrontClient) {
-    return parseProduct({
-      id: "unavailable",
-      price: "399.00",
-      productId: "unavailable",
-      availableForSale: false,
-    });
+    return createUnavailableProduct("storefront");
   }
 
   const productQuery = `
@@ -82,6 +85,11 @@ export async function getProduct(handle: string): Promise<Product> {
                 amount
               }
               availableForSale
+              quantityRule {
+                minimum
+                maximum
+                increment
+              }
             }
           }
         }
@@ -89,20 +97,37 @@ export async function getProduct(handle: string): Promise<Product> {
     }
   `;
 
-  const { data, errors } = await storefrontClient.request(productQuery, {
-    variables: { handle },
-  });
+  let response;
+  try {
+    response = await storefrontClient.request(productQuery, {
+      variables: { handle },
+    });
+  } catch {
+    return createUnavailableProduct("storefront");
+  }
 
-  if (errors) throw new Error("Failed to fetch product data");
+  const { data, errors } = response;
 
-  const price =
-    data?.product?.variants?.edges[0]?.node?.price?.amount || "399.00";
+  if (errors) return createUnavailableProduct("storefront");
+
+  let variant = data?.product?.variants?.edges[0]?.node;
+  if (!data?.product?.id || !variant?.id) {
+    return createUnavailableProduct("product");
+  }
+
+  const price = variant.price?.amount || "399.00";
   const product = {
-    id: data?.product?.id,
+    id: data.product.id,
     price: Number(price).toFixed(2),
-    productId: data?.product?.variants?.edges[0]?.node?.id,
-    availableForSale:
-      data?.product?.variants?.edges[0]?.node?.availableForSale || false,
+    productId: variant.id,
+    availableForSale: variant.availableForSale || false,
+    quantityRule: variant.quantityRule
+      ? {
+          minimum: variant.quantityRule.minimum,
+          maximum: variant.quantityRule.maximum ?? undefined,
+          increment: variant.quantityRule.increment,
+        }
+      : undefined,
   };
 
   return parseProduct(product);
@@ -176,7 +201,6 @@ export async function createCart(params: {
   }
 
   let { productId, quantity, discountCode } = params;
-  quantity = Math.min(quantity, MAX_QUANTITY);
   discountCode = (discountCode ?? "").trim().toUpperCase();
 
   const createCartMutation = `
@@ -194,28 +218,40 @@ export async function createCart(params: {
           field
           message
         }
+        warnings {
+          code
+          message
+          target
+        }
       }
     }
   `;
 
-  let discountCodes = [];
-  if (discountCode) {
-    discountCodes.push(discountCode);
+  let response;
+  try {
+    response = await storefrontClient.request(createCartMutation, {
+      variables: {
+        cartInput: {
+          lines: [
+            {
+              merchandiseId: productId,
+              quantity,
+            },
+          ],
+          discountCodes: discountCode ? [discountCode] : [],
+        },
+      },
+    });
+  } catch {
+    return { error: "Ticket checkout is unavailable right now" };
   }
 
-  const { data, errors } = await storefrontClient.request(createCartMutation, {
-    variables: {
-      cartInput: {
-        lines: [
-          {
-            merchandiseId: productId,
-            quantity,
-          },
-        ],
-        discountCodes,
-      },
-    },
-  });
+  const { data, errors } = response;
+
+  let userError = data?.cartCreate?.userErrors?.[0]?.message;
+  if (userError) {
+    return { error: userError };
+  }
 
   if (errors || !data?.cartCreate?.cart?.checkoutUrl) {
     return { error: "Failed to create cart" };
@@ -224,5 +260,17 @@ export async function createCart(params: {
   return parseCart({
     id: data.cartCreate.cart.id,
     checkoutUrl: data.cartCreate.cart.checkoutUrl,
+  });
+}
+
+function createUnavailableProduct(
+  unavailableReason: "storefront" | "product",
+): Product {
+  return parseProduct({
+    id: "unavailable",
+    price: "399.00",
+    productId: "unavailable",
+    availableForSale: false,
+    unavailableReason,
   });
 }

--- a/app/router.test.ts
+++ b/app/router.test.ts
@@ -27,6 +27,15 @@ describe("app router", () => {
     expect(xml).toContain("<link>https://remix.run/blog</link>");
   });
 
+  it("redirects the Jam index to the 2026 archive", async () => {
+    let response = await router.fetch("http://localhost/jam", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://localhost/jam/2026");
+  });
+
   it("allows same-origin browser form posts", async () => {
     let formData = new FormData();
     formData.set("theme", "dark");

--- a/app/router.ts
+++ b/app/router.ts
@@ -9,7 +9,7 @@ import { staticFiles } from "remix/middleware/static";
 import { rateLimit } from "./middleware/rate-limit.ts";
 import { loadAssetEntry } from "./middleware/asset-entry.ts";
 import { createRedirectRoutes, loadRedirectsFromFile } from "./redirects.ts";
-import { routes, showJam2026 } from "./routes.ts";
+import { routes } from "./routes.ts";
 import { assetServer } from "./utils/assets.server.ts";
 
 import actionsController from "./controllers/actions/controller.tsx";
@@ -115,9 +115,7 @@ function createAppRouter() {
   router.map(routes.jam.y2025.gallery, jam2025GalleryController);
   router.map(routes.jam.y2025.ticket, jam2025TicketController);
   router.map(routes.jam.y2025, jam2025Controller);
-  if (showJam2026) {
-    router.map(routes.jam.y2026, jam2026Controller);
-  }
+  router.map(routes.jam.y2026, jam2026Controller);
   router.map(routes.remix3ActiveDevelopment, remix3ActiveDevelopmentHandler);
 
   // Redirects from _redirects (must be before * catchall)

--- a/app/router.ts
+++ b/app/router.ts
@@ -26,6 +26,7 @@ import {
   jam2025GalleryController,
   jam2025TicketController,
   jam2026Controller,
+  jam2026TicketController,
   jamRedirectHandler,
 } from "./controllers/jam/controller.ts";
 import { newsletterHandler } from "./controllers/newsletter.tsx";
@@ -115,6 +116,7 @@ function createAppRouter() {
   router.map(routes.jam.y2025.gallery, jam2025GalleryController);
   router.map(routes.jam.y2025.ticket, jam2025TicketController);
   router.map(routes.jam.y2025, jam2025Controller);
+  router.map(routes.jam.y2026.ticket, jam2026TicketController);
   router.map(routes.jam.y2026, jam2026Controller);
   router.map(routes.remix3ActiveDevelopment, remix3ActiveDevelopmentHandler);
 

--- a/app/router.ts
+++ b/app/router.ts
@@ -24,9 +24,9 @@ import { homeHandler } from "./controllers/home/controller.tsx";
 import {
   jam2025Controller,
   jam2025GalleryController,
-  jam2025RedirectHandler,
   jam2025TicketController,
   jam2026Controller,
+  jamRedirectHandler,
 } from "./controllers/jam/controller.ts";
 import { newsletterHandler } from "./controllers/newsletter.tsx";
 
@@ -111,7 +111,7 @@ function createAppRouter() {
   router.map(routes.brand, brandHandler);
   router.map(routes.home, homeHandler);
   router.map(routes.newsletter, newsletterHandler);
-  router.map(routes.jam.index, jam2025RedirectHandler);
+  router.map(routes.jam.index, jamRedirectHandler);
   router.map(routes.jam.y2025.gallery, jam2025GalleryController);
   router.map(routes.jam.y2025.ticket, jam2025TicketController);
   router.map(routes.jam.y2025, jam2025Controller);

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -29,7 +29,7 @@ export let routes = route({
     y2026: route("2026", {
       index: get("/"),
       theme: post("theme"),
-      ticket: get("ticket"),
+      ticket: form("ticket"),
     }),
   }),
   newsletter: get("/newsletter"),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,8 +1,5 @@
 import { form, get, post, route } from "remix/routes";
 
-export let showJam2026 =
-  typeof process === "undefined" || process.env?.NODE_ENV !== "production";
-
 export let routes = route({
   actions: route("_actions", {
     newsletter: post("/newsletter"),
@@ -37,13 +34,3 @@ export let routes = route({
   }),
   newsletter: get("/newsletter"),
 });
-
-export let enabledRoutes = {
-  ...routes,
-  jam: showJam2026
-    ? routes.jam
-    : {
-        index: routes.jam.index,
-        y2025: routes.jam.y2025,
-      },
-};

--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -8,7 +8,7 @@ const LINKS: Array<{ to: string; label: string; document?: boolean }> = [
   { to: "https://github.com/remix-run/remix", label: "GitHub", document: true },
   { to: "https://api.remix.run", label: "Docs", document: true },
   { to: routes.blog.href(), label: "Blog" },
-  { to: routes.jam.y2025.index.href(), label: "Jam" },
+  { to: routes.jam.y2026.index.href(), label: "Jam" },
   { to: "https://shop.remix.run", label: "Store", document: true },
 ];
 

--- a/docs/remix-jam-2026-plan.md
+++ b/docs/remix-jam-2026-plan.md
@@ -63,7 +63,6 @@ Run a focused browser pass once landing and ticket UI are in place.
 
 Do this only when the 2026 pages are ready to publish.
 
-- Delete the leftover `showJam2026` flag, conditional router mapping, and commented production gate.
 - Change `/jam` redirect from `/jam/2025` to `/jam/2026`.
 - Update global header and landing nav links that should point to 2026.
 - Keep 2025 archive routes live but out of primary navigation unless intentionally linked.

--- a/docs/remix-jam-2026-plan.md
+++ b/docs/remix-jam-2026-plan.md
@@ -59,14 +59,6 @@ Run a focused browser pass once landing and ticket UI are in place.
 - Reduced-motion pass for countdown, cloud layer, FAQ, and ticket animations.
 - Check color contrast and text overlap in light and dark themes.
 
-### Production Launch Cleanup
-
-Do this only when the 2026 pages are ready to publish.
-
-- Change `/jam` redirect from `/jam/2025` to `/jam/2026`.
-- Update global header and landing nav links that should point to 2026.
-- Keep 2025 archive routes live but out of primary navigation unless intentionally linked.
-
 ### Launch Verification
 
 Final checks before opening sales.

--- a/test/jam.test.e2e.ts
+++ b/test/jam.test.e2e.ts
@@ -133,6 +133,29 @@ describe("Jam", () => {
     await expect(page).toHaveTitle("Remix Jam 2026");
   });
 
+  it("jam 2026 ticket modal closes with browser back without remounting the page", async (t) => {
+    let handler = swallowAbortErrors(router);
+    let page = await t.serve(await createTestServer(handler));
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/jam/2026", { waitUntil: "networkidle" });
+
+    let marker = await markPage(page);
+    await clickJam2026TicketNavLink(page);
+    await page.waitForURL("**/jam/2026/ticket");
+    await expectMarkerToStay(page, marker);
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await page.goBack();
+    await page.waitForURL("**/jam/2026");
+    await expectMarkerToStay(page, marker);
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+
+    await clickJam2026TicketNavLink(page);
+    await page.waitForURL("**/jam/2026/ticket");
+    await expectMarkerToStay(page, marker);
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
   it("jam 2026 mobile layout does not create horizontal document overflow", async (t) => {
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));

--- a/test/jam.test.e2e.ts
+++ b/test/jam.test.e2e.ts
@@ -86,11 +86,11 @@ describe("Jam", () => {
     await expect(mobileNav.getByRole("link", { name: "Ticket" })).toBeVisible();
   });
 
-  it("jam root redirects to jam 2025", async (t) => {
+  it("jam root redirects to jam 2026", async (t) => {
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));
     await page.goto("/jam");
-    await page.waitForURL("**/jam/2025");
+    await page.waitForURL("**/jam/2026");
     await expect(page.locator("main")).toBeVisible();
   });
 

--- a/test/navigation.test.e2e.ts
+++ b/test/navigation.test.e2e.ts
@@ -75,30 +75,27 @@ describe("Navigation", () => {
     await expect(page.locator("html.dark")).toHaveCount(1);
   });
 
-  it("Remix 3 active development page to jam applies jam head styles and forced dark theme", async (t) => {
+  it("Remix 3 active development page to Jam 2026 applies Jam head content", async (t) => {
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));
     await page.goto("/remix-3-active-development");
 
     await expectClientNavigation(
       page,
-      () => page.locator('header a[href="/jam/2025"]').first().click(),
-      "**/jam/2025",
+      () => page.locator('header a[href="/jam/2026"]').first().click(),
+      "**/jam/2026",
     );
 
-    await expect(page.locator('html[data-theme="dark"]')).toHaveCount(1);
-    await expect(page.locator("html.dark")).toHaveCount(1);
+    await expect(page).toHaveTitle("Remix Jam 2026");
     await expect
       .poll(() =>
-        page.evaluate(() =>
-          Array.from(
-            document.head.querySelectorAll('link[rel="stylesheet"]'),
-          ).some((element) =>
-            element.getAttribute("href")?.includes("jam-2025.css"),
-          ),
-        ),
+        page.evaluate(() => {
+          return document
+            .querySelector('link[rel="canonical"]')
+            ?.getAttribute("href");
+        }),
       )
-      .toBe(true);
+      .toBe(`${page.url()}`);
   });
 
   it("header wordmark context menu uses client navigation for brand", async (t) => {


### PR DESCRIPTION
## Summary
- Refine Jam 2026 story and footer spacing.
- Update the floating ticket CTA hover treatment.
- Restyle the newsletter signup to match the latest Figma direction while preserving existing page styles.

## Test plan
- `pnpm run build`
- Previewed locally at `http://localhost:44100/jam/2026`