### PR TITLE
Enable live reload for blog posts

### DIFF
--- a/app/data/blog.test.ts
+++ b/app/data/blog.test.ts
@@ -1,3 +1,5 @@
+import { rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
@@ -15,5 +17,31 @@ describe("blog data", () => {
 
     expect(timestamps.length).toBeGreaterThan(1);
     expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a));
+  });
+
+  it("reloads changed posts outside production", async () => {
+    let slug = `test-live-blog-${process.pid}`;
+    let postPath = path.join(process.cwd(), "data", "posts", `${slug}.md`);
+    let post = (title: string) => `---
+title: ${title}
+summary: Test post for live blog data.
+date: 2026-08-27
+draft: true
+authors:
+  - Brooks Lybrand
+image: /blog-images/headers/remix-3-beta-preview.png
+imageAlt: Test image
+---
+`;
+
+    try {
+      writeFileSync(postPath, post("Before edit"));
+      expect((await getBlogPost(slug)).title).toBe("Before edit");
+
+      writeFileSync(postPath, post("After edit"));
+      expect((await getBlogPost(slug)).title).toBe("After edit");
+    } finally {
+      rmSync(postPath, { force: true });
+    }
   });
 });

--- a/app/data/blog.ts
+++ b/app/data/blog.ts
@@ -10,14 +10,10 @@ const DATA_DIRECTORY = path.join(process.cwd(), "data");
 const POSTS_DIRECTORY = path.join(DATA_DIRECTORY, "posts");
 const AUTHORS_FILE_PATH = path.join(DATA_DIRECTORY, "authors.yml");
 
-const postContentsBySlug = Object.fromEntries(
-  readdirSync(POSTS_DIRECTORY, { withFileTypes: true })
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
-    .map((entry) => [
-      entry.name.replace(/\.md$/, ""),
-      readFileSync(path.join(POSTS_DIRECTORY, entry.name), "utf8"),
-    ]),
-);
+const shouldCacheBlogData = process.env.NODE_ENV === "production";
+const cachedPostContentsBySlug = shouldCacheBlogData
+  ? readPostContentsBySlug()
+  : undefined;
 
 const AUTHORS: BlogAuthor[] = yaml.parse(
   readFileSync(AUTHORS_FILE_PATH, "utf8"),
@@ -32,9 +28,12 @@ const postsCache = new LRUCache<string, BlogPost>({
 });
 
 export async function getBlogPost(slug: string): Promise<BlogPost> {
-  let cached = postsCache.get(slug);
-  if (cached) return cached;
-  let contents = postContentsBySlug[slug];
+  if (shouldCacheBlogData) {
+    let cached = postsCache.get(slug);
+    if (cached) return cached;
+  }
+
+  let contents = getPostContentsBySlug()[slug];
   if (!contents) {
     throw new Response("Not Found", { status: 404, statusText: "Not Found" });
   }
@@ -68,7 +67,7 @@ export async function getBlogPost(slug: string): Promise<BlogPost> {
     dateDisplay: formatDate(attributes.date),
     html,
   };
-  postsCache.set(slug, post);
+  if (shouldCacheBlogData) postsCache.set(slug, post);
   return post;
 }
 
@@ -80,10 +79,10 @@ let postListings: Array<MarkdownPostListing> | undefined;
  * just to read their titles cost ~1.1s on the first request to /blog.
  */
 export function getBlogPostListings(): Array<MarkdownPostListing> {
-  if (postListings) return postListings;
+  if (shouldCacheBlogData && postListings) return postListings;
 
   let listings: Array<MarkdownPostListing & { date: Date }> = [];
-  for (let [slug, contents] of Object.entries(postContentsBySlug)) {
+  for (let [slug, contents] of Object.entries(getPostContentsBySlug())) {
     let { attributes } = parseFrontMatter(contents);
     assert(
       isMarkdownPostFrontmatter(attributes),
@@ -103,19 +102,35 @@ export function getBlogPostListings(): Array<MarkdownPostListing> {
     });
   }
 
-  postListings = listings
+  let sortedListings = listings
     .sort((a, b) => b.date.getTime() - a.date.getTime())
     .map(({ date: _date, ...listing }) => listing);
 
-  return postListings;
+  if (shouldCacheBlogData) postListings = sortedListings;
+  return sortedListings;
 }
 
 export function getRawBlogPostMarkdown(slug: string): string {
-  let contents = postContentsBySlug[slug];
+  let contents = getPostContentsBySlug()[slug];
   if (!contents) {
     throw new Response("Not Found", { status: 404, statusText: "Not Found" });
   }
   return contents;
+}
+
+function getPostContentsBySlug(): Record<string, string> {
+  return cachedPostContentsBySlug ?? readPostContentsBySlug();
+}
+
+function readPostContentsBySlug(): Record<string, string> {
+  return Object.fromEntries(
+    readdirSync(POSTS_DIRECTORY, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+      .map((entry) => [
+        entry.name.replace(/\.md$/, ""),
+        readFileSync(path.join(POSTS_DIRECTORY, entry.name), "utf8"),
+      ]),
+  );
 }
 
 function getAuthor(name: string): BlogAuthor | undefined {

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createAssetServer, defineFileTransform } from "remix/assets";
@@ -13,6 +14,7 @@ let isHmr = Boolean(isDevelopment && process.env.REMIX_NODE_HMR);
 let config = await loadConfig(import.meta.dirname);
 if (!config.assets) throw new Error("Missing assets configuration");
 if (!config.assets.files) throw new Error("Missing asset file configuration");
+let rootDir = config.assets.rootDir;
 
 let buildId = isProduction ? getBuildId() : undefined;
 let webpInputExtensions = [".jpeg", ".jpg", ".png"] as const;
@@ -52,10 +54,7 @@ export let assets = createAssetServer({
   },
   sourceMaps: isDevelopment ? "external" : undefined,
   minify: isProduction,
-  hmr: isHmr
-    ? async () =>
-        (await import("remix/node-hmr/runtime")).createBrowserHmrChannel()
-    : undefined,
+  hmr: isHmr ? createAppBrowserHmrChannel : undefined,
   scripts: {
     define: {
       "process.env.NODE_ENV": JSON.stringify(nodeEnv),
@@ -64,6 +63,29 @@ export let assets = createAssetServer({
   },
   watch: isDevelopment,
 });
+
+async function createAppBrowserHmrChannel() {
+  let channel = await (
+    await import("remix/node-hmr/runtime")
+  ).createBrowserHmrChannel();
+  let postsDirectory = path.join(rootDir, "data/posts");
+  let postFilePaths = new Set(
+    readdirSync(postsDirectory, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+      .map((entry) => path.join(postsDirectory, entry.name)),
+  );
+
+  channel.updateWatchedFiles({ add: [...postFilePaths], remove: [] });
+  channel.onFileEvents(async (events) => {
+    let files = events
+      .map((event) => event.filePath)
+      .filter((filePath) => postFilePaths.has(filePath));
+
+    return files.length > 0 ? [{ type: "reload", files }] : [];
+  });
+
+  return channel;
+}
 
 export function getWebpHref(filePath: string, width?: number) {
   let transform = width === undefined ? "webp" : `webp-${width}`;

--- a/app/utils/cache-control.ts
+++ b/app/utils/cache-control.ts
@@ -4,7 +4,10 @@ export const CACHE_CONTROL = {
    * back/forward/etc. it's super fast. SWR for 1 week on CDN so it stays fast,
    * but people get typos/fixes and stuff too.
    */
-  DEFAULT: "max-age=300, stale-while-revalidate=604800",
+  DEFAULT:
+    process.env.NODE_ENV === "development"
+      ? "no-store"
+      : "max-age=300, stale-while-revalidate=604800",
   /**
    * Keep it in the browser (and CDN) for 1 day, we won't be updating these as
    * often until the conf is a bit closer, and we can prevent over-fetching from


### PR DESCRIPTION
## Summary

- re-read blog Markdown and listings outside production while preserving production caches
- register existing `data/posts/*.md` files with the browser HMR channel and reload when they change
- disable default response caching in development so reloads render fresh content
- cover development post reloading with a focused data test

## Validation

- `pnpm test` — 208 passed
- `pnpm run build`
- `pnpm remix doctor` — no issues
- `pnpm exec oxlint app/data/blog.test.ts app/data/blog.ts app/utils/assets.ts app/utils/cache-control.ts`
- manual HMR check: client returned 200 and editing an existing post emitted `browser:reload`

`pnpm run lint` was also attempted, but the full-repo linter process was terminated for memory usage; changed-file lint passed.
