### PR TITLE
Align site navigation with Remix Guides

### DIFF
--- a/app/assets/remix-landing/components/landing-nav.test.browser.tsx
+++ b/app/assets/remix-landing/components/landing-nav.test.browser.tsx
@@ -1,0 +1,43 @@
+import { expect } from "remix/assert";
+import { describe, it } from "remix/test";
+import { render } from "remix/ui/test";
+
+import { routes } from "../../../routes.ts";
+import { LandingNav } from "./landing-nav.tsx";
+
+describe("LandingNav", () => {
+  it("renders the shared site links in order", (t) => {
+    let result = render(
+      <LandingNav
+        activeIndexRef={{ current: 0 }}
+        totalSections={1}
+        onJump={() => {}}
+        scrollYRef={{ current: 0 }}
+        shouldBlockBlogShortcut={() => false}
+      />,
+    );
+    t.after(result.cleanup);
+
+    let desktopNavigation = result.container.querySelector(
+      'nav[aria-label="Primary"]',
+    );
+    if (!desktopNavigation) throw new Error("Missing primary navigation");
+
+    let links = [...desktopNavigation.querySelectorAll("a")].map((link) => ({
+      href: link.getAttribute("href"),
+      label: link.textContent?.trim(),
+    }));
+
+    expect(links).toEqual([
+      { href: "https://guides.remix.run", label: "[G] guides" },
+      { href: "https://api.remix.run", label: "[A] api" },
+      { href: routes.blog.href(), label: "[B] blog" },
+      { href: routes.jam.y2026.index.href(), label: "[J] jam" },
+      { href: "https://shop.remix.run", label: "[S] store" },
+      {
+        href: "https://github.com/remix-run/remix",
+        label: "[H] github",
+      },
+    ]);
+  });
+});

--- a/app/assets/remix-landing/components/landing-nav.tsx
+++ b/app/assets/remix-landing/components/landing-nav.tsx
@@ -139,14 +139,14 @@ const svgIconStyles = css({
 const NAV_ITEMS = [
   {
     key: "G",
-    label: "github",
-    href: "https://github.com/remix-run/remix",
+    label: "guides",
+    href: "https://guides.remix.run",
     external: true,
   },
   {
-    key: "D",
-    label: "docs",
-    href: "https://api.remix.run/",
+    key: "A",
+    label: "api",
+    href: "https://api.remix.run",
     external: true,
   },
   { key: "B", label: "blog", href: routes.blog.href() },
@@ -159,7 +159,13 @@ const NAV_ITEMS = [
     href: routes.jam.y2026.index.href(),
     document: true,
   },
-  { key: "S", label: "store", href: "https://shop.remix.run/", external: true },
+  { key: "S", label: "store", href: "https://shop.remix.run", external: true },
+  {
+    key: "H",
+    label: "github",
+    href: "https://github.com/remix-run/remix",
+    external: true,
+  },
 ];
 
 type NavItem = (typeof NAV_ITEMS)[number];

--- a/app/controllers/blog/controller.test.ts
+++ b/app/controllers/blog/controller.test.ts
@@ -25,5 +25,21 @@ describe("Blog route", () => {
     );
     expect(html).toContain("Featured Articles");
     expect(html).toContain('action="/_actions/newsletter"');
+
+    let mainNavigation = html.match(/<nav aria-label="Main".*?<\/nav>/s)?.[0];
+    if (!mainNavigation) throw new Error("Missing main navigation");
+
+    let navigationLinks = [
+      ...mainNavigation.matchAll(/<a href="([^"]+)"[^>]*>([^<]+)<\/a>/g),
+    ].map((match) => ({ href: match[1], label: match[2] }));
+
+    expect(navigationLinks).toEqual([
+      { href: "https://guides.remix.run", label: "Guides" },
+      { href: "https://api.remix.run", label: "API" },
+      { href: routes.blog.href(), label: "Blog" },
+      { href: routes.jam.y2026.index.href(), label: "Jam" },
+      { href: "https://shop.remix.run", label: "Store" },
+      { href: "https://github.com/remix-run/remix", label: "GitHub" },
+    ]);
   });
 });

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -37,6 +37,29 @@
     border: 0 solid #c8c8c8;
   }
 
+  * {
+    scrollbar-color: light-dark(#d1d5db, #3f3f46) transparent;
+    scrollbar-width: thin;
+  }
+
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background: light-dark(#d1d5db, #3f3f46);
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: light-dark(#9ca3af, #52525b);
+  }
+
   ::before,
   ::after {
     --tw-content: "";

--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -1,30 +1,37 @@
 import type { Handle } from "remix/ui";
-import { cx } from "../utils/cx.ts";
 import { MobileMenu } from "../assets/mobile-menu.tsx";
 import { WordmarkLink } from "../assets/wordmark-link.tsx";
 import { routes } from "../routes.ts";
+import { theme } from "./theme.ts";
 
 const LINKS: Array<{ to: string; label: string; document?: boolean }> = [
-  { to: "https://github.com/remix-run/remix", label: "GitHub", document: true },
-  { to: "https://api.remix.run", label: "Docs", document: true },
+  { to: "https://guides.remix.run", label: "Guides", document: true },
+  { to: "https://api.remix.run", label: "API", document: true },
   { to: routes.blog.href(), label: "Blog" },
   { to: routes.jam.y2026.index.href(), label: "Jam" },
   { to: "https://shop.remix.run", label: "Store", document: true },
+  { to: "https://github.com/remix-run/remix", label: "GitHub", document: true },
 ];
 
 export function Header() {
   return () => (
-    <header class={cx("p-6", "text-rmx-primary", "relative z-50")}>
-      <div class="flex w-full items-start justify-between gap-8">
+    <header
+      class="relative z-50 h-16 pl-6 pr-4 sm:pr-6 min-[900px]:pr-[30px]"
+      style={{ fontFamily: theme.fontFamily.system }}
+    >
+      <div class="flex h-full w-full items-center justify-between gap-8">
         <WordmarkLink
           href={routes.home.href()}
           brandHref={routes.brand.href()}
-          width={164}
+          width={163}
           height={16}
           class="text-gray-900 dark:text-gray-200"
         />
 
-        <nav class="hidden items-center gap-6 md:flex" aria-label="Main">
+        <nav
+          class="hidden h-full items-center gap-5 sm:flex min-[900px]:gap-8"
+          aria-label="Main"
+        >
           {LINKS.map((link) => (
             <HeaderLink key={link.to} to={link.to} document={link.document}>
               {link.label}
@@ -32,7 +39,7 @@ export function Header() {
           ))}
         </nav>
 
-        <MobileMenu class="-mt-3 md:hidden">
+        <MobileMenu class="sm:hidden">
           {LINKS.map((link) => (
             <HeaderLink key={link.to} to={link.to} document={link.document}>
               {link.label}
@@ -51,9 +58,7 @@ function HeaderLink(
     <a
       href={handle.props.to}
       rmx-document={handle.props.document ? "" : undefined}
-      class={cx(
-        "text-rmx-primary text-sm font-semibold leading-4 tracking-[0.01em] opacity-80 hover:opacity-100",
-      )}
+      class="whitespace-nowrap text-base font-normal text-[#0074c0] hover:text-[#00304a] dark:text-[#2dacf9] dark:hover:text-[#63c2fb]"
     >
       {handle.props.children}
     </a>

--- a/app/ui/theme.ts
+++ b/app/ui/theme.ts
@@ -23,6 +23,8 @@ export const theme = {
   },
   fontFamily: {
     sans: '"Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+    system:
+      'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
     mono: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
   },
   fontWeight: {


### PR DESCRIPTION
## Summary

- align the shared site header links, typography, spacing, and logo placement with Remix Guides
- add the Guides-style thin scrollbar treatment in light and dark themes
- synchronize the homepage navigation links and ordering while preserving its distinct visual design
- cover the shared navigation order and destinations with focused tests

## Validation

- `pnpm run build`
- `pnpm exec remix test app/controllers/blog/controller.test.ts app/controllers/home/controller.test.ts app/assets/remix-landing/components/landing-nav.test.browser.tsx app/assets/mobile-menu.test.browser.tsx`
- `pnpm exec oxlint app/assets/remix-landing/components/landing-nav.test.browser.tsx app/assets/remix-landing/components/landing-nav.tsx app/controllers/blog/controller.test.ts app/ui/header.tsx app/ui/theme.ts`
