### PR TITLE
Disable production asset minification for staging test

### DIFF
--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -26,7 +26,7 @@ export let assets = createAssetServer({
   },
   fingerprint: isProduction ? { buildId: getBuildId() } : undefined,
   sourceMaps: isDevelopment ? "external" : undefined,
-  minify: isProduction,
+  minify: false,
   hmr: isHmr
     ? async () =>
         (await import("remix/node-hmr/runtime")).createBrowserHmrChannel()


### PR DESCRIPTION
## What this tests

This is a deliberately isolated asset-pipeline experiment. It changes `app/utils/assets.ts` from production-only minification to `minify: false` so we can compare the experience of serving readable, unminified browser assets against the normal minified `remix.run` site.

There are no intended UI or application-behavior changes. The comparison is specifically about:

- whether the page still loads and behaves normally;
- how readable the downloaded JavaScript and CSS are; and
- how much the asset payload grows before and after HTTP content encoding.

## Demo

- **Unminified staging:** https://remixdotrunstage.fly.dev/
- **Minified baseline:** https://remix.run/

Open both pages in separate tabs and use DevTools → Network. Disable the cache, reload, and filter to `/assets/`. The staging responses should contain readable JavaScript/CSS, while the `remix.run` responses are minified. Compare both the decoded size and transferred size for the same logical assets.

Both pages passed a browser smoke test: they reached `document.readyState === "complete"`, rendered the same title and H1, and loaded the expected scripts and stylesheets.

## Results

The homepage exposed 127 common browser assets. Assets were matched by logical path after removing their fingerprint, so the minified and unminified versions of the same asset were compared.

### Uncompressed payloads: isolate minification

This test requests both sites with `Accept-Encoding: identity`. This compares the asset bodies before HTTP compression and is the clearest measurement of the minifier's effect:

| Measure | Staging (`minify: false`) | `remix.run` (minified) | Difference |
| --- | ---: | ---: | ---: |
| All asset bytes | 2,552,420 | 1,079,530 | **+1,472,890 / +136.4%** |
| JavaScript bytes | 2,285,356 | 899,300 | **+1,386,056 / +154.1%** |
| CSS bytes | 73,345 | 60,057 | **+13,288 / +22.1%** |

### Controlled gzip comparison: approximate transfer impact

The sites do use different encodings: staging negotiates Brotli, while Fastly serves `remix.run` gzip. To compare the same encoding, we explicitly requested `Accept-Encoding: gzip` from both sites. Both returned gzip responses for all 127 assets:

| Measure | Staging gzip | `remix.run` gzip | Difference |
| --- | ---: | ---: | ---: |
| All asset bytes | 577,347 | 311,268 | **+266,079 / +85.5%** |
| JavaScript bytes | 495,525 | 249,600 | **+245,925 / +98.5%** |
| CSS bytes | 14,538 | 13,428 | **+1,110 / +8.3%** |

This is a real response-size comparison with the encoding held constant, although the staging app and Fastly may use different gzip settings.

For the normal browser request (`Accept-Encoding: gzip, br`), staging returned 453,536 bytes using Brotli and `remix.run` returned 311,268 bytes using gzip. That is useful as an observed-user-path result, but it is not a pure compression comparison because the algorithms differ.

## Validation and deployment

- `pnpm run build`
- `pnpm exec oxlint --threads=1 .`
- `pnpm run test:ci` — 155 tests passed
- Staging deployment workflow passed: https://github.com/remix-run/remix-website/actions/runs/32306316228
- Staging healthcheck returned `200 OK`

## Important

This is a temporary experiment. Merging this PR as written would also leave production asset minification disabled, so the setting should be reverted or made staging-only after the comparison.