### PR TITLE
Adopt import maps for browser assets

### DIFF
--- a/app/actions/home.test.ts
+++ b/app/actions/home.test.ts
@@ -91,5 +91,19 @@ describe("home route", () => {
       "/assets/app/styles/public/global.css",
       "/assets/app/styles/public/home.css",
     ]);
+
+    let importMapIndices = [...html.matchAll(/<script[^>]+type="importmap"/g)]
+      .map((match) => match.index)
+      .filter((index) => index !== undefined);
+    let modulePreloadIndices = [...html.matchAll(/rel="modulepreload"/g)]
+      .map((match) => match.index)
+      .filter((index) => index !== undefined);
+    let moduleScriptIndex = html.indexOf('<script type="module"');
+    expect(importMapIndices.length).toBeGreaterThan(0);
+    expect(modulePreloadIndices.length).toBeGreaterThan(0);
+    expect(moduleScriptIndex).toBeGreaterThan(Math.max(...importMapIndices));
+    expect(moduleScriptIndex).toBeGreaterThan(
+      Math.max(...modulePreloadIndices),
+    );
   });
 });

--- a/app/actions/public/entry.ts
+++ b/app/actions/public/entry.ts
@@ -1,3 +1,8 @@
+import {
+  detectMultipleImportMapSupport,
+  importModule,
+  preloadShim,
+} from "remix/multiple-import-maps-polyfill";
 import { run } from "remix/ui";
 import { DOCUMENT_REDIRECT_HEADER } from "./document-redirect.ts";
 import { initFathomAnalytics } from "./fathom.ts";
@@ -6,14 +11,20 @@ initFathomAnalytics();
 
 let app = run({
   async loadModule(src, exportName) {
-    let mod = await import(src);
+    let mod = await importModule(src);
 
-    let exp = (mod as Record<string, unknown>)[exportName];
+    let exp = mod[exportName];
     if (typeof exp !== "function") {
       throw new Error(`Export "${exportName}" from "${src}" is not a function`);
     }
 
     return exp;
+  },
+  async processClientEntryPreloads(preloads) {
+    if (await detectMultipleImportMapSupport()) return preloads;
+
+    preloadShim(preloads);
+    return [];
   },
   async resolveFrame(src, options) {
     let headers = new Headers();

--- a/app/middleware/asset-entry.ts
+++ b/app/middleware/asset-entry.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import type { ScriptEntry } from "remix/assets";
 import { getContext } from "remix/middleware/async-context";
 import {
   createContextKey,
@@ -10,8 +11,7 @@ import { assets } from "../utils/assets.ts";
 
 interface AssetEntry {
   fonts: Record<FontName, FontAsset>;
-  src: string;
-  preloads: string[];
+  scriptEntry: ScriptEntry;
   stylesheets: Record<StylesheetName, StylesheetAsset>;
 }
 
@@ -60,7 +60,7 @@ export function loadAssetEntry(
   entry = defaultEntry,
 ): Middleware<AssetEntryContextEntry> {
   return async (context, next) => {
-    let [fonts, src, preloads, stylesheets] = await Promise.all([
+    let [fonts, scriptEntry, stylesheets] = await Promise.all([
       Promise.all(
         Object.entries(fontEntries).map(async ([name, fontEntry]) => {
           let href = await assets.getHref(fontEntry);
@@ -69,12 +69,7 @@ export function loadAssetEntry(
       ).then(
         (entries) => Object.fromEntries(entries) as Record<FontName, FontAsset>,
       ),
-      assets.getHref(entry),
-      assets.getPreloads(entry).catch((error) => {
-        // Surface asset compilation errors without breaking HTML rendering.
-        console.error(error);
-        return [];
-      }),
+      assets.getScriptEntry(entry),
       Promise.all(
         Object.entries(stylesheetEntries).map(
           async ([name, stylesheetEntry]) => {
@@ -93,8 +88,7 @@ export function loadAssetEntry(
 
     context.set(assetEntryKey, {
       fonts,
-      src,
-      preloads,
+      scriptEntry,
       stylesheets,
     });
     return next();

--- a/app/middleware/render.ts
+++ b/app/middleware/render.ts
@@ -209,12 +209,9 @@ async function resolveClientEntry(
     return { href: sourceId, exportName };
   }
 
-  let [href, preloads] = await Promise.all([
-    assets.getHref(sourceId),
-    assets.getPreloads(sourceId),
-  ]);
+  let { href, importMap, preloads } = await assets.getScriptEntry(sourceId);
 
-  return { href, exportName, preloads };
+  return { href, importMap, exportName, preloads };
 }
 
 function escapeHtml(value: string) {

--- a/app/ui/document.tsx
+++ b/app/ui/document.tsx
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { attrs, css, type Handle, type Props, type RemixNode } from "remix/ui";
+import { ImportMap } from "remix/ui/server";
 
 import {
   getAssetEntry,
@@ -67,6 +68,7 @@ export function Document(handle: Handle<DocumentProps>) {
       children,
     } = handle.props;
     let assetEntry = getAssetEntry();
+    let { href: scriptHref, importMap, preloads } = assetEntry.scriptEntry;
     let stylesheetNames = new Set<StylesheetName>(["global"]);
     for (let name of requestedStylesheets) stylesheetNames.add(name);
 
@@ -258,7 +260,8 @@ export function Document(handle: Handle<DocumentProps>) {
             ),
           )}
 
-          {assetEntry.preloads.map((href) => (
+          <ImportMap value={importMap} />
+          {preloads.map((href) => (
             <link
               key={href}
               data-rmx-key={`modulepreload:${getCompactHeadKey(href)}`}
@@ -266,7 +269,6 @@ export function Document(handle: Handle<DocumentProps>) {
               href={href}
             />
           ))}
-          <script type="module" async src={assetEntry.src} />
 
           {/* Apply the system color scheme before first paint. */}
           <script innerHTML={colorSchemeScript} />
@@ -296,6 +298,7 @@ export function Document(handle: Handle<DocumentProps>) {
           {/* Inline so route-local theme resets emitted later cannot reveal the sprite. */}
           <div style={{ display: "none" }} innerHTML={iconsSpriteHtml} />
           {children}
+          <script type="module" src={scriptHref} />
         </body>
       </html>
     );

--- a/app/utils/assets.test.ts
+++ b/app/utils/assets.test.ts
@@ -35,7 +35,9 @@ describe("browser asset boundary", () => {
 
     for (let modulePath of modules) {
       try {
-        let href = await productionAssets.assets.getHref(modulePath);
+        let href = modulePath.endsWith(".css")
+          ? await productionAssets.assets.getHref(modulePath)
+          : (await productionAssets.assets.getScriptEntry(modulePath)).href;
         let response = await productionAssets.assets.fetch(
           new Request(new URL(href, "http://localhost")),
         );

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -16,7 +16,7 @@ if (!config.assets) throw new Error("Missing assets configuration");
 if (!config.assets.files) throw new Error("Missing asset file configuration");
 let rootDir = config.assets.rootDir;
 
-let buildId = isProduction ? getBuildId() : undefined;
+let fileCacheKey = process.env.FLY_IMAGE_REF ?? `process-${process.pid}`;
 let webpInputExtensions = [".jpeg", ".jpg", ".png"] as const;
 let webpTransforms = {
   webp: createWebpTransform(),
@@ -37,24 +37,22 @@ export let assets = createAssetServer({
     firefox: "115",
     safari: "16.4",
   },
-  fingerprint: buildId ? { buildId } : undefined,
+  fingerprint: isProduction,
   files: {
     ...config.assets.files,
-    cache: createFsFileStorage(
-      path.join(
-        os.tmpdir(),
-        "remix-website-assets",
-        buildId
-          ? Buffer.from(buildId).toString("base64url")
-          : `process-${process.pid}`,
-      ),
-    ),
+    cache: createFsFileStorage(path.join(os.tmpdir(), "remix-website-assets")),
+    cacheKey: fileCacheKey,
     maxRequestTransforms: 1,
     transforms: webpTransforms,
   },
   sourceMaps: isDevelopment ? "external" : undefined,
   minify: isProduction,
-  hmr: isHmr ? createAppBrowserHmrChannel : undefined,
+  hmr: isHmr
+    ? {
+        channel: createAppBrowserHmrChannel,
+        moduleImporter: "remix/multiple-import-maps-polyfill",
+      }
+    : undefined,
   scripts: {
     define: {
       "process.env.NODE_ENV": JSON.stringify(nodeEnv),
@@ -115,14 +113,4 @@ function createWebpTransform(width?: number) {
       return { content, extension: ".webp" };
     },
   });
-}
-
-function getBuildId() {
-  let buildId = process.env.ASSET_BUILD_ID || process.env.FLY_IMAGE_REF;
-  if (!buildId) {
-    throw new Error(
-      "ASSET_BUILD_ID or FLY_IMAGE_REF is required for production asset fingerprinting",
-    );
-  }
-  return buildId;
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "remark-gfm": "4.0.1",
     "remark-parse": "11.0.0",
     "remark-rehype": "11.1.2",
-    "remix": "3.0.0-rc.1",
+    "remix": "3.0.0-rc.2",
     "satori": "0.26.0",
     "semver": "7.7.4",
     "sharp": "0.35.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 11.1.2
         version: 11.1.2
       remix:
-        specifier: 3.0.0-rc.1
-        version: 3.0.0-rc.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
+        specifier: 3.0.0-rc.2
+        version: 3.0.0-rc.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
       satori:
         specifier: 0.26.0
         version: 0.26.0
@@ -1595,41 +1595,41 @@ packages:
         integrity: sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ==,
       }
 
-  "@remix-run/assets@0.6.0":
+  "@remix-run/assets@0.7.0":
     resolution:
       {
-        integrity: sha512-mIYfP8PCCn5thlEhUhYffb9XbNqNVSmsXfW9+Fsp7go5BW0XTJtugMW1K7oo8TbXEo/xHXSGg4hWPdrBmTnsDg==,
+        integrity: sha512-zdYyxyzh+lBH+cNfj2Vm+sItTMPAbIpUGgqHxiDDbFgXEyrct8vNLnBE7NXeIEGO7QOiez1yGzo7NR316VAhhA==,
       }
 
-  "@remix-run/async-context-middleware@0.3.5":
+  "@remix-run/async-context-middleware@0.3.6":
     resolution:
       {
-        integrity: sha512-H8HbZyuX9u1FUQDvaR5Yib/QmALKhMe+40Jjis4+B7u+c23YKUwUB/0pjWRMOrXE8udZ1y848/B9z7stZHP1WA==,
+        integrity: sha512-raPjElPfyPO6mEWP0XH/QPL/3oFEo23B73Gn71iBvIB2ZkCM5jXnAUhilXRVjrFALqsIwaBZAZvB3fJVpW7b4g==,
       }
 
-  "@remix-run/auth-middleware@0.2.5":
+  "@remix-run/auth-middleware@0.2.6":
     resolution:
       {
-        integrity: sha512-R3R+qtnnglotSiCGm60l2zLbPl9tU9E0dJwuXR7gWYcA4Pop5IqCHxXXurLPDDWaqiMF/FZIo0akwxFZ6vS9iA==,
+        integrity: sha512-7+UX3OUA2QFcj/N8gKjiWolk71OCZZedMZQWqMPeVJAdMcxHC9+kUWkXWijs/RPSpqhrSCwMYJaNTfd4TiRQKg==,
       }
 
-  "@remix-run/auth@0.3.0":
+  "@remix-run/auth@0.3.1":
     resolution:
       {
-        integrity: sha512-ZcQng5NtF7jyKx5hdR1necSXRbVG14OOQIJ4ghM/Zyfs5CgQ7kNA9sNTaXKRaPkIo57jFP6Dd9AKA6Z46lrKxg==,
+        integrity: sha512-iYSGBxp1l1x9xLV/KX965ai89OYAA216oEG8VIf3I1y0cg+miVzr1mCpx5UIfGJoYY+7GVnPRsRMNI61X4VtQQ==,
       }
 
-  "@remix-run/cli@0.6.0":
+  "@remix-run/cli@0.7.0":
     resolution:
       {
-        integrity: sha512-he8W0bAQkNOpUNIA06T8ayB7JVO987qyKbTx3QXFzr55GsnoU+OauUPIEILXsvyow25xltIoIwNtKvg+8iKn6Q==,
+        integrity: sha512-LrQdXEkUqwgmInLFHRS4FTDpYibHfWqfs1Y5vh14LwwANRJD0erxx6oy8pVm8ETHQZVFF2NPbgtwQkdtAwskQA==,
       }
     engines: { node: ">=24.3.0" }
 
-  "@remix-run/compression-middleware@0.1.13":
+  "@remix-run/compression-middleware@0.1.14":
     resolution:
       {
-        integrity: sha512-b7c+mFPIuT/eRaO2UEhH6YT4SXwhzh0PyA/EtE2H66KvjbWy/KsAY4gu1jtczprhF3AFYaE29m/mEKT8X4o67g==,
+        integrity: sha512-UJdAUDIWk2vwq55EwzaL+UJEGIXrvM9FMzSNTvsaHgFW2ZdwDtUBcjQDJc6xof+3gw0weaahg1GEgVsgABH9jw==,
       }
 
   "@remix-run/cookie@0.6.0":
@@ -1638,22 +1638,22 @@ packages:
         integrity: sha512-juCoNHiHbXLT0gXDAYg06eVaFSKNqMS/dud49ZQdCHfCpHk1PPFDAbWajSz90ZG5BWWMPSWDvod4o1SAqPnlFA==,
       }
 
-  "@remix-run/cop-middleware@0.1.8":
+  "@remix-run/cop-middleware@0.1.9":
     resolution:
       {
-        integrity: sha512-0AOzbNsTyjxFmwpF0im1RGQCpaj6I2gyUTbai5/vjx2D2H/6LRg6t2eJXj715m1e1dDuyQwURZUJKGKFjVYAlw==,
+        integrity: sha512-qzdqCjCu/YAebSsQsNnfObha40SdbHBfId9t7Xyji5ltUBMhGaGomWNnOCS8/lL1yEJPZ8/bPoLtmdKDo8Uutw==,
       }
 
-  "@remix-run/cors-middleware@0.1.8":
+  "@remix-run/cors-middleware@0.1.9":
     resolution:
       {
-        integrity: sha512-Vhgtvrbafl1ng8tGmoYKNZ0nxa6vDtNKR2QwLbrW/xwjprTcwkJPSP2IiyQI+75HTzG5zWgJ/Z6OMO+iKdBjuQ==,
+        integrity: sha512-zx0WY9O5Ko88X/Bm2DTslSm0n6o6+Ixmlq8bfbLAcVwOqcHPif9DdgrasbJPooe+geN9+HZ0qfmLRBI7wDuz3A==,
       }
 
-  "@remix-run/csrf-middleware@0.1.8":
+  "@remix-run/csrf-middleware@0.1.9":
     resolution:
       {
-        integrity: sha512-7zMWNLjJQW5UwWC2eIwNxT2yFLXzriBD5tls1SEkXyLMlk/NVnqqzISbd0BbZuAX+a+p6RD2vyE4ldcpLdaj+w==,
+        integrity: sha512-uYvD1fvvvOaepd0qjW3gYshnFvfIOU57w8B0Y/RbhL2cKgNzHnRIO99fzN4sA/4NFhGA0E68ql+NectXE8375g==,
       }
 
   "@remix-run/data-schema@0.3.0":
@@ -1662,10 +1662,10 @@ packages:
         integrity: sha512-rjGaFJduzO3iMFOKwA5URpZDuGbUxgBwcX9myBglfqbax8dBlhRcxurydepq+xi+XBE+bPrT9V57Jur6p1igow==,
       }
 
-  "@remix-run/data-table-mysql@0.5.1":
+  "@remix-run/data-table-mysql@0.5.2":
     resolution:
       {
-        integrity: sha512-0KA8A4F38BQpTyA4iS7xiJhuUGZdGhcdftADsGuaN6YPSpu/1huK40VzDr9eYdxmC4n6Oo7g9taqrp6bREAL4A==,
+        integrity: sha512-M4sA1jCtMZuzGRP7kz5LwFOJGivuD0RpHPHWe6ZnRt+K5UTA8gdsqDMgITeKYV53u6T2jDOaiPibq5IeiB8qaA==,
       }
     peerDependencies:
       mysql2: ^3.15.3
@@ -1673,10 +1673,10 @@ packages:
       mysql2:
         optional: true
 
-  "@remix-run/data-table-postgres@0.5.1":
+  "@remix-run/data-table-postgres@0.5.2":
     resolution:
       {
-        integrity: sha512-CsjfpEzgbHau5G3zx8cKdrXtWFraQxxDE3qolkZmRUPWw1Er8IEeURfMQGT22h+a7t5iKDH7YbRaqAAbggXI7g==,
+        integrity: sha512-i31IweRRMVML2CNaAcfv25xcntH/lC1j4Y3Vf7UiCKVKbsxMCvDg9+t7pK8hMIpzlldGdLqNzdQ9B09uCwnajA==,
       }
     peerDependencies:
       pg: ^8.16.3
@@ -1684,16 +1684,16 @@ packages:
       pg:
         optional: true
 
-  "@remix-run/data-table-sqlite@0.6.1":
+  "@remix-run/data-table-sqlite@0.6.2":
     resolution:
       {
-        integrity: sha512-CVwHZbsCDa9Sg//GR2orWrh0KL/nVa1e5CvWW/G33flX6sBwv+A5OGZJHe+ZFCTLT9EAfY06+8Cew8AgIB8xCw==,
+        integrity: sha512-S/sBp7PU3uQMPRCuoyTFLcvZ5XE2jkcASN3VTn1xLW6hdnRI7YWLUMrrcmM9MivpirVmAeZrzUUT7z/TmlNINg==,
       }
 
-  "@remix-run/data-table@0.5.0":
+  "@remix-run/data-table@0.5.1":
     resolution:
       {
-        integrity: sha512-ntc23qDYnSCA2iq1r2L5+u/9MH+5207mopekOM4NRsVDrMt0e14DVq37JhfVmzcZDCb8lx7iP+D+H8i9a9IiCw==,
+        integrity: sha512-AbGRuT25urh2l61iVHmaREFmke74GxfGNyxih7wdqKWXHO4zlqfkWE4NuY1BkRWeLeIT7YXdgpsN4jdGAAj5TQ==,
       }
 
   "@remix-run/fetch-proxy@0.8.5":
@@ -1702,10 +1702,10 @@ packages:
         integrity: sha512-NZmqaa/61xyWYkbERgIth3fPqkqOkmmlMYwmNFL0sG2RE29kH9wG18I6fCg/fu1W3qvSOrMSIS5hMk5ggqZzHg==,
       }
 
-  "@remix-run/fetch-router@0.21.0":
+  "@remix-run/fetch-router@0.22.0":
     resolution:
       {
-        integrity: sha512-dN3Lsd4dHAV0USTF3Dm04effXcdr7GMgXiqeozTFDfvVIx2DbRAl94bwF6UdAWurgTOK2Oyz4cs9uadW/ylWXA==,
+        integrity: sha512-ErxqVZWUYTYPd6L/NbOe12BeRd8ulik7gCZnQxChEDlnko3chcTLqTsXc//h8IAqOY2x8NSOlo+ZQdFzfhCrpg==,
       }
 
   "@remix-run/file-storage-s3@0.1.4":
@@ -1720,10 +1720,10 @@ packages:
         integrity: sha512-7tDgyzs1v0dQgfMt+lpbIzEVkrgrcKJLGbBeXrpJITuCeWoc0XgFfDTp6gghS3s8aWQTm5XHbgnldLoQCEU9Mw==,
       }
 
-  "@remix-run/form-data-middleware@0.3.5":
+  "@remix-run/form-data-middleware@0.3.6":
     resolution:
       {
-        integrity: sha512-gPb12PC46F0RbUUm2qjjqmRmVjzB589Wdp7WBA/Lhn6tDPskCYKmwCew5owIIhoEgBEAuXD5nm16gMuDaZ/DVA==,
+        integrity: sha512-Uwi8Uh0VxtZ5LWImJQlA/OV1q/CAnoywdCx9RYFVUFmr5x+MIjAUT9MM9M1WBBlU0r4GhiB3A9fVwfmMkgd2HA==,
       }
 
   "@remix-run/form-data-parser@0.17.5":
@@ -1756,16 +1756,16 @@ packages:
         integrity: sha512-jIeeqkqR+AgTEKls5WMPbiGyXhrkAJugN4ot/K9X74CLzO9uMbcFDKef7CWCfjN1s+551u+5LxNWLJx1nztuVg==,
       }
 
-  "@remix-run/logger-middleware@0.3.5":
+  "@remix-run/logger-middleware@0.3.6":
     resolution:
       {
-        integrity: sha512-UBIUjdhfD9kvYH3ZtMjXycyvEjhcCPAc3g4SytNVB9uKZzpX3SwrnYHmqNNYFONFsX9dI4P9cefdZEIk55U/QQ==,
+        integrity: sha512-gmcIqPdKHeQONAge/86B6BLdrinKznK5VPS2cLRc14yyFNSZpTTWV0sHaus13Gj0ewoYWN2jHVTmLZlXXawbqw==,
       }
 
-  "@remix-run/method-override-middleware@0.1.13":
+  "@remix-run/method-override-middleware@0.1.14":
     resolution:
       {
-        integrity: sha512-Q3/oPl/kso7c/7TYNuC3IXXX/gnM0x0AGYhu4Brklzu71HZe28xBPCoiiDO47F+6uS2qvY9RhGQ6NGvTjZWzEw==,
+        integrity: sha512-F7wt7m9ngI+6Jbz7HWrQeoCL9ly6wJwwlyHqHDnMaqCrjk1RustepYdZgp7IcUBnld1sFQZ/IGuOXQ0CJHQx2g==,
       }
 
   "@remix-run/mime@0.4.2":
@@ -1780,16 +1780,22 @@ packages:
         integrity: sha512-XrrfbuU4csgEpTmHv9rjrnFrGu/7iz+31PM51cFL2fcu/JZ7+wZhDyqaOca2uOE8qNhVgXuJHqEOl/8eFCYTHQ==,
       }
 
+  "@remix-run/multiple-import-maps-polyfill@0.1.0":
+    resolution:
+      {
+        integrity: sha512-jxYH1ZVbi+dwbqqHHgnHjCd3B0Qhuu//K2VDPQjrJU8SXV4jiSy6hp3Tuvi2C8gUoU/5myyJE3TW4HGoltsv9Q==,
+      }
+
   "@remix-run/node-fetch-server@0.14.1":
     resolution:
       {
         integrity: sha512-pKenF5ysIN5lDCnCyvoUxDhKP0tfnGagvGbZh01xxHG6DJXSIXWVC9NpLSDGjxcxd1CKdCOKuZFleXBF3pChIg==,
       }
 
-  "@remix-run/node-hmr@0.1.0":
+  "@remix-run/node-hmr@0.2.0":
     resolution:
       {
-        integrity: sha512-LMONcqnqJ/kYfKxSfgG/dpTZZP7QmarUk47e+kd4861/q8G+SHZOYOC3vlWoiZgJdx/JwOkTnmvqovpQpjlXkA==,
+        integrity: sha512-C2IOnJn7RQBA9/zuDUfPNRPPGnWsIfLSBaCRbdtIksN9WYXCy2RyCVbNltCz+QhC1UF/+cXVksmLxuDzfGsCoA==,
       }
 
   "@remix-run/node-tsx@0.1.1":
@@ -1799,10 +1805,10 @@ packages:
       }
     engines: { node: ">=24.3.0" }
 
-  "@remix-run/render-middleware@0.2.0":
+  "@remix-run/render-middleware@0.3.0":
     resolution:
       {
-        integrity: sha512-y1Hz9QRKr62aV3SUZDFp+QEdulsmURwuFh7DgS8z+1R3qquxbZl+cV00rL3Ly9qn6jUyrEZRQdPhYI8uf84MgA==,
+        integrity: sha512-UL99BvVq3pIFgq8h3I2xdCuMUHIaGWMnKffkAbuxBiHp0R3D/Uf/xW5vX3QEm1Tqx4svZl+/us5WoLZmxVlOlA==,
       }
 
   "@remix-run/response@0.3.8":
@@ -1817,10 +1823,10 @@ packages:
         integrity: sha512-w0/lhgY40l2GrBQjJIOeYWIuKm1rxlOsc9Hvt+nyydnka0v4aI9Vv0VK4XzLD3aP08JzGtTlxFxwf1PZ8SGdLg==,
       }
 
-  "@remix-run/session-middleware@0.4.0":
+  "@remix-run/session-middleware@0.4.1":
     resolution:
       {
-        integrity: sha512-v563WyWG8GABVF0T1tX+xPDEmHswbbEqMh54GfxwcfLMWr+wJl16kEzZb+q0dPmvjZjwDHBtUIj8b1rOFglFHQ==,
+        integrity: sha512-OumS9+8PA34phExNzAqQ9VkuEldlK7AZ6Isv2mVxPfrEeUTf3EZWWGvgNQBfmdwU66FKxZg2Hw2y6cZMYRMs+A==,
       }
 
   "@remix-run/session-storage-memcache@0.1.2":
@@ -1846,16 +1852,16 @@ packages:
         integrity: sha512-NGzu6/gC5xD/tq40W0WqzTt4JhCdSCIwDHM1aa13JBqb4Ml/Mb0kmXqjfOe/gBYfu6AA11nRQ/BJyr+VduTodA==,
       }
 
-  "@remix-run/spa@0.1.0":
+  "@remix-run/spa@0.1.1":
     resolution:
       {
-        integrity: sha512-WJudc3XjY++LQbD18xHqXVWP5140AqSrcZYXU4dbxbNtz7+yEhG9c+XMDS6vuNA927s81NNJ0Ijx9cbWfqNoZg==,
+        integrity: sha512-mnvssAWmzb/kcVz5fIDwO/zAECumWZBcsXnQhMKVoPmb6ZuqVuqYYfmoufOZ8N7w1Q00YuVM71x9KNIS4tBMUQ==,
       }
 
-  "@remix-run/static-middleware@0.4.14":
+  "@remix-run/static-middleware@0.4.15":
     resolution:
       {
-        integrity: sha512-kfz94iBjwFTeORQjs/V/9Pp4pAfJAz9EGlDB7Sh9VvAbG8wggsPs84pFgIIm5xy6Os7ey9OEeQXeLSm70TIzQg==,
+        integrity: sha512-lBix1nMAtwa+E1QEhdWRY5JhGLMfD1PwIw7vkniR97pS83l5h5EN7Fyt0dj+itdk3iJDqFpKQe02TFpCSHwHPw==,
       }
 
   "@remix-run/tar-parser@0.7.1":
@@ -1888,10 +1894,10 @@ packages:
         integrity: sha512-9hV0iNWBSjCmrA6b9/8uG7qWSHPXyy5XuIzfMayIH661YfmKuBFchkOIiTenadaI4g7ZxCBT+igh/HtRvyxS4Q==,
       }
 
-  "@remix-run/ui@0.8.0":
+  "@remix-run/ui@0.9.0":
     resolution:
       {
-        integrity: sha512-4OdZ3oj0zbyVVaCFT/x2vjK5YxpD63KpLONkLZ2QVKIEBcLjJUGSenp2f08BOzC8oythLHCJgzHLKKulYJpIQA==,
+        integrity: sha512-M25PBhOnBmCluu+HGVGMbFxY0Ven/Tz/pESEL6CkGs1o4K8PdX6upVSHkytmsZ5V8Q+BBYL85zcGmH+mXESKrg==,
       }
 
   "@resvg/resvg-js-android-arm-eabi@2.6.2":
@@ -3366,10 +3372,10 @@ packages:
         integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
       }
 
-  remix@3.0.0-rc.1:
+  remix@3.0.0-rc.2:
     resolution:
       {
-        integrity: sha512-GnVF3Zecw/SdkpklTaQOKeVvziyXnSIuiqPPq1MFeMaoBeYS5PXXIaxnQcmbDuuMyy1R4cmwi+mJGVoCP78x9w==,
+        integrity: sha512-3ZA+HCFS/EW58bJa8Z6VMovgmWEL8evys65jn2JGOg4cgtUYm1ucBN3NpVmU/HnQfTEopb0C+Zjuz5VSYoDZYQ==,
       }
     engines: { node: ">=24.3.0" }
     hasBin: true
@@ -4261,7 +4267,7 @@ snapshots:
 
   "@remix-run/assert@0.3.0": {}
 
-  "@remix-run/assets@0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+  "@remix-run/assets@0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
     dependencies:
       "@oxc-project/runtime": 0.121.0
       "@remix-run/file-storage": 0.13.7
@@ -4282,27 +4288,27 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/async-context-middleware@0.3.5":
+  "@remix-run/async-context-middleware@0.3.6":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
 
-  "@remix-run/auth-middleware@0.2.5":
+  "@remix-run/auth-middleware@0.2.6":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/session": 0.4.2
 
-  "@remix-run/auth@0.3.0":
+  "@remix-run/auth@0.3.1":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/session": 0.4.2
 
-  "@remix-run/cli@0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)":
+  "@remix-run/cli@0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)":
     dependencies:
-      "@remix-run/assets": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/data-table": 0.5.0
-      "@remix-run/data-table-mysql": 0.5.1
-      "@remix-run/data-table-postgres": 0.5.1
-      "@remix-run/data-table-sqlite": 0.6.1
+      "@remix-run/assets": 0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/data-table": 0.5.1
+      "@remix-run/data-table-mysql": 0.5.2
+      "@remix-run/data-table-postgres": 0.5.2
+      "@remix-run/data-table-sqlite": 0.6.2
       "@remix-run/terminal": 0.1.1
       "@remix-run/test": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
       jsonc-parser: 3.3.1
@@ -4314,9 +4320,9 @@ snapshots:
       - pg
       - playwright
 
-  "@remix-run/compression-middleware@0.1.13":
+  "@remix-run/compression-middleware@0.1.14":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/mime": 0.4.2
       "@remix-run/response": 0.3.8
 
@@ -4324,43 +4330,43 @@ snapshots:
     dependencies:
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/cop-middleware@0.1.8":
+  "@remix-run/cop-middleware@0.1.9":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
 
-  "@remix-run/cors-middleware@0.1.8":
+  "@remix-run/cors-middleware@0.1.9":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/csrf-middleware@0.1.8":
+  "@remix-run/csrf-middleware@0.1.9":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/session": 0.4.2
 
   "@remix-run/data-schema@0.3.0":
     dependencies:
       "@standard-schema/spec": 1.1.0
 
-  "@remix-run/data-table-mysql@0.5.1":
+  "@remix-run/data-table-mysql@0.5.2":
     dependencies:
-      "@remix-run/data-table": 0.5.0
+      "@remix-run/data-table": 0.5.1
 
-  "@remix-run/data-table-postgres@0.5.1":
+  "@remix-run/data-table-postgres@0.5.2":
     dependencies:
-      "@remix-run/data-table": 0.5.0
+      "@remix-run/data-table": 0.5.1
 
-  "@remix-run/data-table-sqlite@0.6.1":
+  "@remix-run/data-table-sqlite@0.6.2":
     dependencies:
-      "@remix-run/data-table": 0.5.0
+      "@remix-run/data-table": 0.5.1
 
-  "@remix-run/data-table@0.5.0": {}
+  "@remix-run/data-table@0.5.1": {}
 
   "@remix-run/fetch-proxy@0.8.5":
     dependencies:
       "@remix-run/headers": 0.21.1
 
-  "@remix-run/fetch-router@0.21.0":
+  "@remix-run/fetch-router@0.22.0":
     dependencies:
       "@remix-run/route-pattern": 0.24.0
 
@@ -4374,9 +4380,9 @@ snapshots:
       "@remix-run/fs": 0.4.6
       "@remix-run/lazy-file": 5.0.6
 
-  "@remix-run/form-data-middleware@0.3.5":
+  "@remix-run/form-data-middleware@0.3.6":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/form-data-parser": 0.17.5
 
   "@remix-run/form-data-parser@0.17.5":
@@ -4396,14 +4402,14 @@ snapshots:
     dependencies:
       "@remix-run/mime": 0.4.2
 
-  "@remix-run/logger-middleware@0.3.5":
+  "@remix-run/logger-middleware@0.3.6":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/terminal": 0.1.1
 
-  "@remix-run/method-override-middleware@0.1.13":
+  "@remix-run/method-override-middleware@0.1.14":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
 
   "@remix-run/mime@0.4.2": {}
 
@@ -4411,9 +4417,13 @@ snapshots:
     dependencies:
       "@remix-run/headers": 0.21.1
 
+  "@remix-run/multiple-import-maps-polyfill@0.1.0":
+    dependencies:
+      es-module-lexer: 2.3.2
+
   "@remix-run/node-fetch-server@0.14.1": {}
 
-  "@remix-run/node-hmr@0.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+  "@remix-run/node-hmr@0.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
     dependencies:
       "@remix-run/terminal": 0.1.1
       chokidar: 5.0.0
@@ -4431,12 +4441,12 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/render-middleware@0.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+  "@remix-run/render-middleware@0.3.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
     dependencies:
-      "@remix-run/assets": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/assets": 0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/response": 0.3.8
-      "@remix-run/ui": 0.8.0
+      "@remix-run/ui": 0.9.0
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -4449,10 +4459,10 @@ snapshots:
 
   "@remix-run/route-pattern@0.24.0": {}
 
-  "@remix-run/session-middleware@0.4.0":
+  "@remix-run/session-middleware@0.4.1":
     dependencies:
       "@remix-run/cookie": 0.6.0
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/session": 0.4.2
 
   "@remix-run/session-storage-memcache@0.1.2":
@@ -4465,18 +4475,18 @@ snapshots:
 
   "@remix-run/session@0.4.2": {}
 
-  "@remix-run/spa@0.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+  "@remix-run/spa@0.1.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
-      "@remix-run/render-middleware": 0.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/ui": 0.8.0
+      "@remix-run/fetch-router": 0.22.0
+      "@remix-run/render-middleware": 0.3.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/ui": 0.9.0
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/static-middleware@0.4.14":
+  "@remix-run/static-middleware@0.4.15":
     dependencies:
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/fs": 0.4.6
       "@remix-run/html-template": 0.3.1
       "@remix-run/mime": 0.4.2
@@ -4515,7 +4525,7 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@remix-run/ui@0.8.0":
+  "@remix-run/ui@0.9.0":
     dependencies:
       "@types/dom-navigation": 1.0.7
 
@@ -5537,54 +5547,55 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remix@3.0.0-rc.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0):
+  remix@3.0.0-rc.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0):
     dependencies:
       "@remix-run/assert": 0.3.0
-      "@remix-run/assets": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/async-context-middleware": 0.3.5
-      "@remix-run/auth": 0.3.0
-      "@remix-run/auth-middleware": 0.2.5
-      "@remix-run/cli": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
-      "@remix-run/compression-middleware": 0.1.13
+      "@remix-run/assets": 0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/async-context-middleware": 0.3.6
+      "@remix-run/auth": 0.3.1
+      "@remix-run/auth-middleware": 0.2.6
+      "@remix-run/cli": 0.7.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
+      "@remix-run/compression-middleware": 0.1.14
       "@remix-run/cookie": 0.6.0
-      "@remix-run/cop-middleware": 0.1.8
-      "@remix-run/cors-middleware": 0.1.8
-      "@remix-run/csrf-middleware": 0.1.8
+      "@remix-run/cop-middleware": 0.1.9
+      "@remix-run/cors-middleware": 0.1.9
+      "@remix-run/csrf-middleware": 0.1.9
       "@remix-run/data-schema": 0.3.0
-      "@remix-run/data-table": 0.5.0
-      "@remix-run/data-table-mysql": 0.5.1
-      "@remix-run/data-table-postgres": 0.5.1
-      "@remix-run/data-table-sqlite": 0.6.1
+      "@remix-run/data-table": 0.5.1
+      "@remix-run/data-table-mysql": 0.5.2
+      "@remix-run/data-table-postgres": 0.5.2
+      "@remix-run/data-table-sqlite": 0.6.2
       "@remix-run/fetch-proxy": 0.8.5
-      "@remix-run/fetch-router": 0.21.0
+      "@remix-run/fetch-router": 0.22.0
       "@remix-run/file-storage": 0.13.7
       "@remix-run/file-storage-s3": 0.1.4
-      "@remix-run/form-data-middleware": 0.3.5
+      "@remix-run/form-data-middleware": 0.3.6
       "@remix-run/form-data-parser": 0.17.5
       "@remix-run/fs": 0.4.6
       "@remix-run/headers": 0.21.1
       "@remix-run/html-template": 0.3.1
       "@remix-run/lazy-file": 5.0.6
-      "@remix-run/logger-middleware": 0.3.5
-      "@remix-run/method-override-middleware": 0.1.13
+      "@remix-run/logger-middleware": 0.3.6
+      "@remix-run/method-override-middleware": 0.1.14
       "@remix-run/mime": 0.4.2
       "@remix-run/multipart-parser": 0.16.4
+      "@remix-run/multiple-import-maps-polyfill": 0.1.0
       "@remix-run/node-fetch-server": 0.14.1
-      "@remix-run/node-hmr": 0.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/node-hmr": 0.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       "@remix-run/node-tsx": 0.1.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/render-middleware": 0.2.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/render-middleware": 0.3.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       "@remix-run/response": 0.3.8
       "@remix-run/route-pattern": 0.24.0
       "@remix-run/session": 0.4.2
-      "@remix-run/session-middleware": 0.4.0
+      "@remix-run/session-middleware": 0.4.1
       "@remix-run/session-storage-memcache": 0.1.2
       "@remix-run/session-storage-redis": 0.1.1
-      "@remix-run/spa": 0.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-      "@remix-run/static-middleware": 0.4.14
+      "@remix-run/spa": 0.1.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      "@remix-run/static-middleware": 0.4.15
       "@remix-run/tar-parser": 0.7.1
       "@remix-run/terminal": 0.1.1
       "@remix-run/test": 0.6.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(playwright@1.60.0)
-      "@remix-run/ui": 0.8.0
+      "@remix-run/ui": 0.9.0
       "@remix-run/ui-hmr": 0.1.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optionalDependencies:
       playwright: 1.60.0


### PR DESCRIPTION
This adopts the final browser asset import-map implementation shipped in Remix `3.0.0-rc.2` (from https://github.com/remix-run/remix/pull/11706).

It migrates the app to `getScriptEntry()` and `<ImportMap>`, includes client-entry import maps in frame rendering, and configures `remix/multiple-import-maps-polyfill` for late client entries and HMR.

This is deployed to [staging](https://remixdotrunstage.fly.dev/).

## Homepage network comparison

Captured in Chrome 152 from cold homepage loads with the cache disabled. Sizes are from the Resource Timing API; compressed body sizes use `encodedBodySize`. The table covers the document and same-origin JavaScript. Timings are intentionally omitted because staging does not have the production CDN in front of it.

| Metric | Staging (import maps) | Production | Difference |
| --- | ---: | ---: | ---: |
| Document compressed body | 15.4 KiB | 17.0 KiB | -1.5 KiB (-9.1%) |
| JavaScript compressed bodies | 247.7 KiB | 293.7 KiB | -46.0 KiB (-15.7%) |
| Document + JS compressed bodies | 263.1 KiB | 310.6 KiB | **-47.6 KiB (-15.3%)** |
| Document + JS transferred (bodies + response headers) | 302.9 KiB | 347.0 KiB | **-44.0 KiB (-12.7%)** |
| Document + JS requests | 136 | 124 | +12 (+9.7%) |

The tradeoff is more module requests and a larger uncompressed document: the import map increases decoded HTML from 84.7 KiB to 113.5 KiB (+28.8 KiB). Brotli compresses the repetitive map well enough that the document is still 1.5 KiB smaller over the wire, while JavaScript saves 46.0 KiB.

https://github.com/user-attachments/assets/4b015f99-bab1-4241-8f0d-f8f4f62f59a9
