### PR TITLE
Fingerprint production assets

### DIFF
--- a/app/utils/assets.server.ts
+++ b/app/utils/assets.server.ts
@@ -18,6 +18,7 @@ export let assetServer = createAssetServer({
     "app/data/**",
     "app/middleware/**",
   ],
+  fingerprint: isDevelopment ? undefined : { buildId: getBuildId() },
   sourceMaps: isDevelopment ? "external" : undefined,
   minify: !isDevelopment,
   scripts: {
@@ -29,3 +30,13 @@ export let assetServer = createAssetServer({
   },
   watch: false,
 });
+
+function getBuildId() {
+  let buildId = process.env.ASSET_BUILD_ID || process.env.FLY_IMAGE_REF;
+  if (!buildId) {
+    throw new Error(
+      "ASSET_BUILD_ID or FLY_IMAGE_REF is required for production asset fingerprinting",
+    );
+  }
+  return buildId;
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "push:stage": "git tag -f stage && git push origin stage -f",
     "browser": "playwright-cli",
     "start": "cross-env NODE_ENV=production node --import remix/node-tsx server.ts",
-    "preview": "cross-env NODE_ENV=production node --env-file=.env --import remix/node-tsx server.ts",
+    "preview": "cross-env NODE_ENV=production ASSET_BUILD_ID=local-preview node --env-file=.env --import remix/node-tsx server.ts",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "pretest": "pnpm run build:css",


### PR DESCRIPTION
## Summary

- enable Remix asset fingerprinting in production
- use the explicit `ASSET_BUILD_ID` override or Fly's deployment-specific `FLY_IMAGE_REF`
- keep local production previews working with a local build ID

## Validation

- `pnpm run build`
- `pnpm exec oxlint . --threads=1`
- staging CI and deployment succeeded twice from the same commit
- all 44 asset references on staging were fingerprinted and served with `Cache-Control: public, max-age=31536000, immutable`
- the entry fingerprint changed across deployments (`Ykqa9K` → `lQBI6D`), confirming deployment-level cache busting

Staging workflow: https://github.com/remix-run/remix-website/actions/runs/30036670494