### PR TITLE
Update Remix to beta 4

### DIFF
--- a/app/controllers/actions/controller.test.ts
+++ b/app/controllers/actions/controller.test.ts
@@ -3,6 +3,7 @@ import { expect } from "remix/assert";
 
 import { routes } from "../../routes.ts";
 import { newsletterTagIds } from "../../utils/newsletter-tags.ts";
+import { createRouteTestRouter } from "../../../test/setup.ts";
 import actionsController from "./controller.tsx";
 
 describe("Newsletter subscribe route", () => {
@@ -17,23 +18,15 @@ describe("Newsletter subscribe route", () => {
   });
 
   async function submitNewsletter(body: URLSearchParams) {
-    let formData = new FormData();
-    for (let [key, value] of body.entries()) {
-      formData.append(key, value);
-    }
+    let router = createRouteTestRouter();
+    router.map(routes.actions, actionsController);
 
-    type NewsletterContext = Parameters<
-      typeof actionsController.actions.newsletter
-    >[0];
-    let context = {
-      request: new Request(
-        `http://localhost:3000${routes.actions.newsletter.href()}`,
-        { method: "POST" },
-      ),
-      formData,
-    } as unknown as NewsletterContext;
-
-    return actionsController.actions.newsletter(context);
+    return router.fetch(
+      new Request(`http://localhost:3000${routes.actions.newsletter.href()}`, {
+        method: "POST",
+        body,
+      }),
+    );
   }
 
   it("rejects invalid emails", async () => {

--- a/app/middleware/render.ts
+++ b/app/middleware/render.ts
@@ -102,7 +102,7 @@ async function resolveFrame(
   src: string,
   target: string | undefined,
   context: ResolveFrameContext | undefined,
-  router: Router,
+  router: Router<RequestContext<any, any>>,
   request: Request,
 ) {
   let frameSrc = context?.currentFrameSrc ?? request.url;
@@ -131,7 +131,7 @@ async function resolveFrame(
 }
 
 export async function followFrameRedirects(
-  router: Router,
+  router: Router<RequestContext<any, any>>,
   request: Request,
   url: URL,
   headers: Headers,

--- a/app/router.ts
+++ b/app/router.ts
@@ -1,6 +1,6 @@
 import { compression } from "remix/middleware/compression";
 import { cop } from "remix/middleware/cop";
-import { createRouter, type RequestContext } from "remix/router";
+import { createRouter, type Middleware } from "remix/router";
 import { formData } from "remix/middleware/form-data";
 import { logger } from "remix/middleware/logger";
 import { staticFiles } from "remix/middleware/static";
@@ -49,7 +49,7 @@ function createAppRouter() {
   middleware.push(compression());
 
   if (isDev) {
-    middleware.push((context: RequestContext) => {
+    let ignoreChromeDevToolsRequest: Middleware = (context, next) => {
       if (
         context.request.method === "GET" &&
         context.url.pathname ===
@@ -57,7 +57,10 @@ function createAppRouter() {
       ) {
         return new Response(null, { status: 204 });
       }
-    });
+      return next();
+    };
+
+    middleware.push(ignoreChromeDevToolsRequest);
   }
 
   middleware.push(

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "remark-gfm": "4.0.1",
     "remark-parse": "11.0.0",
     "remark-rehype": "11.1.2",
-    "remix": "3.0.0-beta.3",
+    "remix": "3.0.0-beta.4",
     "satori": "0.26.0",
     "semver": "7.7.4",
     "shiki": "0.14.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 11.1.2
         version: 11.1.2
       remix:
-        specifier: 3.0.0-beta.3
-        version: 3.0.0-beta.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
+        specifier: 3.0.0-beta.4
+        version: 3.0.0-beta.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
       satori:
         specifier: 0.26.0
         version: 0.26.0
@@ -1405,47 +1405,47 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
-  "@remix-run/assert@0.2.1":
+  "@remix-run/assert@0.3.0":
     resolution:
       {
-        integrity: sha512-jHoxChSCIbueiED3ZeMqWGNZMVYFN/7Eo51PkID174dPloRHeXLL7Kj9Ck1phtXPalEyofzWsxdWwKUnQYHzCw==,
+        integrity: sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ==,
       }
 
-  "@remix-run/assets@0.4.2":
+  "@remix-run/assets@0.4.3":
     resolution:
       {
-        integrity: sha512-ecPwUF0fL3RIQNthpd5ZihwyqW+Huc15pUraSroBTPN99WvK7e72m6Q4v+G3kukyygHyZLHOiirbxhE6iwOgFw==,
+        integrity: sha512-3YKANQIc/dATxy9+7VpaILXZ4KPOP7y888EbyAphvEu++jOILpjHxMi5N+fhXoRZxpmL+CXaB7PKEwbsAAnKpA==,
       }
 
-  "@remix-run/async-context-middleware@0.3.2":
+  "@remix-run/async-context-middleware@0.3.3":
     resolution:
       {
-        integrity: sha512-AIUVST4WPThE9exOOHqoxwcXMyL7jeAKLWYBL1tZpII9qOIayI1nUEvxGFA3px7RcKK3nWpFb3apUNBS31XJwg==,
+        integrity: sha512-Qg53vPttFVX9kxYjn8dxd+/BpCCe9gaYGPUze+YAMvQ73InKyeTF1a4zqnmHgHxTVp2qYK+kp0derTVlRAMTpQ==,
       }
 
-  "@remix-run/auth-middleware@0.2.2":
+  "@remix-run/auth-middleware@0.2.3":
     resolution:
       {
-        integrity: sha512-uZWKwF5BOMtDOlMrI6ZvgO7ocW5/NXmX5CXZSJS4wLQkt3+Y8DSDGA+QuhuOlFV6DsYXSLMxo6DsvMaXBu9Wyg==,
+        integrity: sha512-dUt/b/Vj4dntpORbQ9bV51eWyi7DyHM7zV4EfbSGsw7jyYfwtRptqu5Y3gAW6YlGAM1jp+ahSUMSzOqb1EEKWw==,
       }
 
-  "@remix-run/auth@0.2.4":
+  "@remix-run/auth@0.2.5":
     resolution:
       {
-        integrity: sha512-fgDC+lJlOfrc50X9NtM8mMaoNWrRIuuX+kd/zNN07+aZYsJnZu+fsn0N49HcAOSY2u34IIv5RZHhXE7Mhci7kA==,
+        integrity: sha512-liwLro3rHgtjTc3MuYD4iKlZUcVvAzZUSGk0Tc1JFd7QSI8E8G2QeCxJvZRpul6TO0ojnjSogNydmj42ZpI4iQ==,
       }
 
-  "@remix-run/cli@0.3.2":
+  "@remix-run/cli@0.3.3":
     resolution:
       {
-        integrity: sha512-BlP+/uWzA/B+q4oBacfTplusHR0g/ehs+jpVOl1HCD+MhVJ3Tk6yUOEYyi7H4Paf3ARXUNYcFghY5ap9HzrNSg==,
+        integrity: sha512-3ho5CuzpIA6IIyY48EvAsA5I2c5mlT6RNvGa5/oSi6OutgNX+Fb9UDLIw7MbvKRvaIL6b/XOHT0LCQ+TrIAL+g==,
       }
     engines: { node: ">=24.3.0" }
 
-  "@remix-run/compression-middleware@0.1.10":
+  "@remix-run/compression-middleware@0.1.11":
     resolution:
       {
-        integrity: sha512-2icevxi0O14RRzdWokrrpqjQRfyXBYkCLg6hVmEXN8ydSOH3NNbPbBjU95pjaKnVYoEqMc36x9yi75e2ZwFhJw==,
+        integrity: sha512-VgnCV8cZqH11HhBXqIbgskUaK7ORkFlVBy9I+6dQQKWpDv/WnouFtKI2anlAfYqUZ+6WCfyBTNlq5FfbAz5lVA==,
       }
 
   "@remix-run/cookie@0.5.4":
@@ -1454,22 +1454,22 @@ packages:
         integrity: sha512-QxV2yo0umBXxwMub8kZFC+nOFnGMVpGo3jQ1Gvs4p1n2N7/0LAKhPgKsWbsk5ab6EqVhpr0S+v9gSQON1nuyoA==,
       }
 
-  "@remix-run/cop-middleware@0.1.5":
+  "@remix-run/cop-middleware@0.1.6":
     resolution:
       {
-        integrity: sha512-mJt81FwPS8Qee4CaCQPy9Gbt9Hm38J4y8hrVJ0DFDBVz0NaTSu56qitfAsa10EUGox9zN7c6w6feOGQUJzrwNQ==,
+        integrity: sha512-KPTHCIunLQxzNHXPel0jYFpKcmM7TF9GxMaitV0NGh8JktRDX0ckS+6lpHk7gGf06lIBYcafgqwrIVdp/LXSXg==,
       }
 
-  "@remix-run/cors-middleware@0.1.5":
+  "@remix-run/cors-middleware@0.1.6":
     resolution:
       {
-        integrity: sha512-0y5sAZScPTXgR1fFMGU+WYHAV9MBUAVLwOfj5s2OaRcLqEDGJv2EeUu6I/quLFWAqbZTBEoL33qeYUC9DFeQYg==,
+        integrity: sha512-n4+sL7ePUhtWKrTjSfjs37sgz228cZPQbSyOEPy6b8nGhX8cRDFYqkF3M9BSelxoP4sWfIQZTaE1LTGAemHrrA==,
       }
 
-  "@remix-run/csrf-middleware@0.1.5":
+  "@remix-run/csrf-middleware@0.1.6":
     resolution:
       {
-        integrity: sha512-YGc9WXaOyRfC1k0bykTWf5THh8GYLXcHAcva+lqa9rXxXNSwh86xre77k8ZtugppZdxISZvh0jRyVk0ZyXQszQ==,
+        integrity: sha512-qqF92bQFwKu3qnLvMjFPhf6B0gHr4U4ZolLFcfOVgK8OcszHZQdBCLwmwGu+G6MxbaNnk0OtE+kL36liJ5+Tzw==,
       }
 
   "@remix-run/data-schema@0.3.0":
@@ -1518,10 +1518,10 @@ packages:
         integrity: sha512-FP2/0DIdnPGXMk+UAsRhYmunj3ElH2QNjuvD7VjjyWOAs9vHn7XnvfKk+qs1VDXAO5J9fkzwPQ+Y0n9FJZ8srQ==,
       }
 
-  "@remix-run/fetch-router@0.19.2":
+  "@remix-run/fetch-router@0.20.0":
     resolution:
       {
-        integrity: sha512-jlMuXQTNYC4CTyzYBCxTBrLDo8f/tBPJn/PG+c0+EDBMGhylMTe95hDvZmnWdC7J1RN/sDL8rpKoX5TQLPEVGQ==,
+        integrity: sha512-iNjDAesu37Yf8nApAkKgKjmZBavC+AuzWK9EUmiwo+OnH7nn8ag5whyVFR4kb0LJN5CeXciFEIjX+oHG5cNeyw==,
       }
 
   "@remix-run/file-storage-s3@0.1.3":
@@ -1536,10 +1536,10 @@ packages:
         integrity: sha512-dXX7gcoPPWFa/041U/fCW9jHS11v8oC8UCrMRpbkyltz+tI55KvJ60oHYPUqnu75b9Ep60lZHvNviqlSn1Iv4w==,
       }
 
-  "@remix-run/form-data-middleware@0.3.2":
+  "@remix-run/form-data-middleware@0.3.3":
     resolution:
       {
-        integrity: sha512-7/tgeJG22O01ZlbftSd+taHvQsvofbYWgxvHL0mPQrNZPvaCEEjPAc2QUlkxnq7+shftuMOIEhFOyAziDnmzcQ==,
+        integrity: sha512-46FpwGGyjJXvH1ZioZtL8FGO14qDASqaZmnqXmeUspZ4XvtEVAiEfzcPYUnmCNzrvBSuGlgU5WqUfOQxbtXAHA==,
       }
 
   "@remix-run/form-data-parser@0.17.3":
@@ -1572,16 +1572,16 @@ packages:
         integrity: sha512-PhjTgR266T2qDKki6lQnlOtgZv4VB8Dqeu1sBUu2pBazgi2nZA2n7lvDpNiegKozBgGfUXS8ScdIQ6FPuNvtcw==,
       }
 
-  "@remix-run/logger-middleware@0.3.2":
+  "@remix-run/logger-middleware@0.3.3":
     resolution:
       {
-        integrity: sha512-KLv81BWNelT2bAuHe9O2BJ68bjHTUYDUka46mhwu+VRY3MJJxpfI/iAD1fMHnIrDJ8UIlUjuhQSMv5LrCIqIrA==,
+        integrity: sha512-nrKhWowr3PPimgwngx3U343ohS5noBTx1jgohMVP+3M0DxrQbJNppXu2qty93XZk4XGECj+DgQhU9U1O8ARLcA==,
       }
 
-  "@remix-run/method-override-middleware@0.1.10":
+  "@remix-run/method-override-middleware@0.1.11":
     resolution:
       {
-        integrity: sha512-+PgtACfzfNwjxIfu8x7TXxv41mesx7IE+v7Fo/L3DLv4muq49BrWWmTzaHwTm7jWtPg6L3EjFrF87SgMGxKK7Q==,
+        integrity: sha512-OP9yc33e3bEkjJ36YgVlUVuQcIUSLpFjjpDA7etK1qgRNE2EHBmVBR5ypqfGF2PORV0FnLvmAaeVpdz3eo/CNA==,
       }
 
   "@remix-run/mime@0.4.1":
@@ -1609,10 +1609,10 @@ packages:
       }
     engines: { node: ">=24.3.0" }
 
-  "@remix-run/render-middleware@0.1.2":
+  "@remix-run/render-middleware@0.1.3":
     resolution:
       {
-        integrity: sha512-PCTBROGg/Gwt7b08PgSPOXaK6SJ//tpX8V4CUuuIkbT7ec8WjOzx91qscx4xdvQKascwBnx+jk9qKcsIgyNjYQ==,
+        integrity: sha512-wxrjRdYbiE7yT2VhCe1M7/ir4M44M6cxwnzCdxd8qVIg+i4lbFdizDR72ClDNoAQ2hPtlHDy7+2U+ufnNHUGRQ==,
       }
 
   "@remix-run/response@0.3.6":
@@ -1621,16 +1621,16 @@ packages:
         integrity: sha512-WgbAXEGesrfVz449Lv1AUruT2r2t79XxkcG/cdzDZWXB/2UKcKFsVSM/tFvfmIuAtwdvhQrrnaFpnC04OfYSNA==,
       }
 
-  "@remix-run/route-pattern@0.22.0":
+  "@remix-run/route-pattern@0.22.1":
     resolution:
       {
-        integrity: sha512-YN3HBtEKV5+LuwGeOc4jdYXJd58oECZ6zZYOG8b9d6U/jnAc5tKszPwUeLZ+5Z0ZwT1QgB/9QQ2yXJPzj45XYQ==,
+        integrity: sha512-czdGJWh09Lapvcqt7Vb09KlrU2PhRJ8xQaI+AItTuD9aDJ5MAgxnS38lnys6Ll+6RJEqPiaUqTwIQhVLwFvv+w==,
       }
 
-  "@remix-run/session-middleware@0.3.2":
+  "@remix-run/session-middleware@0.3.3":
     resolution:
       {
-        integrity: sha512-a6TmQTZgwKoxV777JVgbJ3wBAkA2I29a1Lbb+W187NJZwI1QLJxiZ9SflvCvMeiJ5jU9C1j+0KltBWLrnfqr2w==,
+        integrity: sha512-mMY3DJNpRAdEu6TMAVV0N6kGr3UCvucfunHHOzvWwMy7QVXqIgYFfJFIzWuHiKKGVUdNyBhDAADA3e9eLNtXRA==,
       }
 
   "@remix-run/session-storage-memcache@0.1.2":
@@ -1656,10 +1656,10 @@ packages:
         integrity: sha512-NGzu6/gC5xD/tq40W0WqzTt4JhCdSCIwDHM1aa13JBqb4Ml/Mb0kmXqjfOe/gBYfu6AA11nRQ/BJyr+VduTodA==,
       }
 
-  "@remix-run/static-middleware@0.4.11":
+  "@remix-run/static-middleware@0.4.12":
     resolution:
       {
-        integrity: sha512-7z/zum8X8gjUE7DfyCG2xqeoaYB16Qu3JNZyjeTcD5mOeRG+BSKG0sZN5CPanefXNDccghEPlwy8zTxQ0DWlsQ==,
+        integrity: sha512-ovppEYU9SdEzt7+jIZYN+ReD4LaWau2Vi98obAzgMdOfKBiP3C0ftdXhVmTBBtDq0kJdFoVi7NE/c95FpnGkwg==,
       }
 
   "@remix-run/tar-parser@0.7.1":
@@ -1674,10 +1674,10 @@ packages:
         integrity: sha512-M8JNcsYp/mWZ0yOB12Ir+Ud1eLxodPr8YSKQcG2PTPeiq9p9c59D9gvF9m6EU2Hmd4esJMiTyy6lJHc/VKKvcw==,
       }
 
-  "@remix-run/test@0.4.2":
+  "@remix-run/test@0.5.0":
     resolution:
       {
-        integrity: sha512-zZKdAFR7pMKZoHXnCLyP0U2JZzowpPtguzRz/KQbADSkOEj6wiIjv+/ofiZ0GLRXrAh/xzocISR1AZsMVEx5vg==,
+        integrity: sha512-jaJLJi7+YXFh4JblWe3hjqve8tkiZ1Nzsog1j6EwCEv814bHldCqBbFrajI69DUULd3nNCs3Mk3rz96lt83xYA==,
       }
     engines: { node: ">=24.3.0" }
     hasBin: true
@@ -4128,10 +4128,10 @@ packages:
         integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
       }
 
-  remix@3.0.0-beta.3:
+  remix@3.0.0-beta.4:
     resolution:
       {
-        integrity: sha512-pOohIdQPcmr8mtylPSBVsOCNhljUEBYDALBT0K0XICY6nSGE7TGn1ODy1/87OoX0s/s7rNYQdlEtewzt0tld0w==,
+        integrity: sha512-KT3elI5Xqbsuy17EXyAicM4aOrbReMMu4ozwRVGxe+XYu7IiZ0q4ScCHUg2MLRrazADLewbZLIODrK61LGMfwg==,
       }
     engines: { node: ">=24.3.0" }
     hasBin: true
@@ -5116,15 +5116,15 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  "@remix-run/assert@0.2.1": {}
+  "@remix-run/assert@0.3.0": {}
 
-  "@remix-run/assets@0.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+  "@remix-run/assets@0.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
       "@oxc-project/runtime": 0.121.0
       "@remix-run/file-storage": 0.13.6
       "@remix-run/headers": 0.21.1
       "@remix-run/mime": 0.4.1
-      "@remix-run/route-pattern": 0.22.0
+      "@remix-run/route-pattern": 0.22.1
       chokidar: 5.0.0
       es-module-lexer: 2.1.0
       get-tsconfig: 4.14.0
@@ -5140,33 +5140,33 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/async-context-middleware@0.3.2":
+  "@remix-run/async-context-middleware@0.3.3":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
 
-  "@remix-run/auth-middleware@0.2.2":
+  "@remix-run/auth-middleware@0.2.3":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/session": 0.4.2
 
-  "@remix-run/auth@0.2.4":
+  "@remix-run/auth@0.2.5":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/session": 0.4.2
 
-  "@remix-run/cli@0.3.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)":
+  "@remix-run/cli@0.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)":
     dependencies:
       "@remix-run/terminal": 0.1.1
-      "@remix-run/test": 0.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
+      "@remix-run/test": 0.5.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
       semver: 7.7.4
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
       - playwright
 
-  "@remix-run/compression-middleware@0.1.10":
+  "@remix-run/compression-middleware@0.1.11":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/mime": 0.4.1
       "@remix-run/response": 0.3.6
 
@@ -5174,18 +5174,18 @@ snapshots:
     dependencies:
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/cop-middleware@0.1.5":
+  "@remix-run/cop-middleware@0.1.6":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
 
-  "@remix-run/cors-middleware@0.1.5":
+  "@remix-run/cors-middleware@0.1.6":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/csrf-middleware@0.1.5":
+  "@remix-run/csrf-middleware@0.1.6":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/session": 0.4.2
 
   "@remix-run/data-schema@0.3.0":
@@ -5210,9 +5210,9 @@ snapshots:
     dependencies:
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/fetch-router@0.19.2":
+  "@remix-run/fetch-router@0.20.0":
     dependencies:
-      "@remix-run/route-pattern": 0.22.0
+      "@remix-run/route-pattern": 0.22.1
 
   "@remix-run/file-storage-s3@0.1.3":
     dependencies:
@@ -5224,9 +5224,9 @@ snapshots:
       "@remix-run/fs": 0.4.5
       "@remix-run/lazy-file": 5.0.5
 
-  "@remix-run/form-data-middleware@0.3.2":
+  "@remix-run/form-data-middleware@0.3.3":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/form-data-parser": 0.17.3
 
   "@remix-run/form-data-parser@0.17.3":
@@ -5246,14 +5246,14 @@ snapshots:
     dependencies:
       "@remix-run/mime": 0.4.1
 
-  "@remix-run/logger-middleware@0.3.2":
+  "@remix-run/logger-middleware@0.3.3":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/terminal": 0.1.1
 
-  "@remix-run/method-override-middleware@0.1.10":
+  "@remix-run/method-override-middleware@0.1.11":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
 
   "@remix-run/mime@0.4.1": {}
 
@@ -5271,9 +5271,9 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/render-middleware@0.1.2":
+  "@remix-run/render-middleware@0.1.3":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
 
   "@remix-run/response@0.3.6":
     dependencies:
@@ -5281,12 +5281,12 @@ snapshots:
       "@remix-run/html-template": 0.3.1
       "@remix-run/mime": 0.4.1
 
-  "@remix-run/route-pattern@0.22.0": {}
+  "@remix-run/route-pattern@0.22.1": {}
 
-  "@remix-run/session-middleware@0.3.2":
+  "@remix-run/session-middleware@0.3.3":
     dependencies:
       "@remix-run/cookie": 0.5.4
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/session": 0.4.2
 
   "@remix-run/session-storage-memcache@0.1.2":
@@ -5299,9 +5299,9 @@ snapshots:
 
   "@remix-run/session@0.4.2": {}
 
-  "@remix-run/static-middleware@0.4.11":
+  "@remix-run/static-middleware@0.4.12":
     dependencies:
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/fs": 0.4.5
       "@remix-run/html-template": 0.3.1
       "@remix-run/mime": 0.4.1
@@ -5311,7 +5311,7 @@ snapshots:
 
   "@remix-run/terminal@0.1.1": {}
 
-  "@remix-run/test@0.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)":
+  "@remix-run/test@0.5.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)":
     dependencies:
       "@remix-run/node-tsx": 0.1.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       "@remix-run/terminal": 0.1.1
@@ -6893,51 +6893,51 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remix@3.0.0-beta.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0):
+  remix@3.0.0-beta.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0):
     dependencies:
-      "@remix-run/assert": 0.2.1
-      "@remix-run/assets": 0.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      "@remix-run/async-context-middleware": 0.3.2
-      "@remix-run/auth": 0.2.4
-      "@remix-run/auth-middleware": 0.2.2
-      "@remix-run/cli": 0.3.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
-      "@remix-run/compression-middleware": 0.1.10
+      "@remix-run/assert": 0.3.0
+      "@remix-run/assets": 0.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      "@remix-run/async-context-middleware": 0.3.3
+      "@remix-run/auth": 0.2.5
+      "@remix-run/auth-middleware": 0.2.3
+      "@remix-run/cli": 0.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
+      "@remix-run/compression-middleware": 0.1.11
       "@remix-run/cookie": 0.5.4
-      "@remix-run/cop-middleware": 0.1.5
-      "@remix-run/cors-middleware": 0.1.5
-      "@remix-run/csrf-middleware": 0.1.5
+      "@remix-run/cop-middleware": 0.1.6
+      "@remix-run/cors-middleware": 0.1.6
+      "@remix-run/csrf-middleware": 0.1.6
       "@remix-run/data-schema": 0.3.0
       "@remix-run/data-table": 0.3.0
       "@remix-run/data-table-mysql": 0.4.0
       "@remix-run/data-table-postgres": 0.4.0
       "@remix-run/data-table-sqlite": 0.5.1
       "@remix-run/fetch-proxy": 0.8.3
-      "@remix-run/fetch-router": 0.19.2
+      "@remix-run/fetch-router": 0.20.0
       "@remix-run/file-storage": 0.13.6
       "@remix-run/file-storage-s3": 0.1.3
-      "@remix-run/form-data-middleware": 0.3.2
+      "@remix-run/form-data-middleware": 0.3.3
       "@remix-run/form-data-parser": 0.17.3
       "@remix-run/fs": 0.4.5
       "@remix-run/headers": 0.21.1
       "@remix-run/html-template": 0.3.1
       "@remix-run/lazy-file": 5.0.5
-      "@remix-run/logger-middleware": 0.3.2
-      "@remix-run/method-override-middleware": 0.1.10
+      "@remix-run/logger-middleware": 0.3.3
+      "@remix-run/method-override-middleware": 0.1.11
       "@remix-run/mime": 0.4.1
       "@remix-run/multipart-parser": 0.16.3
       "@remix-run/node-fetch-server": 0.13.3
       "@remix-run/node-tsx": 0.1.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      "@remix-run/render-middleware": 0.1.2
+      "@remix-run/render-middleware": 0.1.3
       "@remix-run/response": 0.3.6
-      "@remix-run/route-pattern": 0.22.0
+      "@remix-run/route-pattern": 0.22.1
       "@remix-run/session": 0.4.2
-      "@remix-run/session-middleware": 0.3.2
+      "@remix-run/session-middleware": 0.3.3
       "@remix-run/session-storage-memcache": 0.1.2
       "@remix-run/session-storage-redis": 0.1.1
-      "@remix-run/static-middleware": 0.4.11
+      "@remix-run/static-middleware": 0.4.12
       "@remix-run/tar-parser": 0.7.1
       "@remix-run/terminal": 0.1.1
-      "@remix-run/test": 0.4.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
+      "@remix-run/test": 0.5.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(playwright@1.60.0)
       "@remix-run/ui": 0.3.0
     optionalDependencies:
       playwright: 1.60.0


### PR DESCRIPTION
## Summary
- Update Remix to 3.0.0-beta.4
- Explicitly continue the Chrome DevTools ignore middleware with next()
- Adjust newsletter route test and router typing for beta 4 router types
