### PR TITLE
perf: build the blog listing from frontmatter only

### DIFF
--- a/app/actions/blog/controller.test.ts
+++ b/app/actions/blog/controller.test.ts
@@ -42,4 +42,24 @@ describe("Blog route", () => {
       { href: "https://github.com/remix-run/remix", label: "GitHub" },
     ]);
   });
+
+  it("lists post links newest first", async () => {
+    let router = createRouteTestRouter();
+    router.map(routes.blog, blogController);
+
+    let response = await router.fetch("http://localhost:3000/blog");
+    let html = await response.text();
+
+    let main = html.match(/<main[^>]*>.*<\/main>/s)?.[0];
+    if (!main) throw new Error("Missing main content");
+
+    let postLinks = [...main.matchAll(/href="\/blog\/[^"]+"/g)];
+    expect(postLinks.length).toBeGreaterThan(1);
+
+    let dates = [
+      ...main.matchAll(/<p class="rmx-page-meta">([^<]+)<\/p>/g),
+    ].map((match) => new Date(match[1]).getTime());
+    expect(dates.length).toBeGreaterThan(1);
+    expect(dates).toEqual([...dates].sort((a, b) => b - a));
+  });
 });

--- a/app/actions/blog/controller.tsx
+++ b/app/actions/blog/controller.tsx
@@ -18,10 +18,12 @@ import { buildBlogRssResponse, getBlogRssPosts } from "./rss.ts";
 export default createController(routes.blog, {
   actions: {
     async index({ render, request }) {
-      let posts = await getBlogPostListings();
-      return render(<Page posts={posts} requestUrl={request.url} />, {
-        headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-      });
+      return render(
+        <Page posts={getBlogPostListings()} requestUrl={request.url} />,
+        {
+          headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
+        },
+      );
     },
 
     async post({ params, render, request }) {
@@ -79,7 +81,7 @@ export default createController(routes.blog, {
 
 function Page(
   handle: Handle<{
-    posts: Awaited<ReturnType<typeof getBlogPostListings>>;
+    posts: ReturnType<typeof getBlogPostListings>;
     requestUrl: string;
   }>,
 ) {
@@ -106,7 +108,7 @@ function Page(
 
 function BlogPageContent(
   handle: Handle<{
-    posts: Awaited<ReturnType<typeof getBlogPostListings>>;
+    posts: ReturnType<typeof getBlogPostListings>;
   }>,
 ) {
   return () => {

--- a/app/data/blog.ts
+++ b/app/data/blog.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { LRUCache } from "lru-cache";
+import parseFrontMatter from "front-matter";
 import yaml from "yaml";
 import { processMarkdown } from "./md.ts";
 
@@ -71,20 +72,42 @@ export async function getBlogPost(slug: string): Promise<BlogPost> {
   return post;
 }
 
-export async function getBlogPostListings(): Promise<
-  Array<MarkdownPostListing>
-> {
-  let slugs = Object.keys(postContentsBySlug);
+let postListings: Array<MarkdownPostListing> | undefined;
+
+/**
+ * The listing only renders frontmatter, so it parses frontmatter instead of
+ * running every post through the markdown/Shiki pipeline. Rendering all posts
+ * just to read their titles cost ~1.1s on the first request to /blog.
+ */
+export function getBlogPostListings(): Array<MarkdownPostListing> {
+  if (postListings) return postListings;
+
   let listings: Array<MarkdownPostListing & { date: Date }> = [];
-  for (let slug of slugs) {
-    let { ...listing } = await getBlogPost(slug);
-    if (!listing.draft) {
-      listings.push({ slug, ...listing });
-    }
+  for (let [slug, contents] of Object.entries(postContentsBySlug)) {
+    let { attributes } = parseFrontMatter(contents);
+    assert(
+      isMarkdownPostFrontmatter(attributes),
+      `Invalid post frontmatter in ${slug}`,
+    );
+    if (attributes.draft) continue;
+
+    listings.push({
+      slug,
+      title: attributes.title,
+      summary: attributes.summary,
+      date: attributes.date,
+      dateDisplay: formatDate(attributes.date),
+      image: attributes.image,
+      imageAlt: attributes.imageAlt,
+      featured: attributes.featured,
+    });
   }
-  return listings
+
+  postListings = listings
     .sort((a, b) => b.date.getTime() - a.date.getTime())
-    .map(({ ...listing }) => listing);
+    .map(({ date, ...listing }) => listing);
+
+  return postListings;
 }
 
 export function getRawBlogPostMarkdown(slug: string): string {

--- a/test/mobile-menu.test.e2e.ts
+++ b/test/mobile-menu.test.e2e.ts
@@ -3,7 +3,7 @@ import { createTestServer } from "remix/node-fetch-server/test";
 import { describe, it } from "remix/test";
 
 import { router } from "../app/router.ts";
-import { swallowAbortErrors, warmBlogPostListings } from "../test/setup.ts";
+import { swallowAbortErrors } from "../test/setup.ts";
 
 async function markPage(page: Page) {
   return page.evaluate(() => {
@@ -35,7 +35,6 @@ function mobileMenuToggle(page: Page) {
 
 describe("Mobile menu", () => {
   it("mobile menu links navigate", async (t) => {
-    await warmBlogPostListings();
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));
     await gotoMobileMenuPage(page);

--- a/test/navigation.test.e2e.ts
+++ b/test/navigation.test.e2e.ts
@@ -3,7 +3,7 @@ import { createTestServer } from "remix/node-fetch-server/test";
 import { describe, it } from "remix/test";
 
 import { router } from "../app/router.ts";
-import { swallowAbortErrors, warmBlogPostListings } from "../test/setup.ts";
+import { swallowAbortErrors } from "../test/setup.ts";
 
 async function markPage(page: Page) {
   return page.evaluate(() => {
@@ -38,7 +38,6 @@ async function expectLandingNavReady(page: Page) {
 
 describe("Navigation", () => {
   it("home/blog navigation stays client-side and applies forced dark mode", async (t) => {
-    await warmBlogPostListings();
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));
     await page.emulateMedia({ colorScheme: "dark" });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,7 +6,6 @@ import { formData } from "remix/middleware/form-data";
 import type { Router } from "remix/router";
 import { createRouter } from "remix/router";
 
-import { getBlogPostListings } from "../app/data/blog.ts";
 import { loadAssetEntry } from "../app/middleware/asset-entry.ts";
 import { renderMiddleware, type AppContext } from "../app/middleware/render.ts";
 
@@ -26,18 +25,6 @@ export function createRouteTestRouter(): Router<AppContext> {
   });
 
   return router;
-}
-
-/**
- * Renders every blog post's markdown into the server's post cache.
- *
- * The blog index renders each post through Shiki on the first request, which
- * takes ~1s locally and several seconds on CI. Client navigation updates the
- * URL before that render resolves, so asserting on the listing right after the
- * URL change otherwise races the cold render instead of the navigation.
- */
-export async function warmBlogPostListings() {
-  await getBlogPostListings();
 }
 
 export function swallowAbortErrors(r: Router) {


### PR DESCRIPTION
## Problem

`getBlogPostListings()` pushed all 42 posts through the markdown/Shiki pipeline just to read their frontmatter. The listing only renders `title`, `summary`, `date`, and `image` — the rendered HTML was thrown away.

That made the first request to `/blog` slow for every cold server process, and it's what made the client-navigation e2e assertions flaky on CI: the URL updates optimistically, so the 5s expect timeout ended up covering a ~1.1s (local) / several-seconds (CI) render.

## Change

Parse frontmatter directly and cache the result, matching what the RSS feed already does. `getBlogPost()` still uses the full pipeline for post pages, where the HTML is actually needed.

| | before | after |
|---|---|---|
| `getBlogPostListings()` cold | 1129ms | **13ms** |
| `/blog` full render cold | 1170ms | **69ms** |

Also drops the extra `html`/`authors`/`ogImage` fields the listing previously carried around unused.

## Verification

- Rendered `/blog` HTML is **byte-identical** before/after, apart from per-render hydration ids (which vary run-to-run regardless).
- Removes the e2e cache warm-up from #474 — the cold render is no longer slow enough to race those assertions. The listing's ordering is now covered by a route-level test (`lists post links newest first`) rather than depending on e2e timing.
- `pnpm run test` 148/148 pass, `pnpm run build` clean, `pnpm remix doctor` clean apart from the expected `public/` orphan-directory warnings.