### PR TITLE
Optimize blog images with Remix assets

### DIFF
--- a/app/actions/blog/controller.test.ts
+++ b/app/actions/blog/controller.test.ts
@@ -28,7 +28,7 @@ describe("Blog route", () => {
       ...html.matchAll(/<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/g),
     ]
       .map((match) => match[0])
-      .filter((image) => image.includes('src="/blog-images/'));
+      .filter((image) => image.includes('src="/assets/blog-images/'));
     expect(articleImages.length > 1).toBe(true);
     expect(articleImages[0]).toContain('loading="eager"');
     expect(articleImages[0]).toContain('fetchpriority="high"');

--- a/app/actions/blog/controller.tsx
+++ b/app/actions/blog/controller.tsx
@@ -7,7 +7,10 @@ import { Header } from "../../ui/header.tsx";
 import { NewsletterSubscribeForm } from "../../ui/public/newsletter-subscribe.tsx";
 import { routes } from "../../routes.ts";
 import { getBlogPostListings } from "../../data/blog.ts";
-import { getBlogImageAsset } from "../../utils/blog-image-assets.ts";
+import {
+  getAuthorImageAsset,
+  getBlogImageAsset,
+} from "../../utils/blog-image-assets.ts";
 import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { getBlogPost, getRawBlogPostMarkdown } from "../../data/blog.ts";
@@ -61,12 +64,14 @@ export default createController(routes.blog, {
         throw error;
       }
 
+      let images = await loadBlogPostImages(post);
+
       return render(
         <BlogPostPage
           requestUrl={request.url}
           slug={slug}
           post={post}
-          heroImage={await getBlogImageAsset(post.image)}
+          images={images}
           socialImageUrl={getPostSocialImageUrl(post, slug, request.url)}
         />,
         { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
@@ -233,6 +238,25 @@ async function loadBlogPostListings() {
       imageAsset: await getBlogImageAsset(post.image),
     })),
   );
+}
+
+async function loadBlogPostImages(
+  post: Awaited<ReturnType<typeof getBlogPost>>,
+) {
+  let [hero, authorEntries] = await Promise.all([
+    getBlogImageAsset(post.image),
+    Promise.all(
+      post.authors.map(
+        async (author) =>
+          [author.avatar, await getAuthorImageAsset(author.avatar)] as const,
+      ),
+    ),
+  ]);
+
+  return {
+    authors: Object.fromEntries(authorEntries),
+    hero,
+  };
 }
 
 function getPostSocialImageUrl(

--- a/app/actions/blog/controller.tsx
+++ b/app/actions/blog/controller.tsx
@@ -7,6 +7,7 @@ import { Header } from "../../ui/header.tsx";
 import { NewsletterSubscribeForm } from "../../ui/public/newsletter-subscribe.tsx";
 import { routes } from "../../routes.ts";
 import { getBlogPostListings } from "../../data/blog.ts";
+import { getBlogImageAsset } from "../../utils/blog-image-assets.ts";
 import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { getBlogPost, getRawBlogPostMarkdown } from "../../data/blog.ts";
@@ -17,12 +18,11 @@ import { buildBlogRssResponse, getBlogRssPosts } from "./rss.ts";
 export default createController(routes.blog, {
   actions: {
     async index({ render, request }) {
-      return render(
-        <Page posts={getBlogPostListings()} requestUrl={request.url} />,
-        {
-          headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-        },
-      );
+      let posts = await loadBlogPostListings();
+
+      return render(<Page posts={posts} requestUrl={request.url} />, {
+        headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
+      });
     },
 
     async post({ params, render, request }) {
@@ -66,6 +66,7 @@ export default createController(routes.blog, {
           requestUrl={request.url}
           slug={slug}
           post={post}
+          heroImage={await getBlogImageAsset(post.image)}
           socialImageUrl={getPostSocialImageUrl(post, slug, request.url)}
         />,
         { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
@@ -80,7 +81,7 @@ export default createController(routes.blog, {
 
 function Page(
   handle: Handle<{
-    posts: ReturnType<typeof getBlogPostListings>;
+    posts: Awaited<ReturnType<typeof loadBlogPostListings>>;
     requestUrl: string;
   }>,
 ) {
@@ -107,7 +108,7 @@ function Page(
 
 function BlogPageContent(
   handle: Handle<{
-    posts: ReturnType<typeof getBlogPostListings>;
+    posts: Awaited<ReturnType<typeof loadBlogPostListings>>;
   }>,
 ) {
   return () => {
@@ -125,7 +126,11 @@ function BlogPageContent(
                     <div class="mb-6 aspect-[16/9]">
                       <img
                         class="mb-6 h-full w-full object-cover object-top shadow md:rounded-md"
-                        src={latestPost.image}
+                        src={latestPost.imageAsset.src}
+                        srcSet={latestPost.imageAsset.srcSet}
+                        sizes="(min-width: 1400px) 817px, (min-width: 768px) 58vw, 100vw"
+                        width={latestPost.imageAsset.width}
+                        height={latestPost.imageAsset.height}
                         alt={latestPost.imageAlt}
                         loading="eager"
                         fetchpriority="high"
@@ -147,7 +152,11 @@ function BlogPageContent(
                       <div class="mb-6 aspect-[16/9]">
                         <img
                           class="h-full w-full object-cover object-top shadow md:rounded-md"
-                          src={post.image}
+                          src={post.imageAsset.src}
+                          srcSet={post.imageAsset.srcSet}
+                          sizes="(min-width: 1400px) 397px, (min-width: 1024px) 29vw, (min-width: 768px) 58vw, 100vw"
+                          width={post.imageAsset.width}
+                          height={post.imageAsset.height}
                           alt={post.imageAlt}
                           loading="lazy"
                           decoding="async"
@@ -215,6 +224,15 @@ function BlogPageContent(
       </div>
     );
   };
+}
+
+async function loadBlogPostListings() {
+  return Promise.all(
+    getBlogPostListings().map(async (post) => ({
+      ...post,
+      imageAsset: await getBlogImageAsset(post.image),
+    })),
+  );
 }
 
 function getPostSocialImageUrl(

--- a/app/actions/blog/post-page.test.ts
+++ b/app/actions/blog/post-page.test.ts
@@ -2,7 +2,10 @@ import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 import blogController from "./controller.tsx";
 import { getBlogPost } from "../../data/blog.ts";
-import { getBlogImageAsset } from "../../utils/blog-image-assets.ts";
+import {
+  getAuthorImageAsset,
+  getBlogImageAsset,
+} from "../../utils/blog-image-assets.ts";
 import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
@@ -39,6 +42,16 @@ describe("Blog post route", () => {
       .find((image) => image.includes(`src="${heroAsset.src}"`));
     expect(heroImage).toContain('loading="eager"');
     expect(heroImage).toContain('fetchpriority="high"');
+
+    let author = post.authors[0];
+    let authorAsset = await getAuthorImageAsset(author.avatar);
+    let authorImage = [...html.matchAll(/<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/g)]
+      .map((match) => match[0])
+      .find((image) => image.includes(`src="${authorAsset.src}"`));
+    expect(authorImage).toContain('srcset="');
+    expect(authorImage).toContain('sizes="(min-width: 768px) 56px, 40px"');
+    expect(authorImage).toContain(`width="${authorAsset.width}"`);
+    expect(authorImage).toContain(`height="${authorAsset.height}"`);
   });
 
   it("returns 404 for a non-existent slug", async () => {

--- a/app/actions/blog/post-page.test.ts
+++ b/app/actions/blog/post-page.test.ts
@@ -1,8 +1,9 @@
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 import blogController from "./controller.tsx";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { getBlogPost } from "../../data/blog.ts";
+import { getBlogImageAsset } from "../../utils/blog-image-assets.ts";
+import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 
@@ -32,9 +33,10 @@ describe("Blog post route", () => {
       `href="${routes.blog.post.href({ slug: "remix-v2", ext: "md" })}"`,
     );
 
+    let heroAsset = await getBlogImageAsset(post.image);
     let heroImage = [...html.matchAll(/<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/g)]
       .map((match) => match[0])
-      .find((image) => image.includes(`src="${post.image}"`));
+      .find((image) => image.includes(`src="${heroAsset.src}"`));
     expect(heroImage).toContain('loading="eager"');
     expect(heroImage).toContain('fetchpriority="high"');
   });

--- a/app/actions/blog/post-page.tsx
+++ b/app/actions/blog/post-page.tsx
@@ -5,6 +5,7 @@ import { Footer } from "../../ui/footer.tsx";
 import { Header } from "../../ui/header.tsx";
 import { BlogLightbox } from "./public/blog-lightbox.tsx";
 import { NewsletterSubscribeForm } from "../../ui/public/newsletter-subscribe.tsx";
+import type { BlogImageAsset } from "../../utils/blog-image-assets.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { routes } from "../../routes.ts";
 import type { getBlogPost } from "../../data/blog.ts";
@@ -22,6 +23,7 @@ export function BlogPostPage(
     requestUrl: string;
     slug: string;
     post: Awaited<ReturnType<typeof getBlogPost>>;
+    heroImage: BlogImageAsset;
     socialImageUrl: string;
   }>,
 ) {
@@ -50,7 +52,10 @@ export function BlogPostPage(
     >
       <Header />
       <main id="main-content" class="flex flex-1 flex-col" tabIndex={-1}>
-        <BlogPostContent post={handle.props.post} />
+        <BlogPostContent
+          post={handle.props.post}
+          heroImage={handle.props.heroImage}
+        />
       </main>
       <Footer />
       <BlogLightbox />
@@ -59,7 +64,10 @@ export function BlogPostPage(
 }
 
 function BlogPostContent(
-  handle: Handle<{ post: Awaited<ReturnType<typeof getBlogPost>> }>,
+  handle: Handle<{
+    post: Awaited<ReturnType<typeof getBlogPost>>;
+    heroImage: BlogImageAsset;
+  }>,
 ) {
   return () => (
     <>
@@ -79,7 +87,11 @@ function BlogPostContent(
                     "h-full w-full object-cover object-top md:rounded-xl",
                     !handle.props.post.imageDisableOverlay && "opacity-40",
                   )}
-                  src={handle.props.post.image}
+                  src={handle.props.heroImage.src}
+                  srcSet={handle.props.heroImage.srcSet}
+                  sizes="(min-width: 768px) 768px, 100vw"
+                  width={handle.props.heroImage.width}
+                  height={handle.props.heroImage.height}
                   alt={handle.props.post.imageAlt}
                   loading="eager"
                   fetchpriority="high"

--- a/app/actions/blog/post-page.tsx
+++ b/app/actions/blog/post-page.tsx
@@ -10,6 +10,11 @@ import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { routes } from "../../routes.ts";
 import type { getBlogPost } from "../../data/blog.ts";
 
+interface BlogPostImageAssets {
+  authors: Record<string, BlogImageAsset>;
+  hero: BlogImageAsset;
+}
+
 export const NOT_FOUND_RESPONSE = {
   status: 404,
   statusText: "Not Found",
@@ -23,7 +28,7 @@ export function BlogPostPage(
     requestUrl: string;
     slug: string;
     post: Awaited<ReturnType<typeof getBlogPost>>;
-    heroImage: BlogImageAsset;
+    images: BlogPostImageAssets;
     socialImageUrl: string;
   }>,
 ) {
@@ -54,7 +59,7 @@ export function BlogPostPage(
       <main id="main-content" class="flex flex-1 flex-col" tabIndex={-1}>
         <BlogPostContent
           post={handle.props.post}
-          heroImage={handle.props.heroImage}
+          images={handle.props.images}
         />
       </main>
       <Footer />
@@ -66,7 +71,7 @@ export function BlogPostPage(
 function BlogPostContent(
   handle: Handle<{
     post: Awaited<ReturnType<typeof getBlogPost>>;
-    heroImage: BlogImageAsset;
+    images: BlogPostImageAssets;
   }>,
 ) {
   return () => (
@@ -87,11 +92,11 @@ function BlogPostContent(
                     "h-full w-full object-cover object-top md:rounded-xl",
                     !handle.props.post.imageDisableOverlay && "opacity-40",
                   )}
-                  src={handle.props.heroImage.src}
-                  srcSet={handle.props.heroImage.srcSet}
+                  src={handle.props.images.hero.src}
+                  srcSet={handle.props.images.hero.srcSet}
                   sizes="(min-width: 768px) 768px, 100vw"
-                  width={handle.props.heroImage.width}
-                  height={handle.props.heroImage.height}
+                  width={handle.props.images.hero.width}
+                  height={handle.props.images.hero.height}
                   alt={handle.props.post.imageAlt}
                   loading="eager"
                   fetchpriority="high"
@@ -116,26 +121,34 @@ function BlogPostContent(
                   <div class="h-2" />
                 </div>
                 <div class="flex flex-col gap-1 pb-4 md:pb-10">
-                  {handle.props.post.authors.map((author) => (
-                    <div key={author.name} class="flex items-center">
-                      <div>
-                        <img
-                          class="h-10 w-10 rounded-full md:h-14 md:w-14"
-                          src={author.avatar}
-                          alt=""
-                        />
-                      </div>
-                      <div class="w-6" />
-                      <div class="flex flex-col gap-2">
-                        <div class="rmx-page-title rmx-page-title-xs text-white">
-                          {author.name}
+                  {handle.props.post.authors.map((author) => {
+                    let image = handle.props.images.authors[author.avatar];
+                    return (
+                      <div key={author.name} class="flex items-center">
+                        <div>
+                          <img
+                            class="h-10 w-10 rounded-full md:h-14 md:w-14"
+                            src={image?.src ?? author.avatar}
+                            srcSet={image?.srcSet}
+                            sizes="(min-width: 768px) 56px, 40px"
+                            width={image?.width}
+                            height={image?.height}
+                            alt=""
+                            decoding="async"
+                          />
                         </div>
-                        <div class="rmx-page-body text-white">
-                          {author.title}
+                        <div class="w-6" />
+                        <div class="flex flex-col gap-2">
+                          <div class="rmx-page-title rmx-page-title-xs text-white">
+                            {author.name}
+                          </div>
+                          <div class="rmx-page-body text-white">
+                            {author.title}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/app/actions/blog/public/blog-lightbox.test.browser.tsx
+++ b/app/actions/blog/public/blog-lightbox.test.browser.tsx
@@ -17,7 +17,11 @@ describe("BlogLightbox", () => {
     let result = render(
       <div>
         <article class="md-prose">
-          <img src="/favicon.svg" alt="Remix logo" />
+          <img
+            src="/favicon.svg"
+            data-full-src="/full-remix-logo.svg"
+            alt="Remix logo"
+          />
         </article>
         <BlogLightbox />
       </div>,
@@ -45,7 +49,7 @@ describe("BlogLightbox", () => {
       '[aria-label="Close image preview"]',
     )!;
     expect(dialog.hidden).toBe(false);
-    expect(preview.src).toMatch(/\/favicon\.svg$/);
+    expect(preview.src).toMatch(/\/full-remix-logo\.svg$/);
     expect(preview.alt).toBe("Remix logo");
     expect(document.activeElement).toBe(close);
     expect(root.style.overflow).toBe("hidden");

--- a/app/actions/blog/public/blog-lightbox.tsx
+++ b/app/actions/blog/public/blog-lightbox.tsx
@@ -57,7 +57,10 @@ export let BlogLightbox = clientEntry(
       if (!target.closest(PROSE_SELECTOR)) return false;
       // Defer to wrapping links rather than hijacking them.
       if (target.closest("a[href]")) return false;
-      openLightbox(target.currentSrc || target.src, target.alt);
+      openLightbox(
+        target.dataset.fullSrc || target.currentSrc || target.src,
+        target.alt,
+      );
       return true;
     };
 

--- a/app/data/md.test.ts
+++ b/app/data/md.test.ts
@@ -3,15 +3,15 @@ import { describe, it } from "remix/test";
 import { processMarkdown } from "./md.ts";
 
 describe("Markdown images", () => {
-  it("defers Markdown and trusted HTML images", async () => {
+  it("optimizes and defers Markdown and trusted HTML images", async () => {
     let { html } = await processMarkdown(`
-![Markdown image](/markdown.png)
+![Markdown image](/blog-images/social-background.png)
 
 ![Reference image][reference]
 
-[reference]: /reference.png
+[reference]: /blog-images/social-background.png
 
-<img src="/html.png" alt="HTML image" />
+<img src="/blog-images/social-background.png" alt="HTML image" />
 `);
 
     let images = [...html.matchAll(/<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/g)].map(
@@ -19,6 +19,13 @@ describe("Markdown images", () => {
     );
     expect(images.length).toBe(3);
     for (let image of images) {
+      expect(image).toContain('src="/assets/blog-images/');
+      expect(image).toContain("transform=webp-1600");
+      expect(image).toContain("srcset=");
+      expect(image).toContain("sizes=");
+      expect(image).toContain('width="2400"');
+      expect(image).toContain('height="1256"');
+      expect(image).toContain("data-full-src=");
       expect(image).toContain('loading="lazy"');
       expect(image).toContain('decoding="async"');
     }

--- a/app/data/md.test.ts
+++ b/app/data/md.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "remix/assert";
 import { describe, it } from "remix/test";
+import { getBlogImageAsset } from "../utils/blog-image-assets.ts";
 import { processMarkdown } from "./md.ts";
 
 describe("Markdown images", () => {
@@ -17,6 +18,10 @@ describe("Markdown images", () => {
     let images = [...html.matchAll(/<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/g)].map(
       (match) => match[0],
     );
+    let imageAsset = await getBlogImageAsset(
+      "/blog-images/social-background.png",
+    );
+    expect(imageAsset.fullSrc).not.toContain("transform=");
     expect(images.length).toBe(3);
     for (let image of images) {
       expect(image).toContain('src="/assets/blog-images/');
@@ -25,7 +30,7 @@ describe("Markdown images", () => {
       expect(image).toContain("sizes=");
       expect(image).toContain('width="2400"');
       expect(image).toContain('height="1256"');
-      expect(image).toContain("data-full-src=");
+      expect(image).toContain(`data-full-src="${imageAsset.fullSrc}"`);
       expect(image).toContain('loading="lazy"');
       expect(image).toContain('decoding="async"');
     }

--- a/app/data/md.ts
+++ b/app/data/md.ts
@@ -14,6 +14,10 @@ import type * as Unist from "unist";
 import type * as Shiki from "shiki";
 import type * as Unified from "unified";
 import themeJson from "../../data/base16.json" with { type: "json" };
+import {
+  getBlogImageAsset,
+  type BlogImageAsset,
+} from "../utils/blog-image-assets.ts";
 
 interface ProcessorOptions {
   resolveHref?(href: string): string;
@@ -56,9 +60,10 @@ async function getProcessor(options?: ProcessorOptions) {
     .use(remarkParse)
     .use(plugins.stripLinkExtPlugin, options)
     .use(plugins.remarkCodeBlocksShiki, options)
-    .use(plugins.lazyImages)
+    .use(plugins.rawBlogImages)
     .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
+    .use(plugins.blogImages)
     .use(rehypeStringify, { allowDangerousHtml: true })
     .use(rehypeSlug)
     .use(rehypeAutolinkHeadings);
@@ -97,37 +102,38 @@ async function loadPlugins() {
     };
   };
 
-  const lazyImages: InternalPlugin<UnistNode.Root, UnistNode.Root> = () => {
-    return function transformer(tree: UnistNode.Root) {
-      let deferImage = (node: Unist.Node) => {
-        let data = (node.data ?? {}) as Unist.Data & {
-          hProperties?: Record<string, unknown>;
-        };
-        data.hProperties = {
-          loading: "lazy",
-          decoding: "async",
-          ...data.hProperties,
-        };
-        node.data = data;
-      };
-
-      visit(tree, "image", deferImage);
-      visit(tree, "imageReference", deferImage);
+  const rawBlogImages: InternalPlugin<UnistNode.Root, UnistNode.Root> = () => {
+    return async function transformer(tree: UnistNode.Root) {
+      let tasks: Promise<void>[] = [];
       visit(tree, "html", (node: UnistNode.Html) => {
-        node.value = node.value.replace(
-          /<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi,
-          (tag) => {
-            let attributes = "";
-            if (!/\sloading\s*=/i.test(tag)) {
-              attributes += ' loading="lazy"';
-            }
-            if (!/\sdecoding\s*=/i.test(tag)) {
-              attributes += ' decoding="async"';
-            }
-            return tag.replace(/^<img\b/i, `<img${attributes}`);
-          },
+        tasks.push(
+          transformRawBlogImages(node.value).then((value) => {
+            node.value = value;
+          }),
         );
       });
+      await Promise.all(tasks);
+    };
+  };
+
+  const blogImages: InternalPlugin<Hast.Root, Hast.Root> = () => {
+    return async function transformer(tree: Hast.Root) {
+      let tasks: Promise<void>[] = [];
+      visit(tree, "element", (node: Hast.Element) => {
+        if (node.tagName !== "img") return;
+        let source = node.properties?.src;
+        if (typeof source !== "string") return;
+
+        tasks.push(
+          getBlogImageAsset(source).then((asset) => {
+            node.properties = getBlogImageProperties(
+              node.properties ?? {},
+              asset,
+            );
+          }),
+        );
+      });
+      await Promise.all(tasks);
     };
   };
 
@@ -344,13 +350,110 @@ async function loadPlugins() {
   };
 
   return {
-    stripLinkExtPlugin,
-    lazyImages,
+    blogImages,
+    rawBlogImages,
     remarkCodeBlocksShiki,
+    stripLinkExtPlugin,
   };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+const BLOG_IMAGE_SIZES = "(min-width: 768px) 768px, 100vw";
+const RAW_IMAGE_PATTERN = /<img\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+
+function getBlogImageProperties(
+  properties: Hast.Properties,
+  asset: BlogImageAsset,
+): Hast.Properties {
+  let next: Hast.Properties = {
+    ...properties,
+    decoding: properties.decoding ?? "async",
+    loading: properties.loading ?? "lazy",
+    src: asset.src,
+  };
+
+  if (asset.width && properties.width == null) next.width = asset.width;
+  if (asset.height && properties.height == null) next.height = asset.height;
+  if (asset.srcSet) {
+    next.srcSet = asset.srcSet;
+    next.sizes = properties.sizes ?? BLOG_IMAGE_SIZES;
+    next["data-full-src"] = asset.src;
+  }
+
+  return next;
+}
+
+async function transformRawBlogImages(html: string): Promise<string> {
+  let matches = [...html.matchAll(RAW_IMAGE_PATTERN)];
+  if (matches.length === 0) return html;
+
+  let replacements = await Promise.all(
+    matches.map(async (match) => {
+      let source = getHtmlAttribute(match[0], "src");
+      let asset = source ? await getBlogImageAsset(source) : undefined;
+      let tag = setHtmlAttribute(match[0], "loading", "lazy", false);
+      tag = setHtmlAttribute(tag, "decoding", "async", false);
+      if (!asset) return tag;
+
+      tag = setHtmlAttribute(tag, "src", asset.src);
+      if (asset.width) {
+        tag = setHtmlAttribute(tag, "width", String(asset.width), false);
+      }
+      if (asset.height) {
+        tag = setHtmlAttribute(tag, "height", String(asset.height), false);
+      }
+      if (asset.srcSet) {
+        tag = setHtmlAttribute(tag, "srcset", asset.srcSet);
+        tag = setHtmlAttribute(tag, "sizes", BLOG_IMAGE_SIZES, false);
+        tag = setHtmlAttribute(tag, "data-full-src", asset.src);
+      }
+      return tag;
+    }),
+  );
+
+  let output = "";
+  let offset = 0;
+  for (let [index, match] of matches.entries()) {
+    let matchIndex = match.index ?? offset;
+    output += html.slice(offset, matchIndex);
+    output += replacements[index];
+    offset = matchIndex + match[0].length;
+  }
+  return output + html.slice(offset);
+}
+
+function getHtmlAttribute(tag: string, name: string): string | undefined {
+  let match = tag.match(
+    new RegExp(`\\s${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, "i"),
+  );
+  return match?.[1] ?? match?.[2];
+}
+
+function setHtmlAttribute(
+  tag: string,
+  name: string,
+  value: string,
+  overwrite = true,
+): string {
+  let pattern = new RegExp(
+    `\\s${name}\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+)`,
+    "i",
+  );
+  if (pattern.test(tag)) {
+    return overwrite
+      ? tag.replace(pattern, ` ${name}="${escapeHtmlAttribute(value)}"`)
+      : tag;
+  }
+  return tag.replace(
+    /^<img\b/i,
+    `<img ${name}="${escapeHtmlAttribute(value)}"`,
+  );
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+}
 
 function parseLineHighlights(param: string | null) {
   if (!param) return [];

--- a/app/data/md.ts
+++ b/app/data/md.ts
@@ -378,8 +378,8 @@ function getBlogImageProperties(
   if (asset.srcSet) {
     next.srcSet = asset.srcSet;
     next.sizes = properties.sizes ?? BLOG_IMAGE_SIZES;
-    next["data-full-src"] = asset.src;
   }
+  if (asset.fullSrc) next["data-full-src"] = asset.fullSrc;
 
   return next;
 }
@@ -406,7 +406,9 @@ async function transformRawBlogImages(html: string): Promise<string> {
       if (asset.srcSet) {
         tag = setHtmlAttribute(tag, "srcset", asset.srcSet);
         tag = setHtmlAttribute(tag, "sizes", BLOG_IMAGE_SIZES, false);
-        tag = setHtmlAttribute(tag, "data-full-src", asset.src);
+      }
+      if (asset.fullSrc) {
+        tag = setHtmlAttribute(tag, "data-full-src", asset.fullSrc);
       }
       return tag;
     }),

--- a/app/utils/assets.test.ts
+++ b/app/utils/assets.test.ts
@@ -37,20 +37,21 @@ describe("browser asset boundary", () => {
     expect(failures).toEqual([]);
   });
 
-  it("serves constrained WebP transforms for blog images", async () => {
-    let imagePath = path.join(
-      rootDir,
-      "public/blog-images/social-background.png",
-    );
-    let href = await assets.getHref(imagePath, {
-      transform: ["webp-480"],
-    });
-    let response = await assets.fetch(
-      new Request(new URL(href, "http://localhost")),
-    );
+  it("serves constrained WebP transforms for blog and author images", async () => {
+    for (let [imagePath, transform] of [
+      ["public/blog-images/social-background.png", "webp-480"],
+      ["public/authors/profile-jacob-ebey.png", "webp-128"],
+    ] as const) {
+      let href = await assets.getHref(path.join(rootDir, imagePath), {
+        transform: [transform],
+      });
+      let response = await assets.fetch(
+        new Request(new URL(href, "http://localhost")),
+      );
 
-    expect(response?.status).toBe(200);
-    expect(response?.headers.get("Content-Type")).toBe("image/webp");
+      expect(response?.status).toBe(200);
+      expect(response?.headers.get("Content-Type")).toBe("image/webp");
+    }
 
     let invalidResponse = await assets.fetch(
       new Request(

--- a/app/utils/assets.test.ts
+++ b/app/utils/assets.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
-import { assets } from "./assets.ts";
+import { assets, getWebpHref } from "./assets.ts";
 
 let rootDir = path.resolve(import.meta.dirname, "../..");
 let appDir = path.join(rootDir, "app");
@@ -38,13 +38,11 @@ describe("browser asset boundary", () => {
   });
 
   it("serves constrained WebP transforms for blog and author images", async () => {
-    for (let [imagePath, transform] of [
-      ["public/blog-images/social-background.png", "webp-480"],
-      ["public/authors/profile-jacob-ebey.png", "webp-128"],
+    for (let [imagePath, width] of [
+      ["public/blog-images/social-background.png", 480],
+      ["public/authors/profile-jacob-ebey.png", 128],
     ] as const) {
-      let href = await assets.getHref(path.join(rootDir, imagePath), {
-        transform: [transform],
-      });
+      let href = await getWebpHref(path.join(rootDir, imagePath), width);
       let response = await assets.fetch(
         new Request(new URL(href, "http://localhost")),
       );
@@ -62,6 +60,9 @@ describe("browser asset boundary", () => {
       ),
     );
     expect(invalidResponse?.status).toBe(400);
+    expect(() =>
+      getWebpHref("public/blog-images/social-background.png", 999),
+    ).toThrow("Unsupported responsive image width: 999");
   });
 
   it("does not expose server or test source", async () => {

--- a/app/utils/assets.test.ts
+++ b/app/utils/assets.test.ts
@@ -37,6 +37,32 @@ describe("browser asset boundary", () => {
     expect(failures).toEqual([]);
   });
 
+  it("serves constrained WebP transforms for blog images", async () => {
+    let imagePath = path.join(
+      rootDir,
+      "public/blog-images/social-background.png",
+    );
+    let href = await assets.getHref(imagePath, {
+      transform: ["webp-480"],
+    });
+    let response = await assets.fetch(
+      new Request(new URL(href, "http://localhost")),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("Content-Type")).toBe("image/webp");
+
+    let invalidResponse = await assets.fetch(
+      new Request(
+        new URL(
+          "/assets/blog-images/social-background.png?transform=webp-999",
+          "http://localhost",
+        ),
+      ),
+    );
+    expect(invalidResponse?.status).toBe(400);
+  });
+
   it("does not expose server or test source", async () => {
     for (let pathname of [
       "/assets/app/router.ts",

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -12,6 +12,15 @@ let isHmr = Boolean(isDevelopment && process.env.REMIX_NODE_HMR);
 let rootDir = path.resolve(import.meta.dirname, "../..");
 let buildId = isProduction ? getBuildId() : undefined;
 let webpInputExtensions = [".jpeg", ".jpg", ".png"] as const;
+let webpTransforms = {
+  webp: createWebpTransform(),
+  "webp-64": createWebpTransform(64),
+  "webp-128": createWebpTransform(128),
+  "webp-480": createWebpTransform(480),
+  "webp-768": createWebpTransform(768),
+  "webp-1200": createWebpTransform(1200),
+  "webp-1600": createWebpTransform(1600),
+};
 
 export let assets = createAssetServer({
   basePath: "/assets",
@@ -49,15 +58,7 @@ export let assets = createAssetServer({
     ),
     extensions: [".avif", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"],
     maxRequestTransforms: 1,
-    transforms: {
-      webp: createWebpTransform(),
-      "webp-64": createWebpTransform(64),
-      "webp-128": createWebpTransform(128),
-      "webp-480": createWebpTransform(480),
-      "webp-768": createWebpTransform(768),
-      "webp-1200": createWebpTransform(1200),
-      "webp-1600": createWebpTransform(1600),
-    },
+    transforms: webpTransforms,
   },
   sourceMaps: isDevelopment ? "external" : undefined,
   minify: isProduction,
@@ -73,6 +74,17 @@ export let assets = createAssetServer({
   },
   watch: isDevelopment,
 });
+
+export function getWebpHref(filePath: string, width?: number) {
+  let transform = width === undefined ? "webp" : `webp-${width}`;
+  if (!Object.hasOwn(webpTransforms, transform)) {
+    throw new TypeError(`Unsupported responsive image width: ${width}`);
+  }
+
+  return assets.getHref(filePath, {
+    transform: [transform as keyof typeof webpTransforms],
+  });
+}
 
 function createWebpTransform(width?: number) {
   return defineFileTransform({

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -18,10 +18,16 @@ export let assets = createAssetServer({
   rootDir,
   fileMap: {
     "/app/*path": "app/*path",
+    "/authors/*path": "public/authors/*path",
     "/blog-images/*path": "public/blog-images/*path",
     "/npm/*path": "node_modules/*path",
   },
-  allowFiles: ["app/routes.ts", "app/**/public/**", "public/blog-images/**"],
+  allowFiles: [
+    "app/routes.ts",
+    "app/**/public/**",
+    "public/authors/**",
+    "public/blog-images/**",
+  ],
   allowPackages: ["remix", "three", "fathom-client"],
   denyFiles: ["app/**/*.test.*"],
   target: {
@@ -45,6 +51,8 @@ export let assets = createAssetServer({
     maxRequestTransforms: 1,
     transforms: {
       webp: createWebpTransform(),
+      "webp-64": createWebpTransform(64),
+      "webp-128": createWebpTransform(128),
       "webp-480": createWebpTransform(480),
       "webp-768": createWebpTransform(768),
       "webp-1200": createWebpTransform(1200),

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -1,21 +1,27 @@
+import * as os from "node:os";
 import * as path from "node:path";
-import { createAssetServer } from "remix/assets";
+import { createAssetServer, defineFileTransform } from "remix/assets";
+import { createFsFileStorage } from "remix/file-storage/fs";
 import { uiHmr } from "remix/ui-hmr/assets";
+import sharp from "sharp";
 
 let nodeEnv = process.env.NODE_ENV ?? "development";
 let isDevelopment = nodeEnv === "development";
 let isProduction = nodeEnv === "production";
 let isHmr = Boolean(isDevelopment && process.env.REMIX_NODE_HMR);
 let rootDir = path.resolve(import.meta.dirname, "../..");
+let buildId = isProduction ? getBuildId() : undefined;
+let webpInputExtensions = [".jpeg", ".jpg", ".png"] as const;
 
 export let assets = createAssetServer({
   basePath: "/assets",
   rootDir,
   fileMap: {
     "/app/*path": "app/*path",
+    "/blog-images/*path": "public/blog-images/*path",
     "/npm/*path": "node_modules/*path",
   },
-  allowFiles: ["app/routes.ts", "app/**/public/**"],
+  allowFiles: ["app/routes.ts", "app/**/public/**", "public/blog-images/**"],
   allowPackages: ["remix", "three", "fathom-client"],
   denyFiles: ["app/**/*.test.*"],
   target: {
@@ -24,7 +30,27 @@ export let assets = createAssetServer({
     firefox: "115",
     safari: "16.4",
   },
-  fingerprint: isProduction ? { buildId: getBuildId() } : undefined,
+  fingerprint: buildId ? { buildId } : undefined,
+  files: {
+    cache: createFsFileStorage(
+      path.join(
+        os.tmpdir(),
+        "remix-website-assets",
+        buildId
+          ? Buffer.from(buildId).toString("base64url")
+          : `process-${process.pid}`,
+      ),
+    ),
+    extensions: [".avif", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"],
+    maxRequestTransforms: 1,
+    transforms: {
+      webp: createWebpTransform(),
+      "webp-480": createWebpTransform(480),
+      "webp-768": createWebpTransform(768),
+      "webp-1200": createWebpTransform(1200),
+      "webp-1600": createWebpTransform(1600),
+    },
+  },
   sourceMaps: isDevelopment ? "external" : undefined,
   minify: isProduction,
   hmr: isHmr
@@ -39,6 +65,25 @@ export let assets = createAssetServer({
   },
   watch: isDevelopment,
 });
+
+function createWebpTransform(width?: number) {
+  return defineFileTransform({
+    extensions: webpInputExtensions,
+    async transform(bytes) {
+      let image = sharp(bytes).rotate();
+      if (width) {
+        image.resize({ width, withoutEnlargement: true });
+      }
+
+      let content = await image
+        .webp({ quality: 85, smartSubsample: true })
+        .toBuffer();
+      if (!width && content.byteLength >= bytes.byteLength) return bytes;
+
+      return { content, extension: ".webp" };
+    },
+  });
+}
 
 function getBuildId() {
   let buildId = process.env.ASSET_BUILD_ID || process.env.FLY_IMAGE_REF;

--- a/app/utils/blog-image-assets.test.ts
+++ b/app/utils/blog-image-assets.test.ts
@@ -1,0 +1,13 @@
+import { expect } from "remix/assert";
+import { describe, it } from "remix/test";
+
+import { getBlogImageAsset } from "./blog-image-assets.ts";
+
+describe("Blog image assets", () => {
+  it("falls back to the original source when optimization fails", async (t) => {
+    t.mock.method(console, "error", () => {});
+    let source = "/blog-images/does-not-exist.png";
+
+    expect(await getBlogImageAsset(source)).toEqual({ src: source });
+  });
+});

--- a/app/utils/blog-image-assets.ts
+++ b/app/utils/blog-image-assets.ts
@@ -4,55 +4,77 @@ import sharp, { type Metadata } from "sharp";
 import { assets } from "./assets.ts";
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "../..");
+const AVATAR_WIDTHS = [64, 128] as const;
 const RESPONSIVE_WIDTHS = [480, 768, 1200, 1600] as const;
 const TRANSFORMABLE_EXTENSIONS = new Set([".jpeg", ".jpg", ".png"]);
 
 type WebpTransform =
   | "webp"
+  | "webp-64"
+  | "webp-128"
   | "webp-480"
   | "webp-768"
   | "webp-1200"
   | "webp-1600";
 
 export interface BlogImageAsset {
+  fullSrc?: string;
   height?: number;
   src: string;
   srcSet?: string;
   width?: number;
 }
 
-let assetBySource = new Map<string, Promise<BlogImageAsset>>();
+let authorAssetBySource = new Map<string, Promise<BlogImageAsset>>();
+let blogAssetBySource = new Map<string, Promise<BlogImageAsset>>();
 
-export function getBlogImageAsset(source: string): Promise<BlogImageAsset> {
-  let existing = assetBySource.get(source);
+export function getAuthorImageAsset(source: string): Promise<BlogImageAsset> {
+  let existing = authorAssetBySource.get(source);
   if (existing) return existing;
 
-  let asset = createBlogImageAsset(source);
-  assetBySource.set(source, asset);
+  let asset = createImageAsset(source, "/authors/", AVATAR_WIDTHS, false);
+  authorAssetBySource.set(source, asset);
   return asset;
 }
 
-async function createBlogImageAsset(source: string): Promise<BlogImageAsset> {
-  if (!source.startsWith("/blog-images/")) return { src: source };
+export function getBlogImageAsset(source: string): Promise<BlogImageAsset> {
+  let existing = blogAssetBySource.get(source);
+  if (existing) return existing;
+
+  let asset = createImageAsset(
+    source,
+    "/blog-images/",
+    RESPONSIVE_WIDTHS,
+    true,
+  );
+  blogAssetBySource.set(source, asset);
+  return asset;
+}
+
+async function createImageAsset(
+  source: string,
+  sourcePrefix: string,
+  responsiveWidths: readonly number[],
+  preserveFullSource: boolean,
+): Promise<BlogImageAsset> {
+  if (!source.startsWith(sourcePrefix)) return { src: source };
 
   let pathname = new URL(source, "https://remix.run").pathname;
   let filePath = `public${decodeURIComponent(pathname)}`;
   let extension = path.extname(filePath).toLowerCase();
-  let metadata = await sharp(path.join(ROOT_DIR, filePath)).metadata();
+  let [metadata, originalSrc] = await Promise.all([
+    sharp(path.join(ROOT_DIR, filePath)).metadata(),
+    assets.getHref(filePath),
+  ]);
   let dimensions = getOrientedDimensions(metadata);
 
   if (!TRANSFORMABLE_EXTENSIONS.has(extension) || !dimensions.width) {
-    return {
-      ...dimensions,
-      src: await assets.getHref(filePath),
-    };
+    return { ...dimensions, src: originalSrc };
   }
 
   let sourceWidth = dimensions.width;
-  let outputWidths: number[] = RESPONSIVE_WIDTHS.filter(
-    (width) => width < sourceWidth,
-  );
-  if (sourceWidth <= RESPONSIVE_WIDTHS.at(-1)!) {
+  let outputWidths = responsiveWidths.filter((width) => width < sourceWidth);
+  if (sourceWidth <= responsiveWidths.at(-1)!) {
     outputWidths.push(sourceWidth);
   }
 
@@ -65,15 +87,11 @@ async function createBlogImageAsset(source: string): Promise<BlogImageAsset> {
     })),
   );
   let largest = variants.at(-1);
-  if (!largest) {
-    return {
-      ...dimensions,
-      src: await assets.getHref(filePath),
-    };
-  }
+  if (!largest) return { ...dimensions, src: originalSrc };
 
   return {
     ...dimensions,
+    fullSrc: preserveFullSource ? originalSrc : undefined,
     src: largest.href,
     srcSet:
       variants.length > 1
@@ -85,6 +103,10 @@ async function createBlogImageAsset(source: string): Promise<BlogImageAsset> {
 function getWebpTransform(width: number, sourceWidth: number): WebpTransform {
   if (width === sourceWidth) return "webp";
   switch (width) {
+    case 64:
+      return "webp-64";
+    case 128:
+      return "webp-128";
     case 480:
       return "webp-480";
     case 768:

--- a/app/utils/blog-image-assets.ts
+++ b/app/utils/blog-image-assets.ts
@@ -1,21 +1,10 @@
 import * as path from "node:path";
 import sharp, { type Metadata } from "sharp";
+import { createMatcher } from "remix/route-pattern/match";
 
-import { assets } from "./assets.ts";
+import { assets, getWebpHref } from "./assets.ts";
 
-const ROOT_DIR = path.resolve(import.meta.dirname, "../..");
-const AVATAR_WIDTHS = [64, 128] as const;
-const RESPONSIVE_WIDTHS = [480, 768, 1200, 1600] as const;
-const TRANSFORMABLE_EXTENSIONS = new Set([".jpeg", ".jpg", ".png"]);
-
-type WebpTransform =
-  | "webp"
-  | "webp-64"
-  | "webp-128"
-  | "webp-480"
-  | "webp-768"
-  | "webp-1200"
-  | "webp-1600";
+let imageSourceMatcher = createMatcher("http(s)://remix.run/:directory/*path");
 
 export interface BlogImageAsset {
   fullSrc?: string;
@@ -32,7 +21,7 @@ export function getAuthorImageAsset(source: string): Promise<BlogImageAsset> {
   let existing = authorAssetBySource.get(source);
   if (existing) return existing;
 
-  let asset = createImageAsset(source, "/authors/", AVATAR_WIDTHS, false);
+  let asset = createImageAsset(source, "authors", [64, 128]);
   authorAssetBySource.set(source, asset);
   return asset;
 }
@@ -41,82 +30,70 @@ export function getBlogImageAsset(source: string): Promise<BlogImageAsset> {
   let existing = blogAssetBySource.get(source);
   if (existing) return existing;
 
-  let asset = createImageAsset(
-    source,
-    "/blog-images/",
-    RESPONSIVE_WIDTHS,
-    true,
-  );
+  let asset = createImageAsset(source, "blog-images", [480, 768, 1200, 1600]);
   blogAssetBySource.set(source, asset);
   return asset;
 }
 
 async function createImageAsset(
   source: string,
-  sourcePrefix: string,
+  directory: "authors" | "blog-images",
   responsiveWidths: readonly number[],
-  preserveFullSource: boolean,
 ): Promise<BlogImageAsset> {
-  if (!source.startsWith(sourcePrefix)) return { src: source };
+  let fallback: BlogImageAsset = { src: source };
 
-  let pathname = new URL(source, "https://remix.run").pathname;
-  let filePath = `public${decodeURIComponent(pathname)}`;
-  let extension = path.extname(filePath).toLowerCase();
-  let [metadata, originalSrc] = await Promise.all([
-    sharp(path.join(ROOT_DIR, filePath)).metadata(),
-    assets.getHref(filePath),
-  ]);
-  let dimensions = getOrientedDimensions(metadata);
+  try {
+    let match = imageSourceMatcher.match(source, {
+      baseURL: "https://remix.run",
+    });
+    if (match?.params.directory !== directory) return fallback;
 
-  if (!TRANSFORMABLE_EXTENSIONS.has(extension) || !dimensions.width) {
-    return { ...dimensions, src: originalSrc };
-  }
+    let filePath = path.join("public", directory, match.params.path);
+    let extension = path.extname(filePath).toLowerCase();
+    let [metadata, originalSrc] = await Promise.all([
+      sharp(path.resolve(import.meta.dirname, "../..", filePath)).metadata(),
+      assets.getHref(filePath),
+    ]);
+    let dimensions = getOrientedDimensions(metadata);
+    fallback = { ...dimensions, src: originalSrc };
 
-  let sourceWidth = dimensions.width;
-  let outputWidths = responsiveWidths.filter((width) => width < sourceWidth);
-  if (sourceWidth <= responsiveWidths.at(-1)!) {
-    outputWidths.push(sourceWidth);
-  }
+    if (![".jpeg", ".jpg", ".png"].includes(extension) || !dimensions.width) {
+      return fallback;
+    }
 
-  let variants = await Promise.all(
-    outputWidths.map(async (width) => ({
-      href: await assets.getHref(filePath, {
-        transform: [getWebpTransform(width, sourceWidth)],
-      }),
-      width,
-    })),
-  );
-  let largest = variants.at(-1);
-  if (!largest) return { ...dimensions, src: originalSrc };
+    let sourceWidth = dimensions.width;
+    let outputWidths = responsiveWidths.filter((width) => width < sourceWidth);
+    if (sourceWidth <= responsiveWidths.at(-1)!) {
+      outputWidths.push(sourceWidth);
+    }
 
-  return {
-    ...dimensions,
-    fullSrc: preserveFullSource ? originalSrc : undefined,
-    src: largest.href,
-    srcSet:
-      variants.length > 1
-        ? variants.map(({ href, width }) => `${href} ${width}w`).join(", ")
-        : undefined,
-  };
-}
+    let variants = await Promise.all(
+      outputWidths.map(async (width) => ({
+        href: await getWebpHref(
+          filePath,
+          width === sourceWidth ? undefined : width,
+        ),
+        width,
+      })),
+    );
+    let largest = variants.at(-1);
+    if (!largest) return fallback;
 
-function getWebpTransform(width: number, sourceWidth: number): WebpTransform {
-  if (width === sourceWidth) return "webp";
-  switch (width) {
-    case 64:
-      return "webp-64";
-    case 128:
-      return "webp-128";
-    case 480:
-      return "webp-480";
-    case 768:
-      return "webp-768";
-    case 1200:
-      return "webp-1200";
-    case 1600:
-      return "webp-1600";
-    default:
-      throw new TypeError(`Unsupported responsive image width: ${width}`);
+    return {
+      ...dimensions,
+      fullSrc: directory === "blog-images" ? originalSrc : undefined,
+      src: largest.href,
+      srcSet:
+        variants.length > 1
+          ? variants.map(({ href, width }) => `${href} ${width}w`).join(", ")
+          : undefined,
+    };
+  } catch (error) {
+    console.error(
+      `Failed to optimize image "${source}"; using its original source.`,
+      error,
+    );
+    return fallback;
   }
 }
 

--- a/app/utils/blog-image-assets.ts
+++ b/app/utils/blog-image-assets.ts
@@ -1,0 +1,118 @@
+import * as path from "node:path";
+import sharp, { type Metadata } from "sharp";
+
+import { assets } from "./assets.ts";
+
+const ROOT_DIR = path.resolve(import.meta.dirname, "../..");
+const RESPONSIVE_WIDTHS = [480, 768, 1200, 1600] as const;
+const TRANSFORMABLE_EXTENSIONS = new Set([".jpeg", ".jpg", ".png"]);
+
+type WebpTransform =
+  | "webp"
+  | "webp-480"
+  | "webp-768"
+  | "webp-1200"
+  | "webp-1600";
+
+export interface BlogImageAsset {
+  height?: number;
+  src: string;
+  srcSet?: string;
+  width?: number;
+}
+
+let assetBySource = new Map<string, Promise<BlogImageAsset>>();
+
+export function getBlogImageAsset(source: string): Promise<BlogImageAsset> {
+  let existing = assetBySource.get(source);
+  if (existing) return existing;
+
+  let asset = createBlogImageAsset(source);
+  assetBySource.set(source, asset);
+  return asset;
+}
+
+async function createBlogImageAsset(source: string): Promise<BlogImageAsset> {
+  if (!source.startsWith("/blog-images/")) return { src: source };
+
+  let pathname = new URL(source, "https://remix.run").pathname;
+  let filePath = `public${decodeURIComponent(pathname)}`;
+  let extension = path.extname(filePath).toLowerCase();
+  let metadata = await sharp(path.join(ROOT_DIR, filePath)).metadata();
+  let dimensions = getOrientedDimensions(metadata);
+
+  if (!TRANSFORMABLE_EXTENSIONS.has(extension) || !dimensions.width) {
+    return {
+      ...dimensions,
+      src: await assets.getHref(filePath),
+    };
+  }
+
+  let sourceWidth = dimensions.width;
+  let outputWidths: number[] = RESPONSIVE_WIDTHS.filter(
+    (width) => width < sourceWidth,
+  );
+  if (sourceWidth <= RESPONSIVE_WIDTHS.at(-1)!) {
+    outputWidths.push(sourceWidth);
+  }
+
+  let variants = await Promise.all(
+    outputWidths.map(async (width) => ({
+      href: await assets.getHref(filePath, {
+        transform: [getWebpTransform(width, sourceWidth)],
+      }),
+      width,
+    })),
+  );
+  let largest = variants.at(-1);
+  if (!largest) {
+    return {
+      ...dimensions,
+      src: await assets.getHref(filePath),
+    };
+  }
+
+  return {
+    ...dimensions,
+    src: largest.href,
+    srcSet:
+      variants.length > 1
+        ? variants.map(({ href, width }) => `${href} ${width}w`).join(", ")
+        : undefined,
+  };
+}
+
+function getWebpTransform(width: number, sourceWidth: number): WebpTransform {
+  if (width === sourceWidth) return "webp";
+  switch (width) {
+    case 480:
+      return "webp-480";
+    case 768:
+      return "webp-768";
+    case 1200:
+      return "webp-1200";
+    case 1600:
+      return "webp-1600";
+    default:
+      throw new TypeError(`Unsupported responsive image width: ${width}`);
+  }
+}
+
+function getOrientedDimensions(metadata: Metadata) {
+  let width = metadata.width;
+  let height = metadata.pageHeight ?? metadata.height;
+  if (
+    width &&
+    height &&
+    metadata.orientation &&
+    metadata.orientation >= 5 &&
+    metadata.orientation <= 8
+  ) {
+    [width, height] = [height, width];
+  }
+
+  return {
+    height,
+    width,
+  };
+}


### PR DESCRIPTION
## Summary

- serve blog images through Remix's asset transformation system
- generate constrained responsive WebP variants with intrinsic dimensions and production fingerprinting
- optimize blog listing, post hero, Markdown, and trusted raw HTML images while preserving full-size lightbox sources
- add filesystem transform caching and focused route, Markdown, asset, and browser coverage

## Validation

- `pnpm test` (156 tests passed)
- `pnpm run build`
- `pnpm remix doctor`
- `pnpm run typecheck`
- `pnpm exec oxlint . --threads=1`
- production asset route smoke test (`200 image/webp`, immutable one-year cache)
