### PR TITLE
Prevent landing content flash during particle loading

### DIFF
--- a/app/actions/home.test.ts
+++ b/app/actions/home.test.ts
@@ -79,6 +79,9 @@ describe("home route", () => {
     );
 
     expect(html).toMatch(/class="loading-screen-overlay\b/);
+    expect(html.indexOf("loading-screen-overlay")).toBeLessThan(
+      html.indexOf('id="remix-landing-app"'),
+    );
     expect(html).not.toContain("@keyframes loading-screen-dismiss");
   });
 });

--- a/app/actions/home.tsx
+++ b/app/actions/home.tsx
@@ -72,6 +72,7 @@ export function HomePage(handle: Handle<HomePageProps>) {
         },
       ]}
     >
+      <LoadingScreen />
       <div id="remix-landing-app" mix={[landingShellStyles]}>
         {/* Keep the initially-empty landing enhancements client entry inside
             a stable element so Remix document navigations can hydrate it after
@@ -84,7 +85,6 @@ export function HomePage(handle: Handle<HomePageProps>) {
         <main id="main-content" tabIndex={-1} mix={[landingContentStyles]}>
           <LandingContent />
         </main>
-        <LoadingScreen />
       </div>
     </Document>
   );

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -12,12 +12,21 @@ import { RestBaker } from "../engine/rest-baker.ts";
 import { getMorphBlend, type MorphBlend } from "../engine/morph.ts";
 import { createModelTexture } from "../engine/model-texture.ts";
 import type { ModelData } from "../engine/model-loader.ts";
-import type { Preset, ShaderId, SystemSettings } from "../engine/types.ts";
+import { presets } from "../engine/presets.ts";
+import {
+  DEFAULT_SETTINGS,
+  type Preset,
+  type ShaderId,
+  type SystemSettings,
+} from "../engine/types.ts";
 import { clamp, clamp01, lerp } from "../utils/math.ts";
 import { reducedMotion } from "../utils/reduced-motion.ts";
 
-// Must match `LOADING_SCREEN_MIN_MS` in `landing-enhancements.tsx`.
-const PARTICLE_INTRO_DELAY_S = 1;
+const PARTICLE_INTRO_DURATION_S = 3.5;
+const BRAND_MODE_SETTINGS: SystemSettings = {
+  ...DEFAULT_SETTINGS,
+  colorMode: 2,
+};
 const DEFAULT_CAM_POS: [number, number, number] = [0, 30, 80];
 const DEFAULT_CAM_TARGET: [number, number, number] = [0, 0, 0];
 const CAM_LERP_SPEED = 0.025;
@@ -35,10 +44,6 @@ const SHADER_ID_TO_INT: Record<ShaderId, number> = {
   racetrackCar: 4,
 };
 
-function resolveShaderInt(preset: Preset): number {
-  return SHADER_ID_TO_INT[preset.shaderId];
-}
-
 const shellStyles = css({
   position: "fixed",
   inset: "0",
@@ -51,15 +56,6 @@ const canvasStyles = css({
   width: "100%",
   height: "100%",
 });
-
-type PresetRuntimeData = {
-  presets: Preset[];
-  controls: number[][];
-  shaderInts: number[];
-  racetrackIndex: number;
-  driveIndex: number;
-  driveCarPosY: number;
-};
 
 function setDesiredCameraInto(
   presets: Preset[],
@@ -117,39 +113,31 @@ function buildInitialControls(preset: Preset): number[] {
   return controls;
 }
 
-function getControlInitial(preset: Preset, id: string, fallback = 0): number {
-  return (
-    preset.controls.find((control) => control.id === id)?.initial ?? fallback
-  );
-}
+const DRIVE_INDEX = presets.findIndex((preset) => preset.name === "Drive");
+const PRESET_RUNTIME_DATA = {
+  controls: presets.map(buildInitialControls),
+  shaderInts: presets.map((preset) => SHADER_ID_TO_INT[preset.shaderId]),
+  racetrackIndex: presets.findIndex((preset) => preset.name === "Racetrack"),
+  driveIndex: DRIVE_INDEX,
+  driveCarPosY:
+    DRIVE_INDEX >= 0
+      ? (presets[DRIVE_INDEX].controls.find(
+          (control) => control.id === "_carPosY",
+        )?.initial ?? 0)
+      : 0,
+};
 
-function buildPresetRuntimeData(presets: Preset[]): PresetRuntimeData {
-  const driveIndex = presets.findIndex((preset) => preset.name === "Drive");
-  return {
-    presets,
-    controls: presets.map(buildInitialControls),
-    shaderInts: presets.map(resolveShaderInt),
-    racetrackIndex: presets.findIndex((preset) => preset.name === "Racetrack"),
-    driveIndex,
-    driveCarPosY:
-      driveIndex >= 0
-        ? getControlInitial(presets[driveIndex], "_carPosY", 0)
-        : 0,
-  };
-}
+type ParticleCanvasProps = {
+  brandGradientMode: boolean;
+  morphValueRef: { current: number };
+  modelData: (ModelData | undefined)[];
+  labelsRef: { current: ProjectedLabel[] };
+  labelOpacityRef: { current: number };
+  onFirstFrame: () => Promise<void>;
+  onError: (error: unknown) => void;
+};
 
-export function ParticleCanvas(
-  handle: Handle<{
-    settings: SystemSettings;
-    presets: Preset[];
-    morphValueRef: { current: number };
-    modelData: (ModelData | undefined)[];
-    labelsRef: { current: ProjectedLabel[] };
-    labelOpacityRef: { current: number };
-    onReady: () => void;
-    onError: (error: unknown) => void;
-  }>,
-) {
+export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
   let containerEl: HTMLDivElement | undefined;
   let canvasEl: HTMLCanvasElement | undefined;
   let engine: Engine | null = null;
@@ -159,9 +147,11 @@ export function ParticleCanvas(
   const appliedModelSlots = new Set<number>();
   let frameId = 0;
   let startTime = 0;
+  let reveal: Promise<void> | null = null;
+  let introStartTime: number | null = null;
+  let introFinished = false;
   let frozenTime: number | null = null;
   let previousNearest = -1;
-  let hasReportedReady = false;
   let initFailed = false;
   const labelControlMgr = new ControlManager();
   const desiredCameraPos = new Vector3();
@@ -174,19 +164,6 @@ export function ParticleCanvas(
   const scratchControlsB = [0, 0, 0, 0, 0, 0, 0, 0];
   const scratchLabelControls = [0, 0, 0, 0, 0, 0, 0, 0];
   const morphBlend: MorphBlend = { fromIndex: 0, toIndex: 0, blend: 0 };
-  let presetRuntimeData: PresetRuntimeData | null = null;
-  let currentProps:
-    | {
-        settings: SystemSettings;
-        presets: Preset[];
-        morphValueRef: { current: number };
-        modelData: (ModelData | undefined)[];
-        labelsRef: { current: ProjectedLabel[] };
-        labelOpacityRef: { current: number };
-        onReady: () => void;
-        onError: (error: unknown) => void;
-      }
-    | undefined;
 
   let mouseNormX = 0;
   let mouseNormY = 0;
@@ -266,12 +243,6 @@ export function ParticleCanvas(
     },
   });
 
-  function getPresetRuntimeData(presets: Preset[]) {
-    if (presetRuntimeData?.presets === presets) return presetRuntimeData;
-    presetRuntimeData = buildPresetRuntimeData(presets);
-    return presetRuntimeData;
-  }
-
   function disposeScene() {
     cancelAnimationFrame(frameId);
     if (particles && engine) {
@@ -295,9 +266,9 @@ export function ParticleCanvas(
   });
 
   function syncModelTextures() {
-    if (!restBaker || !currentProps) return;
+    if (!restBaker) return;
 
-    for (const preset of currentProps.presets) {
+    for (const preset of presets) {
       if (
         preset.modelUrl == null ||
         preset.modelSlot == null ||
@@ -305,8 +276,7 @@ export function ParticleCanvas(
       )
         continue;
 
-      const model =
-        currentProps.modelData[currentProps.presets.indexOf(preset)];
+      const model = handle.props.modelData[presets.indexOf(preset)];
       if (!model) continue;
 
       restBaker.setModelTexture(
@@ -319,26 +289,20 @@ export function ParticleCanvas(
   }
 
   function maybeInit() {
-    if (initFailed || engine || !containerEl || !canvasEl || !currentProps) {
-      return;
-    }
+    if (initFailed || engine || !containerEl || !canvasEl) return;
 
     try {
+      const settings = handle.props.brandGradientMode
+        ? BRAND_MODE_SETTINGS
+        : DEFAULT_SETTINGS;
       engine = new Engine();
-      engine.init(canvasEl, containerEl, currentProps.settings);
+      engine.init(canvasEl, containerEl, settings);
 
-      restBaker = new RestBaker(
-        engine.renderer,
-        currentProps.settings.particleCount,
-      );
-      restBaker.setCount(currentProps.settings.particleCount);
+      restBaker = new RestBaker(engine.renderer, settings.particleCount);
+      restBaker.setCount(settings.particleCount);
 
       particles = new ParticleSystem();
-      particles.init(
-        engine.scene,
-        currentProps.settings.particleCount,
-        currentProps.settings.pointSize,
-      );
+      particles.init(engine.scene, settings.particleCount, settings.pointSize);
       // Bind the baker's MRT texture refs to the draw material once. Three
       // caches the references; subsequent bake() calls update the GL backing
       // in place.
@@ -350,10 +314,7 @@ export function ParticleCanvas(
       );
       syncModelTextures();
 
-      mouseSim = new MouseSim(
-        engine.renderer,
-        currentProps.settings.particleCount,
-      );
+      mouseSim = new MouseSim(engine.renderer, settings.particleCount);
       mouseSim.setRestTextures(
         restBaker.getPosTexture(0),
         restBaker.getPosTexture(1),
@@ -366,8 +327,8 @@ export function ParticleCanvas(
 
       startTime = performance.now() / 1000;
       setDesiredCameraInto(
-        currentProps.presets,
-        currentProps.morphValueRef.current,
+        presets,
+        handle.props.morphValueRef.current,
         desiredCameraPos,
         desiredCameraTarget,
       );
@@ -377,18 +338,17 @@ export function ParticleCanvas(
       // samples populated rest textures. This also forces the baker's
       // RawShaderMaterial to compile here, hiding the link/upload cost from
       // the first animate() frame.
-      const initialPresetData = getPresetRuntimeData(currentProps.presets);
       const initialIndex = Math.min(
-        Math.max(0, Math.floor(currentProps.morphValueRef.current)),
-        initialPresetData.presets.length - 1,
+        Math.max(0, Math.floor(handle.props.morphValueRef.current)),
+        presets.length - 1,
       );
       copyControlsInto(
-        initialPresetData.controls[initialIndex],
+        PRESET_RUNTIME_DATA.controls[initialIndex],
         scratchControlsA,
       );
       restBaker.bake(
         0,
-        initialPresetData.shaderInts[initialIndex],
+        PRESET_RUNTIME_DATA.shaderInts[initialIndex],
         scratchControlsA,
         0,
       );
@@ -400,14 +360,12 @@ export function ParticleCanvas(
     } catch (error) {
       initFailed = true;
       disposeScene();
-      currentProps.onError(error);
+      handle.props.onError(error);
       return;
     }
 
     const animate = () => {
-      if (!engine || !particles || !restBaker || !mouseSim || !currentProps) {
-        return;
-      }
+      if (!engine || !particles || !restBaker || !mouseSim) return;
 
       const now = performance.now();
       const time = now / 1000 - startTime;
@@ -417,14 +375,15 @@ export function ParticleCanvas(
       const dtSeconds =
         lastFrameNow === 0 ? 1 / 60 : (now - lastFrameNow) / 1000;
       lastFrameNow = now;
-      const settings = currentProps.settings;
-      const presets = currentProps.presets;
-      const presetData = getPresetRuntimeData(presets);
-      const morphValue = currentProps.morphValueRef.current;
+      const settings = handle.props.brandGradientMode
+        ? BRAND_MODE_SETTINGS
+        : DEFAULT_SETTINGS;
+      const presetData = PRESET_RUNTIME_DATA;
+      const morphValue = handle.props.morphValueRef.current;
       const reduceMotion = reducedMotion.current;
 
       if (reduceMotion) {
-        frozenTime ??= Math.max(time, PARTICLE_INTRO_DELAY_S + 3.5);
+        frozenTime ??= Math.max(time, PARTICLE_INTRO_DURATION_S);
       } else {
         frozenTime = null;
       }
@@ -471,10 +430,19 @@ export function ParticleCanvas(
 
       particles.setColorMode(settings.colorMode);
       particles.setDof(settings.dofAmount, settings.dofFocus);
-      const introTime = Math.max(0, visualTime - PARTICLE_INTRO_DELAY_S);
-      particles.setIntroProgress(
-        reduceMotion ? 1.5 : Math.min(introTime / 3.5, 1.5),
-      );
+      if (reduceMotion && introStartTime !== null) {
+        // Once reduced motion has skipped the intro, do not replay it if the
+        // preference changes while this component is mounted.
+        introFinished = true;
+      }
+      const introTime =
+        introStartTime === null ? 0 : Math.max(0, visualTime - introStartTime);
+      const introProgress =
+        reduceMotion || introFinished
+          ? 1.5
+          : Math.min(introTime / PARTICLE_INTRO_DURATION_S, 1.5);
+      introFinished ||= introProgress >= 1.5;
+      particles.setIntroProgress(introProgress);
       particles.setTime(visualTime);
 
       const maxValue = presets.length - 1;
@@ -689,7 +657,7 @@ export function ParticleCanvas(
         }
 
         projectLabelsInto(
-          currentProps.labelsRef.current,
+          handle.props.labelsRef.current,
           nearestPreset,
           labelControlMgr,
           activeCtrls,
@@ -700,20 +668,21 @@ export function ParticleCanvas(
         );
 
         const distFromNearest = Math.abs(morphValue - nearest);
-        currentProps.labelOpacityRef.current = Math.max(
+        handle.props.labelOpacityRef.current = Math.max(
           0,
           1 - distFromNearest * 4,
         );
       } else {
-        currentProps.labelsRef.current.length = 0;
-        currentProps.labelOpacityRef.current = 0;
+        handle.props.labelsRef.current.length = 0;
+        handle.props.labelOpacityRef.current = 0;
       }
 
       engine.render(time);
-      if (!hasReportedReady) {
-        hasReportedReady = true;
-        currentProps.onReady();
-      }
+      reveal ??= handle.props.onFirstFrame().then(() => {
+        if (!handle.signal.aborted) {
+          introStartTime = performance.now() / 1000 - startTime;
+        }
+      });
       frameId = requestAnimationFrame(animate);
     };
 
@@ -721,8 +690,6 @@ export function ParticleCanvas(
   }
 
   return () => {
-    currentProps = handle.props;
-
     if (engine) {
       syncModelTextures();
     }

--- a/app/actions/public/remix-landing/components/scroll-logo.tsx
+++ b/app/actions/public/remix-landing/components/scroll-logo.tsx
@@ -103,20 +103,19 @@ async function replaceCurrentUrl(href: string) {
 
 export function ScrollLogo(handle: Handle) {
   let largeWidth = window.innerWidth - LEFT * 2;
-  let scrollY = window.scrollY;
+  let scrollY = 0;
 
-  // Each ghost has its own lagging (width, top). Initialize flush with the
-  // main logo so nothing's visible until real motion fans them out.
-  const initialT = getScrollProgress(scrollY);
-  const initialWidth = lerp(largeWidth, SMALL_WIDTH, initialT);
-  const initialTop = lerp(LARGE_TOP, SMALL_TOP, initialT);
+  // Navigation resets scroll after creating the next page's components, so
+  // initialize for the top of the landing page instead of inheriting the
+  // previous page's scroll position.
   const ghostState = GHOST_TAUS.map(() => ({
-    width: initialWidth,
-    top: initialTop,
+    width: largeWidth,
+    top: LARGE_TOP,
   }));
 
   let rafId = 0;
   let lastTime = 0;
+  let canAnimateScroll = false;
 
   const brandMenu = brandContextMenu(routes.brand.href());
   const scrollHomeToTop = on<HTMLAnchorElement>("click", (event) => {
@@ -174,19 +173,38 @@ export function ScrollLogo(handle: Handle) {
     }
   }
 
+  function syncToScroll() {
+    scrollY = window.scrollY;
+    const t = getScrollProgress(scrollY);
+    const width = lerp(largeWidth, SMALL_WIDTH, t);
+    const top = lerp(LARGE_TOP, SMALL_TOP, t);
+    for (const ghost of ghostState) {
+      ghost.width = width;
+      ghost.top = top;
+    }
+    handle.update();
+  }
+
   function ensureLoop() {
     scrollY = window.scrollY;
-    if (rafId) {
-      // Loop is already running; it will pick up the new scrollY on the next
-      // frame. Nothing else to do.
-      return;
-    }
+    if (rafId) return;
     lastTime = 0;
     rafId = requestAnimationFrame(tick);
   }
 
+  handle.queueTask(async () => {
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    if (handle.signal.aborted) return;
+    syncToScroll();
+    canAnimateScroll = true;
+  });
+
   addEventListeners(window, handle.signal, {
-    scroll: () => ensureLoop(),
+    scroll: () => {
+      if (canAnimateScroll) ensureLoop();
+      else syncToScroll();
+    },
     resize: () => {
       largeWidth = window.innerWidth - LEFT * 2;
       ensureLoop();

--- a/app/actions/public/remix-landing/landing-enhancements.tsx
+++ b/app/actions/public/remix-landing/landing-enhancements.tsx
@@ -9,7 +9,6 @@ import { isEditableKeyTarget } from "../../../ui/public/keyboard.ts";
 import type { ProjectedLabel } from "./engine/label-projection.ts";
 import { loadModelPoints, type ModelData } from "./engine/model-loader.ts";
 import { presets } from "./engine/presets.ts";
-import { DEFAULT_SETTINGS, type SystemSettings } from "./engine/types.ts";
 import { colors } from "./styles/tokens.ts";
 import { clamp } from "./utils/math.ts";
 import {
@@ -118,13 +117,7 @@ const KONAMI_KEYS = [
 ] as const;
 
 const KONAMI_IDLE_MS = 4000;
-const LOADING_SCREEN_MIN_MS = 1000;
-const LOADING_SCREEN_SELECTOR = ".loading-screen-overlay";
-const LOADING_SCREEN_DISMISSED_CLASS = "is-dismissed";
-const BRAND_MODE_SETTINGS: SystemSettings = {
-  ...DEFAULT_SETTINGS,
-  colorMode: 2,
-};
+const LOADING_SCREEN_MIN_VISIBLE_MS = 750;
 const LANDING_SECTION_IDS = [
   "the-framework",
   "full-stack",
@@ -136,7 +129,6 @@ const LANDING_SECTION_IDS = [
 
 type ParticleCanvasComponent =
   typeof import("./components/particle-canvas.tsx").ParticleCanvas;
-type ParticleCanvasStatus = "idle" | "loaded" | "ready" | "failed";
 
 function konamiKeyMatches(event: KeyboardEvent, expected: string): boolean {
   if (expected.startsWith("Arrow")) return event.key === expected;
@@ -164,20 +156,9 @@ export let RemixLandingEnhancements = clientEntry(
       frame: 0,
       sectionStops: null as number[] | null,
     };
-    const particleCanvas: {
-      Component: ParticleCanvasComponent | null;
-      load: Promise<void> | null;
-      status: ParticleCanvasStatus;
-    } = {
-      Component: null,
-      load: null,
-      status: "idle",
-    };
-    const loadingScreen = {
-      minElapsed: false,
-      dismissed: false,
-      minTimer: null as ReturnType<typeof setTimeout> | null,
-    };
+    let ParticleCanvas: ParticleCanvasComponent | null = null;
+    let particleCanvasLoad: Promise<void> | null = null;
+    let loadingScreenDismissal: Promise<void> | null = null;
     const projectedLabelsRef = { current: [] as ProjectedLabel[] };
     const labelOpacityRef = { current: 0 };
     const morphValueRef = { current: 0 };
@@ -353,60 +334,51 @@ export let RemixLandingEnhancements = clientEntry(
       }, KONAMI_IDLE_MS);
     }
 
-    function particleCanvasHasSettled() {
-      return (
-        particleCanvas.status === "ready" || particleCanvas.status === "failed"
-      );
-    }
+    function dismissLoadingScreen() {
+      return (loadingScreenDismissal ??= (async () => {
+        const overlay = document.querySelector(".loading-screen-overlay");
+        if (!overlay) return;
 
-    function canDismissLoadingScreen() {
-      return loadingScreen.minElapsed && particleCanvasHasSettled();
-    }
+        const animation = overlay.getAnimations({ subtree: true })[0];
+        let visibleMs = LOADING_SCREEN_MIN_VISIBLE_MS;
+        if (animation) {
+          const now = Number(document.timeline.currentTime ?? 0);
+          const start = Number(animation.startTime ?? now);
+          const delay = Number(animation.effect?.getTiming().delay ?? 0);
+          visibleMs = now - start - delay;
+        }
 
-    function syncLoadingScreenDismissal() {
-      if (loadingScreen.dismissed || !canDismissLoadingScreen()) return;
+        if (visibleMs < 0) {
+          overlay.classList.add("is-skipped");
+          return;
+        }
 
-      const overlay = document.querySelector<HTMLElement>(
-        LOADING_SCREEN_SELECTOR,
-      );
-      overlay?.classList.add(LOADING_SCREEN_DISMISSED_CLASS);
-      loadingScreen.dismissed = true;
-    }
+        const remainingMs = LOADING_SCREEN_MIN_VISIBLE_MS - visibleMs;
+        if (remainingMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, remainingMs));
+        }
+        if (handle.signal.aborted) return;
 
-    function startLoadingScreenMinimumTimer() {
-      loadingScreen.minTimer = setTimeout(() => {
-        loadingScreen.minTimer = null;
-        loadingScreen.minElapsed = true;
-        syncLoadingScreenDismissal();
-      }, LOADING_SCREEN_MIN_MS);
+        overlay.classList.add("is-dismissed");
+        await overlay.getAnimations()[0]?.finished.catch(() => {});
+      })());
     }
 
     function loadParticleCanvas() {
-      particleCanvas.load ??= import("./components/particle-canvas.tsx")
+      particleCanvasLoad ??= import("./components/particle-canvas.tsx")
         .then((module) => {
-          if (handle.signal.aborted) return;
-          particleCanvas.Component = module.ParticleCanvas;
-          particleCanvas.status = "loaded";
+          if (!handle.signal.aborted) ParticleCanvas = module.ParticleCanvas;
         })
         .catch((error: unknown) => {
-          particleCanvas.status = "failed";
           console.error(error);
+          void dismissLoadingScreen();
         });
-      return particleCanvas.load;
-    }
-
-    function markParticleCanvasReady() {
-      if (particleCanvas.status === "ready") return;
-      particleCanvas.status = "ready";
-      syncLoadingScreenDismissal();
+      return particleCanvasLoad;
     }
 
     function markParticleCanvasFailed(error: unknown) {
-      if (particleCanvas.status === "failed") return;
-      particleCanvas.status = "failed";
       console.error(error);
-      syncLoadingScreenDismissal();
-      handle.update();
+      void dismissLoadingScreen();
     }
 
     function onKonamiKeydown(event: KeyboardEvent) {
@@ -436,8 +408,6 @@ export let RemixLandingEnhancements = clientEntry(
       onKonamiKeydown(event);
     }
 
-    // Body styles (margin/background/color/font-family) live in `home.css`;
-    // don't re-apply them here.
     handle.queueTask((signal) => {
       if (signal.aborted || handle.signal.aborted) return;
 
@@ -446,13 +416,9 @@ export let RemixLandingEnhancements = clientEntry(
         syncMorphToScroll();
         handle.update();
       });
-      startLoadingScreenMinimumTimer();
-
       syncMorphToScroll();
       void loadParticleCanvas().then(() => {
-        if (handle.signal.aborted) return;
-        syncLoadingScreenDismissal();
-        handle.update();
+        if (!handle.signal.aborted) handle.update();
       });
 
       addEventListeners(window, handle.signal, {
@@ -466,7 +432,6 @@ export let RemixLandingEnhancements = clientEntry(
 
       handle.signal.addEventListener("abort", () => {
         window.cancelAnimationFrame(scroll.frame);
-        if (loadingScreen.minTimer) clearTimeout(loadingScreen.minTimer);
         clearKonamiIdleTimer();
         konami.index = 0;
       });
@@ -477,23 +442,17 @@ export let RemixLandingEnhancements = clientEntry(
     return () => {
       if (!isHydrated) return null;
 
-      const settings = konami.brandMode
-        ? BRAND_MODE_SETTINGS
-        : DEFAULT_SETTINGS;
-      const ParticleCanvas = particleCanvas.Component;
-
       return (
         <div mix={[appStyles]}>
           <PackageLogos morphValueRef={morphValueRef} />
           {ParticleCanvas ? (
             <ParticleCanvas
-              settings={settings}
-              presets={presets}
+              brandGradientMode={konami.brandMode}
               morphValueRef={morphValueRef}
               modelData={modelData}
               labelsRef={projectedLabelsRef}
               labelOpacityRef={labelOpacityRef}
-              onReady={markParticleCanvasReady}
+              onFirstFrame={dismissLoadingScreen}
               onError={markParticleCanvasFailed}
             />
           ) : null}

--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -54,8 +54,21 @@ body {
   background: var(--brand-cycle);
 }
 
-/* `landing-enhancements.tsx` adds this class after the runner has shown for
- * its minimum duration and the WebGL background has rendered its first frame. */
+/* Delay the runner so fast WebGL starts can skip it without flashing. */
+@keyframes loading-screen-appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.loading-screen-overlay picture {
+  opacity: 0;
+  animation: loading-screen-appear 200ms ease-out 250ms forwards;
+}
+
 @keyframes loading-screen-dismiss {
   from {
     opacity: 1;
@@ -68,6 +81,10 @@ body {
 
 .loading-screen-overlay.is-dismissed {
   animation: loading-screen-dismiss 600ms ease-out forwards;
+}
+
+.loading-screen-overlay.is-skipped {
+  display: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/test/navigation.test.e2e.ts
+++ b/test/navigation.test.e2e.ts
@@ -125,6 +125,51 @@ describe("Navigation", () => {
     );
   });
 
+  it("does not animate the landing logo from another page's scroll position", async (t) => {
+    let handler = swallowAbortErrors(router);
+    let page = await t.serve(await createTestServer(handler));
+    await page.goto("/");
+    await expectLandingNavReady(page);
+
+    await expectClientNavigation(
+      page,
+      () =>
+        page
+          .locator('nav[aria-label="Primary"] a[href="/jam/2026"]')
+          .first()
+          .click(),
+      "**/jam/2026",
+    );
+    await page.evaluate(() =>
+      window.scrollTo(0, document.documentElement.scrollHeight),
+    );
+
+    await expectClientNavigation(
+      page,
+      () => page.locator('footer a[href="/"]').first().click(),
+      "**/",
+    );
+
+    let maxGhostOpacity = await page.evaluate(async () => {
+      let maxOpacity = 0;
+      let end = performance.now() + 500;
+      while (performance.now() < end) {
+        await new Promise(requestAnimationFrame);
+        for (let logo of document.querySelectorAll<SVGElement>(
+          '#remix-landing-app svg[viewBox="0 0 440 43"][style*="opacity"]',
+        )) {
+          maxOpacity = Math.max(
+            maxOpacity,
+            Number.parseFloat(getComputedStyle(logo).opacity),
+          );
+        }
+      }
+      return maxOpacity;
+    });
+
+    expect(maxGhostOpacity).toBe(0);
+  });
+
   it("header wordmark context menu uses client navigation for brand", async (t) => {
     let handler = swallowAbortErrors(router);
     let page = await t.serve(await createTestServer(handler));


### PR DESCRIPTION
## Summary
- keep the black loading overlay opaque while delaying only the runner graphic
- synchronize the particle intro with loading-screen dismissal without mirrored status flags
- simplify particle canvas props, preset runtime data, and loading state

## Validation
- `pnpm run build`
- `NODE_ENV=test pnpm exec remix test app/actions/home.test.ts`
- Oxlint on changed TypeScript files
- Playwright smoke tests for cold/throttled and warm loading paths