### PR TITLE
Add Jam 2026 promo discount handling

### DIFF
--- a/app/assets/jam/2026/tickets-modal.tsx
+++ b/app/assets/jam/2026/tickets-modal.tsx
@@ -29,6 +29,7 @@ type Jam2026TicketsModalProps = {
 
 type Jam2026TicketCheckoutState = {
   availableForSale: boolean;
+  discountCode?: string;
   error?: string;
   initialQuantity: number;
   maxQuantity: number;
@@ -348,7 +349,11 @@ export function Jam2026TicketsModalContent(
                   mix={keyringMix}
                 />
               </div>
-              <p mix={ticketsModalDiscountStyle}>Early bird discount applied</p>
+              <p mix={ticketsModalDiscountStyle}>
+                {ticketCheckout?.discountCode
+                  ? `Code ${ticketCheckout.discountCode} will be applied at checkout`
+                  : "Early bird discount applied"}
+              </p>
               <div mix={ticketsModalBottomStyle}>
                 <article
                   aria-label="Remix Jam 2026 ticket"

--- a/app/controllers/jam/2026/controller.test.ts
+++ b/app/controllers/jam/2026/controller.test.ts
@@ -17,8 +17,14 @@ import {
   getJam2026ThemePreference,
   serializeJam2026ThemePreference,
 } from "./theme-preference.server.ts";
+import {
+  getJam2026DiscountCode,
+  serializeJam2026DiscountCode,
+} from "./discount-code.server.ts";
 
-type TestStorefront = Parameters<typeof createJam2026PageHandler>[0];
+type TestStorefront = NonNullable<
+  Parameters<typeof createJam2026PageHandler>[0]
+>;
 
 describe("Remix Jam 2026 routes", () => {
   it("renders the homepage as the full Jam page with ticket frame navigation", async () => {
@@ -271,7 +277,160 @@ describe("Remix Jam 2026 routes", () => {
       "https://jam.remix.run/checkouts/2026",
     );
   });
+
+  it("stores a discount code from the URL and shows it in the ticket modal", async () => {
+    let router = createJam2026TestRouter(availableStorefront);
+
+    let response = await router.fetch(
+      "http://localhost:3000/jam/2026/ticket?discount=partner-2026",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    let setCookie = response.headers.get("Set-Cookie");
+    expect(setCookie).not.toBe(null);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Path=/jam/2026");
+    expect(setCookie).not.toContain("Max-Age");
+    expect(await getJam2026DiscountCode(setCookie!.split(";")[0])).toBe(
+      "PARTNER-2026",
+    );
+
+    let html = await response.text();
+
+    expect(html).toContain("Code PARTNER-2026 will be applied at checkout");
+  });
+
+  it("reads the stored discount code on tickets frame requests", async () => {
+    let router = createJam2026TestRouter(availableStorefront);
+    let cookie = await serializeJam2026DiscountCode("PARTNER-2026");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        headers: {
+          cookie: cookie.split(";")[0],
+          "x-remix-target": ticketModalConfig.frameName,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toBe(null);
+    expect(response.headers.get("Vary")).toContain("cookie");
+
+    let html = await response.text();
+
+    expect(html).toContain("Code PARTNER-2026 will be applied at checkout");
+  });
+
+  it("ignores malformed discount codes", async () => {
+    let router = createJam2026TestRouter(availableStorefront);
+
+    let response = await router.fetch(
+      "http://localhost:3000/jam/2026/ticket?discount=not%20a%20code",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toBe(null);
+    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
+
+    let html = await response.text();
+
+    expect(html).toContain("Early bird discount applied");
+  });
+
+  it("silently clears an inapplicable discount code", async () => {
+    let router = createJam2026TestRouter({
+      ...availableStorefront,
+      createCart: async () => ({
+        id: "gid://shopify/Cart/2026",
+        checkoutUrl: "https://jam.remix.run/checkouts/2026",
+        discountCode: undefined,
+      }),
+    });
+    let cookie = await serializeJam2026DiscountCode("EXPIRED-2026");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        headers: { cookie: cookie.split(";")[0] },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Set-Cookie")).toContain("Max-Age=0");
+
+    let html = await response.text();
+
+    expect(html).toContain("Early bird discount applied");
+    expect(html).not.toContain("EXPIRED-2026");
+  });
+
+  it("silently checks out without an inapplicable stored discount code", async () => {
+    let router = createJam2026TestRouter({
+      ...availableStorefront,
+      createCart: async () => ({
+        id: "gid://shopify/Cart/2026",
+        checkoutUrl: "https://jam.remix.run/checkouts/2026",
+        discountCode: undefined,
+      }),
+    });
+    let cookie = await serializeJam2026DiscountCode("EXPIRED-2026");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        body: createTicketFormData(),
+        headers: { cookie: cookie.split(";")[0] },
+        method: "POST",
+        redirect: "manual",
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe(
+      "https://jam.remix.run/checkouts/2026",
+    );
+    expect(response.headers.get("Set-Cookie")).toContain("Max-Age=0");
+  });
+
+  it("forwards the stored discount code to the Shopify cart", async () => {
+    let requested: string[] = [];
+    let router = createJam2026TestRouter({
+      ...availableStorefront,
+      createCart: async ({ discountCode }) => {
+        requested.push(discountCode ?? "");
+        return {
+          id: "gid://shopify/Cart/2026",
+          checkoutUrl: "https://jam.remix.run/checkouts/2026",
+          discountCode,
+        };
+      },
+    });
+    let cookie = await serializeJam2026DiscountCode("PARTNER-2026");
+
+    let response = await router.fetch(
+      new Request("http://localhost:3000/jam/2026/ticket", {
+        body: createTicketFormData(),
+        headers: { cookie: cookie.split(";")[0] },
+        method: "POST",
+        redirect: "manual",
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Set-Cookie")).toContain("Max-Age=0");
+    expect(requested).toEqual(["PARTNER-2026"]);
+  });
 });
+
+function createTicketFormData() {
+  let formData = new FormData();
+  formData.set("ticketType", remixJam2026Ticket.type);
+  formData.set("productId", "gid://shopify/ProductVariant/2026");
+  formData.set("quantity", "2");
+  return formData;
+}
 
 let unavailableStorefront = {
   createCart: async () => ({
@@ -287,10 +446,11 @@ let unavailableStorefront = {
     }),
 };
 
-let availableStorefront = {
-  createCart: async () => ({
+let availableStorefront: TestStorefront = {
+  createCart: async ({ discountCode }) => ({
     id: "gid://shopify/Cart/2026",
     checkoutUrl: "https://jam.remix.run/checkouts/2026",
+    discountCode,
   }),
   getProduct: async () =>
     parseProduct({

--- a/app/controllers/jam/2026/controller.tsx
+++ b/app/controllers/jam/2026/controller.tsx
@@ -20,6 +20,12 @@ import {
   getJam2026ThemePreference,
   serializeJam2026ThemePreference,
 } from "./theme-preference.server.ts";
+import {
+  clearJam2026DiscountCode,
+  getJam2026DiscountCode,
+  normalizeJam2026DiscountCode,
+  serializeJam2026DiscountCode,
+} from "./discount-code.server.ts";
 
 type Jam2026Storefront = {
   createCart: typeof createCart;
@@ -27,6 +33,8 @@ type Jam2026Storefront = {
 };
 
 type Jam2026StorefrontProduct = Awaited<ReturnType<typeof getProduct>>;
+
+type Jam2026Discount = { code?: string; setCookie?: string };
 
 export let jam2026Handler = createJam2026PageHandler();
 export let jam2026TicketAction = createJam2026TicketAction();
@@ -44,17 +52,29 @@ export function createJam2026TicketAction(
 ) {
   return async function jam2026TicketAction(context: AppContext) {
     let { formData, render, request } = context;
+    let discount = await resolveJam2026Discount(request);
     let product = await storefront.getProduct(remixJam2026Ticket.handle);
     let result = await handleTicketCheckoutPost({
+      discountCode: discount.code,
       formData,
       product,
       storefront,
     });
 
-    if (result instanceof Response) return result;
+    if ("checkoutUrl" in result) {
+      let headers = new SuperHeaders({
+        cacheControl: "no-store",
+        location: result.checkoutUrl,
+      });
+      if (discount.code) {
+        headers.append("Set-Cookie", await clearJam2026DiscountCode());
+      }
+      return new Response(null, { status: 303, headers });
+    }
 
     return renderJam2026Page({
       cacheControl: "no-store",
+      discount,
       render,
       request,
       status: result.status,
@@ -64,8 +84,31 @@ export function createJam2026TicketAction(
   };
 }
 
+/**
+ * Marketing links land on any Jam 2026 page with `?discount=CODE`, but the
+ * tickets modal renders from its own frame request (which has no query string),
+ * so the code is stashed in a cookie and read back at checkout time.
+ */
+async function resolveJam2026Discount(
+  request: Request,
+): Promise<Jam2026Discount> {
+  let urlCode = normalizeJam2026DiscountCode(
+    new URL(request.url).searchParams.get("discount"),
+  );
+  let storedCode = await getJam2026DiscountCode(request.headers.get("cookie"));
+
+  return {
+    code: urlCode ?? storedCode,
+    setCookie:
+      urlCode && urlCode !== storedCode
+        ? await serializeJam2026DiscountCode(urlCode)
+        : undefined,
+  };
+}
+
 async function renderJam2026Page({
   cacheControl = CACHE_CONTROL.DEFAULT,
+  discount,
   render,
   request,
   status = 200,
@@ -73,12 +116,14 @@ async function renderJam2026Page({
   ticketCheckout,
 }: {
   cacheControl?: string;
+  discount?: Jam2026Discount;
   render: AppRenderer;
   request: Request;
   status?: number;
   storefront: Jam2026Storefront;
   ticketCheckout?: ReturnType<typeof createTicketCheckoutState>;
 }) {
+  discount ??= await resolveJam2026Discount(request);
   let requestUrl = new URL(request.url);
   let ticketsModalOpen =
     requestUrl.pathname === routes.jam.y2026.ticket.index.href();
@@ -90,19 +135,30 @@ async function renderJam2026Page({
   let product = ticketsModalOpen
     ? await storefront.getProduct(remixJam2026Ticket.handle)
     : null;
+  let validatedDiscount = await validateJam2026Discount({
+    discount,
+    product,
+    storefront,
+  });
+  discount = validatedDiscount.discount;
   ticketCheckout ??= product
-    ? createTicketCheckoutState({
-        product,
-      })
+    ? createTicketCheckoutState({ product })
     : undefined;
+  if (ticketCheckout) {
+    ticketCheckout = {
+      ...ticketCheckout,
+      discountCode: validatedDiscount.code,
+    };
+  }
 
-  let responseInit = {
-    status,
-    headers: new SuperHeaders({
-      cacheControl,
-      vary: ["Cookie", "x-remix-target", "x-remix-ssr-frame"],
-    }),
-  };
+  let headers = new SuperHeaders({
+    // Never let a shared cache store a response that hands out a Set-Cookie.
+    cacheControl: discount.setCookie ? "no-store" : cacheControl,
+    vary: ["Cookie", "x-remix-target", "x-remix-ssr-frame"],
+  });
+  if (discount.setCookie) headers.append("Set-Cookie", discount.setCookie);
+
+  let responseInit = { status, headers };
 
   if (isTicketsFrameRequest) {
     return render(
@@ -161,10 +217,12 @@ let ticketCheckoutSubmissionSchema = f.object({
 });
 
 async function handleTicketCheckoutPost({
+  discountCode,
   formData,
   product,
   storefront,
 }: {
+  discountCode?: string;
   formData: FormData;
   product: Jam2026StorefrontProduct | null;
   storefront: Jam2026Storefront;
@@ -174,6 +232,7 @@ async function handleTicketCheckoutPost({
     return {
       status: 400,
       ticketCheckout: createTicketCheckoutState({
+        discountCode,
         error: submission.error,
         product,
       }),
@@ -186,6 +245,7 @@ async function handleTicketCheckoutPost({
     return {
       status: checkoutError.invalidInput ? 400 : 200,
       ticketCheckout: createTicketCheckoutState({
+        discountCode,
         error: checkoutError.message,
         initialQuantity: quantity,
         product,
@@ -193,11 +253,12 @@ async function handleTicketCheckoutPost({
     };
   }
 
-  let cart = await storefront.createCart({ productId, quantity });
+  let cart = await storefront.createCart({ discountCode, productId, quantity });
   if ("error" in cart) {
     return {
       status: 200,
       ticketCheckout: createTicketCheckoutState({
+        discountCode,
         error: cart.error,
         initialQuantity: quantity,
         product,
@@ -205,13 +266,41 @@ async function handleTicketCheckoutPost({
     };
   }
 
-  return new Response(null, {
-    status: 303,
-    headers: {
-      "Cache-Control": "no-store",
-      Location: cart.checkoutUrl,
-    },
+  return { checkoutUrl: cart.checkoutUrl };
+}
+
+async function validateJam2026Discount({
+  discount,
+  product,
+  storefront,
+}: {
+  discount: Jam2026Discount;
+  product: Jam2026StorefrontProduct | null;
+  storefront: Jam2026Storefront;
+}): Promise<{ code?: string; discount: Jam2026Discount }> {
+  if (
+    !discount.code ||
+    !product ||
+    product.unavailableReason ||
+    !product.availableForSale
+  ) {
+    return { discount };
+  }
+
+  let cart = await storefront.createCart({
+    discountCode: discount.code,
+    productId: product.productId,
+    quantity: 1,
   });
+  if ("error" in cart) return { discount };
+
+  if (cart.discountCode === discount.code) {
+    return { code: discount.code, discount };
+  }
+
+  return {
+    discount: { setCookie: await clearJam2026DiscountCode() },
+  };
 }
 
 function parseTicketCheckoutSubmission(formData: FormData) {
@@ -270,10 +359,12 @@ function getTicketCheckoutError({
 }
 
 function createTicketCheckoutState({
+  discountCode,
   error,
   initialQuantity = 1,
   product,
 }: {
+  discountCode?: string;
   error?: string;
   initialQuantity?: number;
   product: Jam2026StorefrontProduct | null;
@@ -282,6 +373,7 @@ function createTicketCheckoutState({
 
   return {
     availableForSale: Boolean(product?.availableForSale),
+    discountCode,
     error,
     initialQuantity: Math.min(Math.max(1, initialQuantity), maxQuantity),
     maxQuantity,

--- a/app/controllers/jam/2026/discount-code.server.ts
+++ b/app/controllers/jam/2026/discount-code.server.ts
@@ -1,0 +1,34 @@
+import { createCookie } from "remix/cookie";
+
+export const JAM_2026_DISCOUNT_COOKIE = "remix_jam_2026_discount";
+
+let jam2026DiscountCookie = createCookie(JAM_2026_DISCOUNT_COOKIE, {
+  httpOnly: true,
+  path: "/jam/2026",
+  sameSite: "Lax",
+  secure: process.env.NODE_ENV === "production",
+});
+
+// Shopify discount codes are case-insensitive; uppercase them so the value we
+// echo in the UI matches the value we send to the Storefront API.
+let discountCodePattern = /^[A-Z0-9][A-Z0-9_-]{0,63}$/;
+
+export function normalizeJam2026DiscountCode(value: unknown) {
+  if (typeof value !== "string") return undefined;
+  let code = value.trim().toUpperCase();
+  return discountCodePattern.test(code) ? code : undefined;
+}
+
+export async function getJam2026DiscountCode(cookieHeader: string | null) {
+  return normalizeJam2026DiscountCode(
+    await jam2026DiscountCookie.parse(cookieHeader),
+  );
+}
+
+export function serializeJam2026DiscountCode(code: string) {
+  return jam2026DiscountCookie.serialize(code);
+}
+
+export function clearJam2026DiscountCode() {
+  return jam2026DiscountCookie.serialize("", { maxAge: 0 });
+}

--- a/app/controllers/jam/2026/ui/home-page.tsx
+++ b/app/controllers/jam/2026/ui/home-page.tsx
@@ -22,6 +22,7 @@ type Jam2026HomePageProps = {
   ticketsModalOpen?: boolean;
   ticketCheckout?: {
     availableForSale: boolean;
+    discountCode?: string;
     error?: string;
     initialQuantity: number;
     maxQuantity: number;
@@ -34,6 +35,13 @@ export function Jam2026HomePage(handle: Handle<Jam2026HomePageProps>) {
   return () => {
     let { ticketsModalOpen = false } = handle.props;
     let head = getJam2026HeadContent({ ticketsModalOpen });
+    // Carry the discount code into the frame URL so the server-resolved modal
+    // shows it on the first paint, before the cookie round-trips.
+    let discountCode = handle.props.ticketCheckout?.discountCode;
+    let ticketsFrameSrc = ticketsModalOpen
+      ? routes.jam.y2026.ticket.index.href() +
+        (discountCode ? `?discount=${encodeURIComponent(discountCode)}` : "")
+      : routes.jam.y2026.index.href();
 
     return (
       <Document
@@ -72,14 +80,7 @@ export function Jam2026HomePage(handle: Handle<Jam2026HomePageProps>) {
                 ticketCheckout={handle.props.ticketCheckout}
               />
             ) : (
-              <Frame
-                name={ticketModalConfig.frameName}
-                src={
-                  ticketsModalOpen
-                    ? routes.jam.y2026.ticket.index.href()
-                    : routes.jam.y2026.index.href()
-                }
-              />
+              <Frame name={ticketModalConfig.frameName} src={ticketsFrameSrc} />
             )}
           </div>
         </div>

--- a/app/data/jam-storefront.server.test.ts
+++ b/app/data/jam-storefront.server.test.ts
@@ -40,8 +40,10 @@ describe("parseCart", () => {
     let cart = parseCart({
       id: "gid://shopify/Cart/abc",
       checkoutUrl: "https://jam.remix.run/checkout/abc",
+      discountCode: "PARTNER-2026",
     });
     expect(cart.checkoutUrl).toBe("https://jam.remix.run/checkout/abc");
+    expect(cart.discountCode).toBe("PARTNER-2026");
   });
 
   it("rejects invalid checkoutUrl", () => {

--- a/app/data/jam-storefront.server.ts
+++ b/app/data/jam-storefront.server.ts
@@ -46,6 +46,7 @@ const CartSchema = s.object({
     .string()
     .pipe(c.url())
     .refine(isTrustedCheckoutUrl, "Expected trusted checkout URL"),
+  discountCode: s.optional(s.string()),
 });
 
 const PhotoSchema = s.object({
@@ -262,10 +263,66 @@ export async function createCart(params: {
     return { error: "Failed to create cart" };
   }
 
+  let cart = data.cartCreate.cart;
+  let appliedDiscountCode = cart.discountCodes?.find(
+    (candidate: { applicable?: boolean; code?: string }) =>
+      candidate.applicable &&
+      candidate.code?.trim().toUpperCase() === discountCode,
+  )?.code;
+
+  if (discountCode && !appliedDiscountCode) {
+    let cleanCart = await removeCartDiscountCodes(storefrontClient, cart.id);
+    if (!cleanCart) return createCart({ productId, quantity });
+    cart = cleanCart;
+  }
+
   return parseCart({
-    id: data.cartCreate.cart.id,
-    checkoutUrl: data.cartCreate.cart.checkoutUrl,
+    id: cart.id,
+    checkoutUrl: cart.checkoutUrl,
+    discountCode: appliedDiscountCode?.trim().toUpperCase(),
   });
+}
+
+async function removeCartDiscountCodes(
+  storefrontClient: NonNullable<ReturnType<typeof getClient>>,
+  cartId: string,
+) {
+  const removeDiscountCodesMutation = `
+    mutation CartDiscountCodesUpdate(
+      $cartId: ID!
+      $discountCodes: [String!]!
+    ) {
+      cartDiscountCodesUpdate(
+        cartId: $cartId
+        discountCodes: $discountCodes
+      ) {
+        cart {
+          id
+          checkoutUrl
+        }
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+  `;
+
+  try {
+    let response = await storefrontClient.request(removeDiscountCodesMutation, {
+      variables: { cartId, discountCodes: [] },
+    });
+    if (
+      response.errors ||
+      response.data?.cartDiscountCodesUpdate?.userErrors?.length ||
+      !response.data?.cartDiscountCodesUpdate?.cart?.checkoutUrl
+    ) {
+      return null;
+    }
+    return response.data.cartDiscountCodesUpdate.cart;
+  } catch {
+    return null;
+  }
 }
 
 function createUnavailableProduct(


### PR DESCRIPTION
## Summary

- persist Jam 2026 promo codes in a scoped session cookie across ticket frame requests
- validate discount applicability with Shopify and silently remove inapplicable codes
- confirm valid codes in the ticket modal and clear promo state after checkout
- add focused route and Storefront cart coverage

## Validation

- `pnpm run build`
- `pnpm test -- app/controllers/jam/2026/controller.test.ts app/data/jam-storefront.server.test.ts`
- `pnpm exec oxlint app/assets/jam/2026/tickets-modal.tsx app/controllers/jam/2026/controller.test.ts app/controllers/jam/2026/controller.tsx app/controllers/jam/2026/ui/home-page.tsx app/data/jam-storefront.server.test.ts app/data/jam-storefront.server.ts app/controllers/jam/2026/discount-code.server.ts`
