### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -52,28 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-
-          flyctl_url="$(
-            curl --fail --silent --show-error --location --retry 5 \
-              --header "Authorization: Bearer $GH_TOKEN" \
-              --header "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/superfly/flyctl/releases/latest \
-              | python3 -c 'import json, sys; print(next(asset["browser_download_url"] for asset in json.load(sys.stdin)["assets"] if asset["name"].endswith("_Linux_x86_64.tar.gz")))'
-          )"
-
-          curl --fail --silent --show-error --location --retry 5 \
-            --output "$tmp_dir/flyctl.tar.gz" \
-            "$flyctl_url"
-          tar -xzf "$tmp_dir/flyctl.tar.gz" -C "$tmp_dir"
-          sudo install "$tmp_dir/flyctl" /usr/local/bin/flyctl
-          flyctl version
+        uses: superfly/flyctl-actions/setup-flyctl@1.6
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -52,7 +52,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@1.6
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          flyctl_url="$(
+            curl --fail --silent --show-error --location --retry 5 \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/superfly/flyctl/releases/latest \
+              | python3 -c 'import json, sys; print(next(asset["browser_download_url"] for asset in json.load(sys.stdin)["assets"] if asset["name"].endswith("_Linux_x86_64.tar.gz")))'
+          )"
+
+          curl --fail --silent --show-error --location --retry 5 \
+            --output "$tmp_dir/flyctl.tar.gz" \
+            "$flyctl_url"
+          tar -xzf "$tmp_dir/flyctl.tar.gz" -C "$tmp_dir"
+          sudo install "$tmp_dir/flyctl" /usr/local/bin/flyctl
+          flyctl version
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@1.5
+        uses: superfly/flyctl-actions/setup-flyctl@1.6
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@1.5
+        uses: superfly/flyctl-actions/setup-flyctl@1.6
 
       - name: 🚀 Deploy Staging
         run: flyctl deploy --remote-only --config ./fly.staging.toml --strategy bluegreen

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -54,28 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-
-          flyctl_url="$(
-            curl --fail --silent --show-error --location --retry 5 \
-              --header "Authorization: Bearer $GH_TOKEN" \
-              --header "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/superfly/flyctl/releases/latest \
-              | python3 -c 'import json, sys; print(next(asset["browser_download_url"] for asset in json.load(sys.stdin)["assets"] if asset["name"].endswith("_Linux_x86_64.tar.gz")))'
-          )"
-
-          curl --fail --silent --show-error --location --retry 5 \
-            --output "$tmp_dir/flyctl.tar.gz" \
-            "$flyctl_url"
-          tar -xzf "$tmp_dir/flyctl.tar.gz" -C "$tmp_dir"
-          sudo install "$tmp_dir/flyctl" /usr/local/bin/flyctl
-          flyctl version
+        uses: superfly/flyctl-actions/setup-flyctl@1.6
 
       - name: 🚀 Deploy Staging
         run: flyctl deploy --remote-only --config ./fly.staging.toml --strategy bluegreen

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -54,7 +54,28 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@1.6
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          flyctl_url="$(
+            curl --fail --silent --show-error --location --retry 5 \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/superfly/flyctl/releases/latest \
+              | python3 -c 'import json, sys; print(next(asset["browser_download_url"] for asset in json.load(sys.stdin)["assets"] if asset["name"].endswith("_Linux_x86_64.tar.gz")))'
+          )"
+
+          curl --fail --silent --show-error --location --retry 5 \
+            --output "$tmp_dir/flyctl.tar.gz" \
+            "$flyctl_url"
+          tar -xzf "$tmp_dir/flyctl.tar.gz" -C "$tmp_dir"
+          sudo install "$tmp_dir/flyctl" /usr/local/bin/flyctl
+          flyctl version
 
       - name: 🚀 Deploy Staging
         run: flyctl deploy --remote-only --config ./fly.staging.toml --strategy bluegreen

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- update `pnpm/action-setup` from v4 to v5 for Node 24 runtime support
- update `superfly/flyctl-actions/setup-flyctl` from v1.5 to v1.6 for Node 24 runtime support
- keep existing `actions/setup-node@v6` steps on `node-version: 24`

## Validation
- `pnpm exec prettier --write .github/workflows/deploy.production.yml .github/workflows/deploy.staging.yml .github/workflows/format.yml .github/workflows/lint.yml .github/workflows/test.yml`
- `git diff --check -- .github/workflows`
- verified `pnpm/action-setup@v5` and `superfly/flyctl-actions/setup-flyctl@1.6` action metadata use `node24`
- PR `⬣ Lint` and `🧪 Test` passed

## Staging
- Staging deploy is green after the Fly incident recovered
- Final PR diff is intentionally limited to action version bumps
