### PR TITLE
Reduce landing page GPU and CPU usage

### DIFF
--- a/app/actions/home.tsx
+++ b/app/actions/home.tsx
@@ -1,5 +1,4 @@
 import { css, type Handle } from "remix/ui";
-import { FpsCounterToggle } from "../ui/public/fps-counter-toggle.tsx";
 import { RemixLandingEnhancements } from "./public/remix-landing/landing-enhancements.tsx";
 import { RUNNER_AVIF_SRC } from "./public/remix-landing/runner-media.ts";
 import { colors } from "./public/remix-landing/styles/tokens.ts";
@@ -70,14 +69,10 @@ export function HomePage(handle: Handle<HomePageProps>) {
       ]}
     >
       <div id="remix-landing-app" mix={[landingShellStyles]}>
-        {/* Keep the initially-empty landing enhancements client entry inside
-            a stable element so Remix document navigations can hydrate it after
-            diffing in from Jam pages. Without the host, the loading screen can
-            remain visible forever on client-side transitions to /. */}
+        {/* Keep a stable host so this entry hydrates after document navigations. */}
         <div>
           <RemixLandingEnhancements />
         </div>
-        <FpsCounterToggle />
         <main
           id="main-content"
           tabIndex={-1}

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -3,7 +3,7 @@ import { Matrix4, Vector3 } from "three";
 import { ControlManager } from "../engine/controls.ts";
 import { setDesiredCameraInto } from "../engine/camera-transition.ts";
 import { Engine } from "../engine/engine.ts";
-import { IDLE_AFTER_MS, shouldRenderFrame } from "../engine/frame-governor.ts";
+import { IDLE_AFTER_MS, nextRenderDeadline } from "../engine/frame-governor.ts";
 import {
   projectLabelsInto,
   type ProjectedLabel,
@@ -84,7 +84,6 @@ function buildInitialControls(preset: Preset): number[] {
   return controls;
 }
 
-/** Halve the particle budget on devices unlikely to keep up at full count. */
 function adaptiveParticleCount(base: number): number {
   const nav = navigator as Navigator & { deviceMemory?: number };
   const lowEnd =
@@ -141,7 +140,8 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
   const scratchCamRight = new Vector3();
   const scratchCamUp = new Vector3();
   let lastFrameNow = 0;
-  let lastRenderAt = 0;
+  let renderDeadline = 0;
+  let renderWasIdle = false;
   let lastActivityAt = 0;
   let lastActivityMorph = NaN;
   let lastStaticKey: string | null = null;
@@ -198,9 +198,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
   const MOUSE_SIM_BRUSH_SMOOTH_TAU = 14;
   const MOUSE_SIM_PUSH_GAIN =
     MOUSE_SIM_PEAK_DISP / (MOUSE_SIM_STRENGTH_SCALE * MOUSE_SIM_REPULSION_REF);
-  /** Post-brush decay window (uFollowTau = 10/s → disp ≈ 0 within 1s). */
   const MOUSE_SIM_SETTLE_S = 1.0;
-  // Starts settled: sim targets are cleared to zero at construction.
   let mouseSimSettleS = MOUSE_SIM_SETTLE_S;
 
   function setMousePosition(clientX: number, clientY: number) {
@@ -262,7 +260,8 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
     mouseVelPrimed = false;
     mouseNdcSpeedSmoothed = 0;
     mouseBrushSmoothed = 0;
-    lastRenderAt = 0;
+    renderDeadline = 0;
+    renderWasIdle = false;
     lastStaticKey = null;
     mouseSimSettleS = MOUSE_SIM_SETTLE_S;
   }
@@ -291,6 +290,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         model.positions.length / 3,
       );
       appliedModelSlots.add(preset.modelSlot);
+      lastStaticKey = null;
     }
   }
 
@@ -309,7 +309,12 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       restBaker.setCount(particleCount);
 
       particles = new ParticleSystem();
-      particles.init(engine.scene, particleCount, settings.pointSize);
+      particles.init(
+        engine.scene,
+        particleCount,
+        settings.pointSize,
+        engine.renderer.getPixelRatio(),
+      );
       // Bind the baker's MRT texture refs to the draw material once. Three
       // caches the references; subsequent bake() calls update the GL backing
       // in place.
@@ -379,20 +384,22 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       const morphValue = handle.props.morphValueRef.current;
       const reduceMotion = reducedMotion.current;
 
-      // Cap at 60fps (30fps when idle); rAF alone runs at native refresh.
-      // Morph movement counts as activity to cover programmatic jumps.
       if (morphValue !== lastActivityMorph) {
         lastActivityMorph = morphValue;
         lastActivityAt = now;
       }
       const idle = introFinished && now - lastActivityAt >= IDLE_AFTER_MS;
-      if (!shouldRenderFrame(now, lastRenderAt, idle)) {
+      if (idle !== renderWasIdle) {
+        renderWasIdle = idle;
+        renderDeadline = 0;
+      }
+      const nextDeadline = nextRenderDeadline(now, renderDeadline, idle);
+      if (nextDeadline === null) {
         frameId = requestAnimationFrame(animate);
         return;
       }
+      renderDeadline = nextDeadline;
 
-      // Under reduced motion the settled scene is fully static; skip
-      // rendering identical frames until one of these inputs changes.
       const staticKey =
         reduceMotion &&
         introFinished &&
@@ -405,7 +412,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         return;
       }
       lastStaticKey = staticKey;
-      lastRenderAt = now;
 
       const time = now / 1000 - startTime;
       // Real-time delta for the mouse sim. First frame falls back to a 60fps
@@ -462,7 +468,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         const brushTarget = linear * linear * (3 - 2 * linear);
         const kBrush = 1 - Math.exp(-MOUSE_SIM_BRUSH_SMOOTH_TAU * dtClamp);
         mouseBrushSmoothed += (brushTarget - mouseBrushSmoothed) * kBrush;
-        // Snap the exponential tail so the sim-settled skip can engage.
         if (mouseBrushSmoothed < 1e-3) mouseBrushSmoothed = 0;
         mouseBrushFactor = mouseBrushSmoothed;
       }
@@ -482,7 +487,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
           : Math.min(introTime / PARTICLE_INTRO_DURATION_S, 1.5);
       if (!introFinished && introProgress >= 1.5) {
         introFinished = true;
-        lastActivityAt = now; // grace period before idle fps kicks in
+        lastActivityAt = now;
       }
       particles.setIntroProgress(introProgress);
       particles.setTime(visualTime);
@@ -557,7 +562,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         ? 0
         : Math.min(effectiveTrail + trailBoost, 0.97);
       engine.afterImagePass.uniforms.damp.value = afterImageDamp;
-      // Zero damp = fullscreen no-op pass; let the composer skip it.
       engine.afterImagePass.enabled = afterImageDamp > 0.001;
 
       const driveIndex = presetData.driveIndex;
@@ -658,7 +662,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       // Run look-at once before reading view/proj so MouseSim matrices match
       // this frame's render (render() calls update() again later on).
       engine.controls.update();
-      // Step the sim only while the brush is active or still decaying.
       if (!reduceMotion && mouseBrushFactor > 0) {
         mouseSimSettleS = 0;
       } else {
@@ -667,7 +670,8 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
           MOUSE_SIM_SETTLE_S,
         );
       }
-      if (mouseSimSettleS < MOUSE_SIM_SETTLE_S) {
+      const displacementActive = mouseSimSettleS < MOUSE_SIM_SETTLE_S;
+      if (displacementActive) {
         scratchViewProj.multiplyMatrices(
           engine.camera.projectionMatrix,
           engine.camera.matrixWorldInverse,
@@ -689,6 +693,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         mouseSim.step(dtSeconds);
         particles.setDispTexture(mouseSim.getDispTexture());
       }
+      particles.setDisplacementEnabled(displacementActive);
 
       const nearest = Math.round(clamp(morphValue, 0, maxValue));
       if (nearest !== previousNearest) {
@@ -733,7 +738,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         handle.props.labelOpacityRef.current = 0;
       }
 
-      // visualTime freezes the background warp under reduced motion too.
       engine.render(visualTime);
       reveal ??= handle.props.onFirstFrame().then(() => {
         if (!handle.signal.aborted) {

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -55,6 +55,8 @@ const canvasStyles = css({
   display: "block",
   width: "100%",
   height: "100%",
+  objectFit: "cover",
+  objectPosition: "center",
 });
 
 function copyControlsInto(source: number[], target: number[]) {

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -3,6 +3,7 @@ import { Matrix4, Vector3 } from "three";
 import { ControlManager } from "../engine/controls.ts";
 import { setDesiredCameraInto } from "../engine/camera-transition.ts";
 import { Engine } from "../engine/engine.ts";
+import { IDLE_AFTER_MS, shouldRenderFrame } from "../engine/frame-governor.ts";
 import {
   projectLabelsInto,
   type ProjectedLabel,
@@ -130,6 +131,10 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
   const scratchCamRight = new Vector3();
   const scratchCamUp = new Vector3();
   let lastFrameNow = 0;
+  let lastRenderAt = 0;
+  let lastActivityAt = 0;
+  let lastActivityMorph = NaN;
+  let lastStaticKey: string | null = null;
   const scratchControlsA = [0, 0, 0, 0, 0, 0, 0, 0];
   const scratchControlsB = [0, 0, 0, 0, 0, 0, 0, 0];
   const scratchLabelControls = [0, 0, 0, 0, 0, 0, 0, 0];
@@ -183,8 +188,13 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
   const MOUSE_SIM_BRUSH_SMOOTH_TAU = 14;
   const MOUSE_SIM_PUSH_GAIN =
     MOUSE_SIM_PEAK_DISP / (MOUSE_SIM_STRENGTH_SCALE * MOUSE_SIM_REPULSION_REF);
+  /** Post-brush decay window (uFollowTau = 10/s → disp ≈ 0 within 1s). */
+  const MOUSE_SIM_SETTLE_S = 1.0;
+  // Starts settled: sim targets are cleared to zero at construction.
+  let mouseSimSettleS = MOUSE_SIM_SETTLE_S;
 
   function setMousePosition(clientX: number, clientY: number) {
+    lastActivityAt = performance.now();
     const vp = containerEl ?? canvasEl;
     if (vp) {
       const rect = vp.getBoundingClientRect();
@@ -218,6 +228,13 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
     },
     { signal: handle.signal },
   );
+  window.addEventListener(
+    "scroll",
+    () => {
+      lastActivityAt = performance.now();
+    },
+    { passive: true, signal: handle.signal },
+  );
 
   function disposeScene() {
     cancelAnimationFrame(frameId);
@@ -235,6 +252,9 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
     mouseVelPrimed = false;
     mouseNdcSpeedSmoothed = 0;
     mouseBrushSmoothed = 0;
+    lastRenderAt = 0;
+    lastStaticKey = null;
+    mouseSimSettleS = MOUSE_SIM_SETTLE_S;
   }
 
   handle.signal.addEventListener("abort", () => {
@@ -302,6 +322,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       particles.setDispTexture(mouseSim.getDispTexture());
 
       startTime = performance.now() / 1000;
+      lastActivityAt = performance.now();
       setDesiredCameraInto(
         presets,
         handle.props.morphValueRef.current,
@@ -344,6 +365,37 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       if (!engine || !particles || !restBaker || !mouseSim) return;
 
       const now = performance.now();
+      const morphValue = handle.props.morphValueRef.current;
+      const reduceMotion = reducedMotion.current;
+
+      // Cap at 60fps (30fps when idle); rAF alone runs at native refresh.
+      // Morph movement counts as activity to cover programmatic jumps.
+      if (morphValue !== lastActivityMorph) {
+        lastActivityMorph = morphValue;
+        lastActivityAt = now;
+      }
+      const idle = introFinished && now - lastActivityAt >= IDLE_AFTER_MS;
+      if (!shouldRenderFrame(now, lastRenderAt, idle)) {
+        frameId = requestAnimationFrame(animate);
+        return;
+      }
+
+      // Under reduced motion the settled scene is fully static; skip
+      // rendering identical frames until one of these inputs changes.
+      const staticKey =
+        reduceMotion &&
+        introFinished &&
+        mouseSimSettleS >= MOUSE_SIM_SETTLE_S &&
+        containerEl
+          ? `${morphValue}|${handle.props.brandGradientMode}|${containerEl.clientWidth}x${containerEl.clientHeight}`
+          : null;
+      if (staticKey !== null && staticKey === lastStaticKey) {
+        frameId = requestAnimationFrame(animate);
+        return;
+      }
+      lastStaticKey = staticKey;
+      lastRenderAt = now;
+
       const time = now / 1000 - startTime;
       // Real-time delta for the mouse sim. First frame falls back to a 60fps
       // step; afterwards it tracks actual frame pacing. MouseSim.step() also
@@ -355,8 +407,6 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         ? BRAND_MODE_SETTINGS
         : DEFAULT_SETTINGS;
       const presetData = PRESET_RUNTIME_DATA;
-      const morphValue = handle.props.morphValueRef.current;
-      const reduceMotion = reducedMotion.current;
 
       if (reduceMotion) {
         frozenTime ??= Math.max(time, PARTICLE_INTRO_DURATION_S);
@@ -401,6 +451,8 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         const brushTarget = linear * linear * (3 - 2 * linear);
         const kBrush = 1 - Math.exp(-MOUSE_SIM_BRUSH_SMOOTH_TAU * dtClamp);
         mouseBrushSmoothed += (brushTarget - mouseBrushSmoothed) * kBrush;
+        // Snap the exponential tail so the sim-settled skip can engage.
+        if (mouseBrushSmoothed < 1e-3) mouseBrushSmoothed = 0;
         mouseBrushFactor = mouseBrushSmoothed;
       }
 
@@ -417,7 +469,10 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         reduceMotion || introFinished
           ? 1.5
           : Math.min(introTime / PARTICLE_INTRO_DURATION_S, 1.5);
-      introFinished ||= introProgress >= 1.5;
+      if (!introFinished && introProgress >= 1.5) {
+        introFinished = true;
+        lastActivityAt = now; // grace period before idle fps kicks in
+      }
       particles.setIntroProgress(introProgress);
       particles.setTime(visualTime);
 
@@ -487,9 +542,12 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       const trailBoost = departingRacetrack
         ? Math.sin(racetrackDist * Math.PI) * 0.75
         : 0;
-      engine.afterImagePass.uniforms.damp.value = reduceMotion
+      const afterImageDamp = reduceMotion
         ? 0
         : Math.min(effectiveTrail + trailBoost, 0.97);
+      engine.afterImagePass.uniforms.damp.value = afterImageDamp;
+      // Zero damp = fullscreen no-op pass; let the composer skip it.
+      engine.afterImagePass.enabled = afterImageDamp > 0.001;
 
       const driveIndex = presetData.driveIndex;
       const racetrackFogDist =
@@ -589,26 +647,37 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       // Run look-at once before reading view/proj so MouseSim matrices match
       // this frame's render (render() calls update() again later on).
       engine.controls.update();
-      scratchViewProj.multiplyMatrices(
-        engine.camera.projectionMatrix,
-        engine.camera.matrixWorldInverse,
-      );
-      const ew = engine.camera.matrixWorld.elements;
-      scratchCamRight.set(ew[0], ew[1], ew[2]).normalize();
-      scratchCamUp.set(ew[4], ew[5], ew[6]).normalize();
-      mouseSim.setViewProj(scratchViewProj);
-      mouseSim.setCamBasis(scratchCamRight, scratchCamUp);
-      mouseSim.setMouseNDC(effectiveMouseNormX, -effectiveMouseNormY);
-      mouseSim.setBlend(blend);
-      mouseSim.setMorphT(morphT);
-      mouseSim.setMouseNdcRadius(MOUSE_SIM_NDC_RADIUS * mouseBrushFactor);
-      mouseSim.setMouseStrength(
-        reduceMotion
-          ? 0
-          : effectiveRepulsion * MOUSE_SIM_STRENGTH_SCALE * mouseBrushFactor,
-      );
-      mouseSim.step(dtSeconds);
-      particles.setDispTexture(mouseSim.getDispTexture());
+      // Step the sim only while the brush is active or still decaying.
+      if (!reduceMotion && mouseBrushFactor > 0) {
+        mouseSimSettleS = 0;
+      } else {
+        mouseSimSettleS = Math.min(
+          mouseSimSettleS + dtSeconds,
+          MOUSE_SIM_SETTLE_S,
+        );
+      }
+      if (mouseSimSettleS < MOUSE_SIM_SETTLE_S) {
+        scratchViewProj.multiplyMatrices(
+          engine.camera.projectionMatrix,
+          engine.camera.matrixWorldInverse,
+        );
+        const ew = engine.camera.matrixWorld.elements;
+        scratchCamRight.set(ew[0], ew[1], ew[2]).normalize();
+        scratchCamUp.set(ew[4], ew[5], ew[6]).normalize();
+        mouseSim.setViewProj(scratchViewProj);
+        mouseSim.setCamBasis(scratchCamRight, scratchCamUp);
+        mouseSim.setMouseNDC(effectiveMouseNormX, -effectiveMouseNormY);
+        mouseSim.setBlend(blend);
+        mouseSim.setMorphT(morphT);
+        mouseSim.setMouseNdcRadius(MOUSE_SIM_NDC_RADIUS * mouseBrushFactor);
+        mouseSim.setMouseStrength(
+          reduceMotion
+            ? 0
+            : effectiveRepulsion * MOUSE_SIM_STRENGTH_SCALE * mouseBrushFactor,
+        );
+        mouseSim.step(dtSeconds);
+        particles.setDispTexture(mouseSim.getDispTexture());
+      }
 
       const nearest = Math.round(clamp(morphValue, 0, maxValue));
       if (nearest !== previousNearest) {
@@ -653,7 +722,8 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         handle.props.labelOpacityRef.current = 0;
       }
 
-      engine.render(time);
+      // visualTime freezes the background warp under reduced motion too.
+      engine.render(visualTime);
       reveal ??= handle.props.onFirstFrame().then(() => {
         if (!handle.signal.aborted) {
           introStartTime = performance.now() / 1000 - startTime;

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -84,6 +84,16 @@ function buildInitialControls(preset: Preset): number[] {
   return controls;
 }
 
+/** Halve the particle budget on devices unlikely to keep up at full count. */
+function adaptiveParticleCount(base: number): number {
+  const nav = navigator as Navigator & { deviceMemory?: number };
+  const lowEnd =
+    window.matchMedia("(pointer: coarse)").matches ||
+    (nav.hardwareConcurrency || 8) <= 4 ||
+    (nav.deviceMemory ?? 8) <= 4;
+  return lowEnd ? Math.round(base / 2) : base;
+}
+
 const DRIVE_INDEX = presets.findIndex((preset) => preset.name === "Drive");
 const PRESET_RUNTIME_DATA = {
   controls: presets.map(buildInitialControls),
@@ -294,11 +304,12 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       engine = new Engine();
       engine.init(canvasEl, containerEl, settings);
 
-      restBaker = new RestBaker(engine.renderer, settings.particleCount);
-      restBaker.setCount(settings.particleCount);
+      const particleCount = adaptiveParticleCount(settings.particleCount);
+      restBaker = new RestBaker(engine.renderer, particleCount);
+      restBaker.setCount(particleCount);
 
       particles = new ParticleSystem();
-      particles.init(engine.scene, settings.particleCount, settings.pointSize);
+      particles.init(engine.scene, particleCount, settings.pointSize);
       // Bind the baker's MRT texture refs to the draw material once. Three
       // caches the references; subsequent bake() calls update the GL backing
       // in place.
@@ -310,7 +321,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       );
       syncModelTextures();
 
-      mouseSim = new MouseSim(engine.renderer, settings.particleCount);
+      mouseSim = new MouseSim(engine.renderer, particleCount);
       mouseSim.setRestTextures(
         restBaker.getPosTexture(0),
         restBaker.getPosTexture(1),

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -400,6 +400,11 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
       }
       renderDeadline = nextDeadline;
 
+      // Resize after the pacing gate so clearing targets is followed by a draw.
+      if (engine.resizeIfNeeded(now)) {
+        lastStaticKey = null;
+      }
+
       const staticKey =
         reduceMotion &&
         introFinished &&

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -20,7 +20,17 @@ function screenScale(width: number): number {
   return Math.min(width / ref, 1);
 }
 
+const MAX_PIXEL_RATIO = 1.5;
 const BLOOM_RESOLUTION_SCALE = 0.5;
+
+class HalfResolutionBloomPass extends UnrealBloomPass {
+  override setSize(width: number, height: number) {
+    super.setSize(
+      Math.max(1, Math.round(width * BLOOM_RESOLUTION_SCALE)),
+      Math.max(1, Math.round(height * BLOOM_RESOLUTION_SCALE)),
+    );
+  }
+}
 
 // Stand-in for `three/addons/controls/OrbitControls`. We only need the
 // look-at target and an enabled flag; the real addon pulled in pointer/touch/
@@ -73,36 +83,26 @@ export class Engine {
       canvas,
       antialias: false,
       alpha: false,
-      // The composer pipeline is fully alpha-blended with `depthWrite: false`
-      // and never reads/writes the stencil buffer, so we can drop both
-      // attachments to save bandwidth on the default framebuffer.
+      // No pass uses depth or stencil.
       depth: false,
       stencil: false,
-      // "default" lets the browser weigh hardware/battery state. Unlike the
-      // old "high-performance" it never forces the discrete GPU awake, and
-      // unlike "low-power" it can't pin this still-substantial workload to a
-      // weak iGPU on hybrid laptops we haven't measured on.
-      powerPreference: "default",
     });
-    // RestBaker and MouseSim render to float MRTs. Without this extension
-    // those targets fail silently (GL errors, not exceptions), leaving a
-    // black particle layer. Throw so ParticleCanvas's init try/catch
-    // degrades to the static page instead.
+    // Float MRTs require this extension; otherwise use the static fallback.
     if (!this.renderer.extensions.has("EXT_color_buffer_float")) {
       throw new Error(
         "EXT_color_buffer_float is not supported; skipping particle scene",
       );
     }
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setPixelRatio(
+      Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO),
+    );
     this.renderer.setSize(container.clientWidth, container.clientHeight);
     this.clearColor.set(settings.backgroundColor);
     this.renderer.setClearColor(this.clearColor);
 
     this.controls = new CameraTargetControls(this.camera);
 
-    // Match Three's default render-target type (HalfFloat) so tone reproduction
-    // through bloom/afterimage stays identical, but drop depth/stencil since
-    // no pass uses them.
+    // Preserve Three's HalfFloat color target without depth/stencil buffers.
     const composerTarget = new WebGLRenderTarget(1, 1, {
       type: HalfFloatType,
       depthBuffer: false,
@@ -110,9 +110,7 @@ export class Engine {
     });
     this.composer = new EffectComposer(this.renderer, composerTarget);
 
-    // Background pass draws the mesh gradient into the composer's read
-    // buffer first. RenderPass then runs with `clear = false` so particles
-    // composite on top of the gradient instead of wiping it to black.
+    // Render the gradient before particles without clearing the shared buffer.
     this.backgroundPass = new BackgroundPass();
     this.backgroundPass.setSize(container.clientWidth, container.clientHeight);
     this.composer.addPass(this.backgroundPass);
@@ -130,22 +128,12 @@ export class Engine {
       container.clientWidth,
       container.clientHeight,
     );
-    this.bloomPass = new UnrealBloomPass(
+    this.bloomPass = new HalfResolutionBloomPass(
       bloomSize,
       settings.bloomStrength * s,
       0.4,
       settings.bloomThreshold,
     );
-    // Bloom is the most expensive pass (~10 blur passes over 5 mips) and is
-    // a blur, so run it at half resolution (~4x less pixel work). Override
-    // setSize because the composer re-feeds full DPR size on every resize.
-    const bloomSetSize = this.bloomPass.setSize.bind(this.bloomPass);
-    this.bloomPass.setSize = (width: number, height: number) => {
-      bloomSetSize(
-        Math.max(1, Math.round(width * BLOOM_RESOLUTION_SCALE)),
-        Math.max(1, Math.round(height * BLOOM_RESOLUTION_SCALE)),
-      );
-    };
     this.composer.addPass(this.bloomPass);
 
     this.resizeObserver = new ResizeObserver(() =>

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -22,6 +22,7 @@ function screenScale(width: number): number {
 
 const MAX_PIXEL_RATIO = 1.5;
 const BLOOM_RESOLUTION_SCALE = 0.5;
+const RESIZE_SETTLE_MS = 100;
 
 class HalfResolutionBloomPass extends UnrealBloomPass {
   override setSize(width: number, height: number) {
@@ -59,7 +60,10 @@ export class Engine {
   backgroundPass!: BackgroundPass;
 
   private resizeObserver: ResizeObserver | null = null;
-  private containerWidth = 1440;
+  private container: HTMLElement | null = null;
+  private resizeRequestedAt: number | null = null;
+  private containerWidth = 0;
+  private containerHeight = 0;
   private lastAppliedSettings: SystemSettings | null = null;
   private lastAppliedWidth = -1;
   private clearColor = new Color();
@@ -96,7 +100,6 @@ export class Engine {
     this.renderer.setPixelRatio(
       Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO),
     );
-    this.renderer.setSize(container.clientWidth, container.clientHeight);
     this.clearColor.set(settings.backgroundColor);
     this.renderer.setClearColor(this.clearColor);
 
@@ -136,21 +139,45 @@ export class Engine {
     );
     this.composer.addPass(this.bloomPass);
 
-    this.resizeObserver = new ResizeObserver(() =>
-      this.handleResize(container),
-    );
+    this.container = container;
+    this.applyResize(container.clientWidth, container.clientHeight);
+    // setSize clears the canvas, so resize targets immediately before a frame.
+    this.resizeObserver = new ResizeObserver(() => {
+      this.resizeRequestedAt = performance.now();
+    });
     this.resizeObserver.observe(container);
   }
 
-  private handleResize(container: HTMLElement) {
-    const w = container.clientWidth;
-    const h = container.clientHeight;
-    this.containerWidth = w;
-    this.camera.aspect = w / h;
+  resizeIfNeeded(nowMs: number): boolean {
+    if (
+      !this.container ||
+      this.resizeRequestedAt === null ||
+      nowMs - this.resizeRequestedAt < RESIZE_SETTLE_MS
+    ) {
+      return false;
+    }
+
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    if (width <= 0 || height <= 0) return false;
+
+    this.resizeRequestedAt = null;
+    if (width === this.containerWidth && height === this.containerHeight) {
+      return false;
+    }
+
+    this.applyResize(width, height);
+    return true;
+  }
+
+  private applyResize(width: number, height: number) {
+    this.containerWidth = width;
+    this.containerHeight = height;
+    this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
-    this.renderer.setSize(w, h);
-    this.composer.setSize(w, h);
-    this.backgroundPass.setSize(w, h);
+    this.renderer.setSize(width, height, false);
+    this.composer.setSize(width, height);
+    this.backgroundPass.setSize(width, height);
   }
 
   getScreenScale(): number {
@@ -194,6 +221,9 @@ export class Engine {
 
   dispose() {
     this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.container = null;
+    this.resizeRequestedAt = null;
     this.controls?.dispose();
     this.renderer?.dispose();
     this.composer?.dispose();

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -20,6 +20,8 @@ function screenScale(width: number): number {
   return Math.min(width / ref, 1);
 }
 
+const BLOOM_RESOLUTION_SCALE = 0.5;
+
 // Stand-in for `three/addons/controls/OrbitControls`. We only need the
 // look-at target and an enabled flag; the real addon pulled in pointer/touch/
 // wheel gesture handlers and damping logic that the landing never used.
@@ -122,6 +124,16 @@ export class Engine {
       0.4,
       settings.bloomThreshold,
     );
+    // Bloom is the most expensive pass (~10 blur passes over 5 mips) and is
+    // a blur, so run it at half resolution (~4x less pixel work). Override
+    // setSize because the composer re-feeds full DPR size on every resize.
+    const bloomSetSize = this.bloomPass.setSize.bind(this.bloomPass);
+    this.bloomPass.setSize = (width: number, height: number) => {
+      bloomSetSize(
+        Math.max(1, Math.round(width * BLOOM_RESOLUTION_SCALE)),
+        Math.max(1, Math.round(height * BLOOM_RESOLUTION_SCALE)),
+      );
+    };
     this.composer.addPass(this.bloomPass);
 
     this.resizeObserver = new ResizeObserver(() =>

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -78,10 +78,21 @@ export class Engine {
       // attachments to save bandwidth on the default framebuffer.
       depth: false,
       stencil: false,
-      // Prefer the integrated GPU on dual-GPU laptops: with the frame cap
-      // and half-res bloom the workload fits, and it runs far cooler.
-      powerPreference: "low-power",
+      // "default" lets the browser weigh hardware/battery state. Unlike the
+      // old "high-performance" it never forces the discrete GPU awake, and
+      // unlike "low-power" it can't pin this still-substantial workload to a
+      // weak iGPU on hybrid laptops we haven't measured on.
+      powerPreference: "default",
     });
+    // RestBaker and MouseSim render to float MRTs. Without this extension
+    // those targets fail silently (GL errors, not exceptions), leaving a
+    // black particle layer. Throw so ParticleCanvas's init try/catch
+    // degrades to the static page instead.
+    if (!this.renderer.extensions.has("EXT_color_buffer_float")) {
+      throw new Error(
+        "EXT_color_buffer_float is not supported; skipping particle scene",
+      );
+    }
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(container.clientWidth, container.clientHeight);
     this.clearColor.set(settings.backgroundColor);

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -78,8 +78,9 @@ export class Engine {
       // attachments to save bandwidth on the default framebuffer.
       depth: false,
       stencil: false,
-      // Hint dual-GPU laptops to use the discrete GPU.
-      powerPreference: "high-performance",
+      // Prefer the integrated GPU on dual-GPU laptops: with the frame cap
+      // and half-res bloom the workload fits, and it runs far cooler.
+      powerPreference: "low-power",
     });
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(container.clientWidth, container.clientHeight);

--- a/app/actions/public/remix-landing/engine/engine.ts
+++ b/app/actions/public/remix-landing/engine/engine.ts
@@ -22,6 +22,7 @@ function screenScale(width: number): number {
 
 const MAX_PIXEL_RATIO = 1.5;
 const BLOOM_RESOLUTION_SCALE = 0.5;
+const LIVE_RESIZE_INTERVAL_MS = 1000 / 30;
 const RESIZE_SETTLE_MS = 100;
 
 class HalfResolutionBloomPass extends UnrealBloomPass {
@@ -62,6 +63,8 @@ export class Engine {
   private resizeObserver: ResizeObserver | null = null;
   private container: HTMLElement | null = null;
   private resizeRequestedAt: number | null = null;
+  private lastResizeAt = -Infinity;
+  private liveResize = false;
   private containerWidth = 0;
   private containerHeight = 0;
   private lastAppliedSettings: SystemSettings | null = null;
@@ -140,6 +143,9 @@ export class Engine {
     this.composer.addPass(this.bloomPass);
 
     this.container = container;
+    this.liveResize = window.matchMedia(
+      "(hover: hover) and (pointer: fine)",
+    ).matches;
     this.applyResize(container.clientWidth, container.clientHeight);
     // setSize clears the canvas, so resize targets immediately before a frame.
     this.resizeObserver = new ResizeObserver(() => {
@@ -149,11 +155,11 @@ export class Engine {
   }
 
   resizeIfNeeded(nowMs: number): boolean {
-    if (
-      !this.container ||
-      this.resizeRequestedAt === null ||
-      nowMs - this.resizeRequestedAt < RESIZE_SETTLE_MS
-    ) {
+    if (!this.container || this.resizeRequestedAt === null) return false;
+
+    if (this.liveResize) {
+      if (nowMs - this.lastResizeAt < LIVE_RESIZE_INTERVAL_MS) return false;
+    } else if (nowMs - this.resizeRequestedAt < RESIZE_SETTLE_MS) {
       return false;
     }
 
@@ -167,6 +173,7 @@ export class Engine {
     }
 
     this.applyResize(width, height);
+    this.lastResizeAt = nowMs;
     return true;
   }
 
@@ -224,6 +231,8 @@ export class Engine {
     this.resizeObserver = null;
     this.container = null;
     this.resizeRequestedAt = null;
+    this.lastResizeAt = -Infinity;
+    this.liveResize = false;
     this.controls?.dispose();
     this.renderer?.dispose();
     this.composer?.dispose();

--- a/app/actions/public/remix-landing/engine/frame-governor.test.ts
+++ b/app/actions/public/remix-landing/engine/frame-governor.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "remix/assert";
+import { it } from "remix/test";
+import { shouldRenderFrame } from "./frame-governor.ts";
+
+/** Count rendered frames over one second of rAF ticks at `refreshHz`. */
+function renderedFramesPerSecond(refreshHz: number, idle: boolean): number {
+  const tickMs = 1000 / refreshHz;
+  let lastRenderMs = 0;
+  let rendered = 0;
+  for (let tick = 0; tick < refreshHz; tick++) {
+    const nowMs = (tick + 1) * tickMs;
+    if (shouldRenderFrame(nowMs, lastRenderMs, idle)) {
+      lastRenderMs = nowMs;
+      rendered++;
+    }
+  }
+  return rendered;
+}
+
+it("renders the very first frame regardless of timing", () => {
+  expect(shouldRenderFrame(0, 0, false)).toBe(true);
+  expect(shouldRenderFrame(0, 0, true)).toBe(true);
+});
+
+it("locks a 120Hz display to ~60fps while active", () => {
+  expect(renderedFramesPerSecond(120, false)).toBe(60);
+});
+
+it("renders every tick on a 60Hz display while active", () => {
+  expect(renderedFramesPerSecond(60, false)).toBe(60);
+});
+
+it("drops to ~30fps when idle", () => {
+  expect(renderedFramesPerSecond(60, true)).toBe(30);
+  expect(renderedFramesPerSecond(120, true)).toBe(30);
+});
+
+it("tolerates rAF timestamp jitter without skipping extra ticks", () => {
+  // 60Hz ticks arriving ~1ms early must still render (16.67ms target).
+  expect(shouldRenderFrame(115.7, 100, false)).toBe(true);
+});

--- a/app/actions/public/remix-landing/engine/frame-governor.test.ts
+++ b/app/actions/public/remix-landing/engine/frame-governor.test.ts
@@ -1,41 +1,51 @@
 import { expect } from "remix/assert";
 import { it } from "remix/test";
-import { shouldRenderFrame } from "./frame-governor.ts";
+import { nextRenderDeadline } from "./frame-governor.ts";
 
-/** Count rendered frames over one second of rAF ticks at `refreshHz`. */
 function renderedFramesPerSecond(refreshHz: number, idle: boolean): number {
   const tickMs = 1000 / refreshHz;
-  let lastRenderMs = 0;
+  let deadlineMs = 0;
   let rendered = 0;
   for (let tick = 0; tick < refreshHz; tick++) {
-    const nowMs = (tick + 1) * tickMs;
-    if (shouldRenderFrame(nowMs, lastRenderMs, idle)) {
-      lastRenderMs = nowMs;
+    const nextDeadline = nextRenderDeadline(
+      (tick + 1) * tickMs,
+      deadlineMs,
+      idle,
+    );
+    if (nextDeadline !== null) {
+      deadlineMs = nextDeadline;
       rendered++;
     }
   }
   return rendered;
 }
 
-it("renders the very first frame regardless of timing", () => {
-  expect(shouldRenderFrame(0, 0, false)).toBe(true);
-  expect(shouldRenderFrame(0, 0, true)).toBe(true);
+it("renders the first frame", () => {
+  expect(nextRenderDeadline(0, 0, false)).not.toBe(null);
+  expect(nextRenderDeadline(0, 0, true)).not.toBe(null);
 });
 
-it("locks a 120Hz display to ~60fps while active", () => {
-  expect(renderedFramesPerSecond(120, false)).toBe(60);
-});
-
-it("renders every tick on a 60Hz display while active", () => {
+it("caps active rendering near 60fps across refresh rates", () => {
   expect(renderedFramesPerSecond(60, false)).toBe(60);
+  expect(renderedFramesPerSecond(75, false)).toBe(60);
+  expect(renderedFramesPerSecond(90, false)).toBe(60);
+  expect(renderedFramesPerSecond(120, false)).toBe(60);
+  expect(renderedFramesPerSecond(144, false)).toBe(60);
 });
 
 it("drops to ~30fps when idle", () => {
   expect(renderedFramesPerSecond(60, true)).toBe(30);
+  expect(renderedFramesPerSecond(90, true)).toBe(30);
   expect(renderedFramesPerSecond(120, true)).toBe(30);
 });
 
-it("tolerates rAF timestamp jitter without skipping extra ticks", () => {
-  // 60Hz ticks arriving ~1ms early must still render (16.67ms target).
-  expect(shouldRenderFrame(115.7, 100, false)).toBe(true);
+it("tolerates slightly early animation-frame timestamps", () => {
+  expect(nextRenderDeadline(115.7, 116.667, false)).not.toBe(null);
+});
+
+it("does not catch up missed frames after a long pause", () => {
+  const deadlineMs = nextRenderDeadline(100, 0, false)!;
+  const resumedDeadlineMs = nextRenderDeadline(10_000, deadlineMs, false)!;
+  expect(resumedDeadlineMs).toBeGreaterThan(10_000);
+  expect(nextRenderDeadline(10_001, resumedDeadlineMs, false)).toBe(null);
 });

--- a/app/actions/public/remix-landing/engine/frame-governor.ts
+++ b/app/actions/public/remix-landing/engine/frame-governor.ts
@@ -1,27 +1,21 @@
-/**
- * Frame pacing for the landing particle loop. rAF fires at native refresh
- * (120Hz on ProMotion); capping saves the entire GPU pipeline per skipped
- * tick, and an idle ambient scene needs even less.
- */
 export const ACTIVE_MAX_FPS = 60;
 export const IDLE_MAX_FPS = 30;
-
-/** How long after the last scroll/pointer/morph activity we drop to idle fps. */
 export const IDLE_AFTER_MS = 5000;
 
-/**
- * Accept a frame at >= 85% of the target interval: loose enough to absorb
- * rAF timestamp jitter without dropping ticks, strict enough that a 120Hz
- * display can't slip an extra tick (75% would run idle at 40fps, not 30).
- */
-const FRAME_ACCEPT_FRACTION = 0.85;
+const FRAME_TIME_TOLERANCE = 0.15;
 
-export function shouldRenderFrame(
+export function nextRenderDeadline(
   nowMs: number,
-  lastRenderMs: number,
+  deadlineMs: number,
   idle: boolean,
-): boolean {
-  if (lastRenderMs === 0) return true;
+): number | null {
   const intervalMs = 1000 / (idle ? IDLE_MAX_FPS : ACTIVE_MAX_FPS);
-  return nowMs - lastRenderMs >= intervalMs * FRAME_ACCEPT_FRACTION;
+  if (deadlineMs === 0) return nowMs + intervalMs;
+  if (nowMs < deadlineMs - intervalMs * FRAME_TIME_TOLERANCE) return null;
+
+  const elapsedIntervals = Math.max(
+    1,
+    Math.floor((nowMs - deadlineMs) / intervalMs) + 1,
+  );
+  return deadlineMs + elapsedIntervals * intervalMs;
 }

--- a/app/actions/public/remix-landing/engine/frame-governor.ts
+++ b/app/actions/public/remix-landing/engine/frame-governor.ts
@@ -1,0 +1,27 @@
+/**
+ * Frame pacing for the landing particle loop. rAF fires at native refresh
+ * (120Hz on ProMotion); capping saves the entire GPU pipeline per skipped
+ * tick, and an idle ambient scene needs even less.
+ */
+export const ACTIVE_MAX_FPS = 60;
+export const IDLE_MAX_FPS = 30;
+
+/** How long after the last scroll/pointer/morph activity we drop to idle fps. */
+export const IDLE_AFTER_MS = 5000;
+
+/**
+ * Accept a frame at >= 85% of the target interval: loose enough to absorb
+ * rAF timestamp jitter without dropping ticks, strict enough that a 120Hz
+ * display can't slip an extra tick (75% would run idle at 40fps, not 30).
+ */
+const FRAME_ACCEPT_FRACTION = 0.85;
+
+export function shouldRenderFrame(
+  nowMs: number,
+  lastRenderMs: number,
+  idle: boolean,
+): boolean {
+  if (lastRenderMs === 0) return true;
+  const intervalMs = 1000 / (idle ? IDLE_MAX_FPS : ACTIVE_MAX_FPS);
+  return nowMs - lastRenderMs >= intervalMs * FRAME_ACCEPT_FRACTION;
+}

--- a/app/actions/public/remix-landing/engine/mouse-sim.ts
+++ b/app/actions/public/remix-landing/engine/mouse-sim.ts
@@ -21,10 +21,7 @@ import { BAKE_TEX_W, computeBakeTexHeight } from "./rest-baker.ts";
 // Reused so the constructor's clear-pass doesn't allocate.
 const _scratchClearColor = new Color();
 
-// GPGPU mouse displacement. First-order exponential blend toward a **screen-space**
-// push: falloff uses NDC distance (same basis as particle rendering), and the
-// shove aligns with camera right/up so the hole tracks the cursor through
-// scene morphs / camera rotates. Ping-pong MRT retained; textures[1] cleared.
+// GPGPU mouse displacement, ping-ponged between two float textures.
 
 const SIM_VS = /* glsl */ `
 precision highp float;
@@ -62,14 +59,12 @@ uniform float uFollowTau; // smoothing rate (/s)
 uniform float uDt;
 uniform float uCount;
 
-layout(location = 0) out vec4 oDisp;
-layout(location = 1) out vec4 oVel;
+out vec4 oDisp;
 
 void main() {
   float fi = floor(gl_FragCoord.y) * ${BAKE_TEX_W}.0 + floor(gl_FragCoord.x);
   if (int(fi) >= int(uCount)) {
     oDisp = vec4(0.0);
-    oVel = vec4(0.0);
     return;
   }
 
@@ -108,37 +103,25 @@ void main() {
   disp = mix(disp, desired, a);
 
   oDisp = vec4(disp, 0.0);
-  oVel = vec4(0.0);
 }
 `;
 }
 
-type SimSlot = {
-  target: WebGLRenderTarget;
-  disp: Texture;
-  vel: Texture;
-};
-
 export class MouseSim {
   private renderer: WebGLRenderer;
-  private slots: [SimSlot, SimSlot];
+  private slots: [WebGLRenderTarget, WebGLRenderTarget];
   private current: 0 | 1 = 0;
   private scene: Scene;
   private camera: OrthographicCamera;
   private material: RawShaderMaterial;
   private mesh: Mesh;
-  readonly bakeTexHeight: number;
+  private readonly bakeTexHeight: number;
 
   constructor(renderer: WebGLRenderer, count: number) {
     this.renderer = renderer;
     this.bakeTexHeight = computeBakeTexHeight(count);
 
-    // FloatType to match RestBaker (the GPU/driver combo in this app is
-    // already known-good with float MRT). HalfFloat would save ~1.5MB but
-    // some Mac/Intel drivers silently zero MRT half-float writes, and the
-    // savings aren't worth the debug surface.
     const targetOptions = {
-      count: 2,
       type: FloatType,
       format: RGBAFormat,
       depthBuffer: false,
@@ -150,18 +133,8 @@ export class MouseSim {
       wrapT: ClampToEdgeWrapping,
     } as const;
 
-    const makeSlot = (): SimSlot => {
-      const target = new WebGLRenderTarget(
-        BAKE_TEX_W,
-        this.bakeTexHeight,
-        targetOptions,
-      );
-      return {
-        target,
-        disp: target.textures[0],
-        vel: target.textures[1],
-      };
-    };
+    const makeSlot = () =>
+      new WebGLRenderTarget(BAKE_TEX_W, this.bakeTexHeight, targetOptions);
     this.slots = [makeSlot(), makeSlot()];
 
     this.scene = new Scene();
@@ -194,16 +167,14 @@ export class MouseSim {
     this.mesh.frustumCulled = false;
     this.scene.add(this.mesh);
 
-    // Zero out both ping-pong slots so the first step() reads (0, 0, 0) for
-    // disp and vel rather than uninitialized GPU memory. WebGL2 doesn't
-    // guarantee zeroed render targets across all drivers, especially with MRT.
+    // Initialize both displacement textures to zero.
     const prev = renderer.getRenderTarget();
     const prevClearColor = renderer.getClearColor(_scratchClearColor).getHex();
     const prevClearAlpha = renderer.getClearAlpha();
     renderer.setClearColor(0x000000, 0);
-    renderer.setRenderTarget(this.slots[0].target);
+    renderer.setRenderTarget(this.slots[0]);
     renderer.clear(true, false, false);
-    renderer.setRenderTarget(this.slots[1].target);
+    renderer.setRenderTarget(this.slots[1]);
     renderer.clear(true, false, false);
     renderer.setRenderTarget(prev);
     renderer.setClearColor(prevClearColor, prevClearAlpha);
@@ -273,10 +244,6 @@ export class MouseSim {
     this.material.uniforms.uFollowTau.value = tau;
   }
 
-  setCount(count: number) {
-    this.material.uniforms.uCount.value = count;
-  }
-
   /**
    * Step the simulation by `dt` seconds. Reads the previous disp slot and
    * writes the next; swaps. `dt` is clamped for tab-switch stability.
@@ -288,24 +255,23 @@ export class MouseSim {
 
     const prev = this.slots[this.current];
     const next = this.slots[1 - this.current];
-    u.uDispPrev.value = prev.disp;
+    u.uDispPrev.value = prev.texture;
 
     const prevTarget = this.renderer.getRenderTarget();
-    this.renderer.setRenderTarget(next.target);
+    this.renderer.setRenderTarget(next);
     this.renderer.render(this.scene, this.camera);
     this.renderer.setRenderTarget(prevTarget);
 
     this.current = (1 - this.current) as 0 | 1;
   }
 
-  /** Latest displacement texture; bind once on the draw material. */
   getDispTexture(): Texture {
-    return this.slots[this.current].disp;
+    return this.slots[this.current].texture;
   }
 
   dispose() {
-    this.slots[0].target.dispose();
-    this.slots[1].target.dispose();
+    this.slots[0].dispose();
+    this.slots[1].dispose();
     this.material.dispose();
     this.mesh.geometry.dispose();
   }

--- a/app/actions/public/remix-landing/engine/particles.ts
+++ b/app/actions/public/remix-landing/engine/particles.ts
@@ -158,7 +158,9 @@ void main() {
     : 0.0;
   vCoc = clamp(coc, 0.0, 1.0);
 
-  gl_PointSize = clamp((baseSize + coc * 12.0) * aSizeBoost, 1.0, 128.0);
+  // Capped at 64px: additive-blended glow points are pure overdraw, and the
+  // cap only binds on extreme close fly-bys.
+  gl_PointSize = clamp((baseSize + coc * 12.0) * aSizeBoost, 1.0, 64.0);
   gl_Position = projectionMatrix * mvPosition;
   vAlpha = smoothstep(500.0, 50.0, dist);
 }

--- a/app/actions/public/remix-landing/engine/particles.ts
+++ b/app/actions/public/remix-landing/engine/particles.ts
@@ -10,7 +10,6 @@ import {
 } from "three";
 import { BAKE_TEX_W, computeBakeTexHeight } from "./rest-baker.ts";
 
-// ~7% of particles get gl_PointSize scaled in [SIZE_BOOST_MIN, SIZE_BOOST_MAX].
 const SIZE_BOOST_FRACTION = 0.03;
 const SIZE_BOOST_MIN = 1.32;
 const SIZE_BOOST_MAX = 3.05;
@@ -56,9 +55,8 @@ uniform sampler2D uPosB;
 uniform sampler2D uColA;
 uniform sampler2D uColB;
 
-// Per-particle displacement (offset from rest pose) produced by MouseSim.
-// xyz = world-space offset; w unused. Zero means "use rest pose as-is".
 uniform sampler2D uDispTex;
+uniform float uDispEnabled;
 
 vec3 hsl2rgb(float h, float s, float l) {
   float c = (1.0 - abs(2.0 * l - 1.0)) * s;
@@ -114,10 +112,9 @@ void main() {
   // (rest pose comes from textures); scale avoids affecting the scene.
   finalPos.xy += position.xy * 1e-7;
 
-  // GPGPU-driven cursor distortion: the sim writes a world-space offset into
-  // uDispTex each frame (spring-back to rest + cursor push + damping). When
-  // the strength is zero the disp settles to ~0 and this becomes a no-op.
-  finalPos += texture(uDispTex, uv).xyz;
+  if (uDispEnabled > 0.5) {
+    finalPos += texture(uDispTex, uv).xyz;
+  }
 
   if (uColorMode > 1.5) {
     float spatialRatio = fract(dot(finalPos, vec3(0.018, 0.014, 0.012)));
@@ -158,8 +155,7 @@ void main() {
     : 0.0;
   vCoc = clamp(coc, 0.0, 1.0);
 
-  // Capped at 64px: additive-blended glow points are pure overdraw, and the
-  // cap only binds on extreme close fly-bys.
+  // Bound glow overdraw on close fly-bys.
   gl_PointSize = clamp((baseSize + coc * 12.0) * aSizeBoost, 1.0, 64.0);
   gl_Position = projectionMatrix * mvPosition;
   vAlpha = smoothstep(500.0, 50.0, dist);
@@ -228,6 +224,7 @@ export class ParticleSystem {
   private lastFogNear = NaN;
   private lastFogFar = NaN;
   private lastBlend = NaN;
+  private lastDisplacementEnabled: boolean | null = null;
 
   private resetSetterCaches() {
     this.lastPointSize = NaN;
@@ -242,9 +239,10 @@ export class ParticleSystem {
     this.lastFogNear = NaN;
     this.lastFogFar = NaN;
     this.lastBlend = NaN;
+    this.lastDisplacementEnabled = null;
   }
 
-  init(scene: Scene, count: number, pointSize: number) {
+  init(scene: Scene, count: number, pointSize: number, pixelRatio: number) {
     this.dispose(scene);
     this.count = count;
     this.resetSetterCaches();
@@ -274,7 +272,7 @@ export class ParticleSystem {
       fragmentShader: FRAGMENT_SHADER,
       uniforms: {
         uPointSize: { value: pointSize },
-        uPixelRatio: { value: Math.min(window.devicePixelRatio, 2) },
+        uPixelRatio: { value: pixelRatio },
         uIntroProgress: { value: 0.0 },
         uFogEnabled: { value: 0.0 },
         uFogNear: { value: 10.0 },
@@ -292,6 +290,7 @@ export class ParticleSystem {
         uColA: { value: null as Texture | null },
         uColB: { value: null as Texture | null },
         uDispTex: { value: null as Texture | null },
+        uDispEnabled: { value: 0 },
       },
       transparent: true,
       blending: AdditiveBlending,
@@ -380,6 +379,12 @@ export class ParticleSystem {
   setDispTexture(disp: Texture) {
     if (!this.material) return;
     this.material.uniforms.uDispTex.value = disp;
+  }
+
+  setDisplacementEnabled(enabled: boolean) {
+    if (!this.material || enabled === this.lastDisplacementEnabled) return;
+    this.lastDisplacementEnabled = enabled;
+    this.material.uniforms.uDispEnabled.value = enabled ? 1 : 0;
   }
 
   setColorMode(value: number) {

--- a/app/actions/public/remix-landing/landing-enhancements.tsx
+++ b/app/actions/public/remix-landing/landing-enhancements.tsx
@@ -69,29 +69,9 @@ const appStyles = css({
   display: "contents",
 });
 
-// The previous implementation stacked five `backdrop-filter: blur()` panes of
-// increasing strength (2/4/8/16/32 px) to fake a progressive blur ramp. Each
-// pane forced the browser to run a separate Gaussian blur pass against the
-// scrolling content underneath on every frame — five stacked blurs over a
-// mix-blend-mode WebGL canvas. That was the dominant cost during scroll. A
-// single moderate blur with a shorter dynamic viewport height gives visually
-// similar "softest at top, clean at bottom" behavior with less content covered.
-const blurShellStyles = css({
-  position: "fixed",
-  top: "0",
-  left: "0",
-  right: "0",
-  height: "15dvh",
-  zIndex: "20",
-  pointerEvents: "none",
-  backdropFilter: "blur(16px)",
-  WebkitBackdropFilter: "blur(16px)",
-  maskImage:
-    "linear-gradient(to bottom, black 0%, black 25%, transparent 100%)",
-  WebkitMaskImage:
-    "linear-gradient(to bottom, black 0%, black 25%, transparent 100%)",
-});
-
+// Top-of-viewport legibility comes from this fade gradient alone. Earlier
+// versions added a backdrop-filter pane here, but any blur over the animating
+// canvas forces the compositor to re-blur a full-width band every frame.
 const topFadeGradientStyles = css({
   position: "fixed",
   top: "0",
@@ -123,6 +103,7 @@ const KONAMI_KEYS = [
 ] as const;
 
 const KONAMI_IDLE_MS = 4000;
+const BRAND_CYCLE_TICK_MS = 100;
 const LOADING_SCREEN_MIN_VISIBLE_MS = 750;
 const LANDING_SECTION_IDS = [
   "fully-stacked-web-framework",
@@ -412,6 +393,22 @@ export let RemixLandingEnhancements = clientEntry(
       }
     }
 
+    // The :root brand-cycle animation is paused in CSS; sample it here by
+    // sliding a negative animation-delay so color updates happen at 10Hz
+    // instead of every compositor frame.
+    function startBrandCycle() {
+      const start = performance.now();
+      const interval = setInterval(() => {
+        if (reducedMotion.current) return;
+        const elapsedS = (performance.now() - start) / 1000;
+        document.documentElement.style.animationDelay = `-${elapsedS.toFixed(2)}s`;
+      }, BRAND_CYCLE_TICK_MS);
+      handle.signal.addEventListener("abort", () => {
+        clearInterval(interval);
+        document.documentElement.style.animationDelay = "";
+      });
+    }
+
     function onKeydown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (isEditableKeyTarget(event)) return;
@@ -428,6 +425,7 @@ export let RemixLandingEnhancements = clientEntry(
         handle.update();
       });
       syncMorphToScroll();
+      startBrandCycle();
       void loadParticleCanvas().then(() => {
         if (!handle.signal.aborted) handle.update();
       });
@@ -483,7 +481,6 @@ export let RemixLandingEnhancements = clientEntry(
                 brandGradientMode={konami.brandMode}
               />
               <ScrollLogo />
-              <div mix={[blurShellStyles]} />
               <div mix={[topFadeGradientStyles]} />
               <LandingNav
                 activeIndexRef={activeIndexRef}

--- a/app/actions/public/remix-landing/landing-enhancements.tsx
+++ b/app/actions/public/remix-landing/landing-enhancements.tsx
@@ -69,9 +69,6 @@ const appStyles = css({
   display: "contents",
 });
 
-// Top-of-viewport legibility comes from this fade gradient alone. Earlier
-// versions added a backdrop-filter pane here, but any blur over the animating
-// canvas forces the compositor to re-blur a full-width band every frame.
 const topFadeGradientStyles = css({
   position: "fixed",
   top: "0",
@@ -393,13 +390,11 @@ export let RemixLandingEnhancements = clientEntry(
       }
     }
 
-    // The :root brand-cycle animation is paused in CSS; sample it here by
-    // sliding a negative animation-delay so color updates happen at 10Hz
-    // instead of every compositor frame.
+    // Advance the paused CSS animation at 10Hz instead of display refresh.
     function startBrandCycle() {
       const start = performance.now();
       const interval = setInterval(() => {
-        if (reducedMotion.current) return;
+        if (document.hidden || reducedMotion.current) return;
         const elapsedS = (performance.now() - start) / 1000;
         document.documentElement.style.animationDelay = `-${elapsedS.toFixed(2)}s`;
       }, BRAND_CYCLE_TICK_MS);

--- a/app/styles/public/home.css
+++ b/app/styles/public/home.css
@@ -27,7 +27,10 @@
 
 :root {
   color-scheme: dark;
-  animation: brand-cycle 10s linear infinite;
+  /* Paused; the landing client entry drives animation-delay at ~10Hz. A
+     running custom-property animation forces style invalidation at native
+     refresh (120Hz) forever, keeping the compositor from ever idling. */
+  animation: brand-cycle 10s linear infinite paused;
   scrollbar-width: thin;
   scrollbar-color: gray transparent;
 }

--- a/app/styles/public/home.css
+++ b/app/styles/public/home.css
@@ -27,9 +27,7 @@
 
 :root {
   color-scheme: dark;
-  /* Paused; the landing client entry drives animation-delay at ~10Hz. A
-     running custom-property animation forces style invalidation at native
-     refresh (120Hz) forever, keeping the compositor from ever idling. */
+  /* Advanced at 10Hz by the landing client entry. */
   animation: brand-cycle 10s linear infinite paused;
   scrollbar-width: thin;
   scrollbar-color: gray transparent;

--- a/test/home.test.e2e.ts
+++ b/test/home.test.e2e.ts
@@ -1,0 +1,52 @@
+import { expect, type Page } from "@playwright/test";
+import sharp from "sharp";
+import { createTestServer } from "remix/node-fetch-server/test";
+import { describe, it } from "remix/test";
+
+import { createAppRouter } from "../app/router.ts";
+import { routes } from "../app/routes.ts";
+import { swallowAbortErrors } from "./setup.ts";
+
+async function litPixelRatio(page: Page) {
+  const viewport = page.viewportSize();
+  if (!viewport) return 0;
+
+  const width = Math.min(200, viewport.width);
+  const height = Math.min(100, viewport.height);
+  const screenshot = await page.screenshot({
+    clip: { x: 0, y: viewport.height - height, width, height },
+  });
+  const { data } = await sharp(screenshot)
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  // This corner contains only WebGL; a cleared canvas has almost no lit pixels.
+  let litPixels = 0;
+  for (let i = 0; i < data.length; i += 3) {
+    if (data[i] + data[i + 1] + data[i + 2] > 15) litPixels++;
+  }
+  return litPixels / (data.length / 3);
+}
+
+describe("Home", () => {
+  it("keeps the particle scene visible after resizing with reduced motion", async (t) => {
+    const page = await t.serve(
+      await createTestServer(swallowAbortErrors(createAppRouter())),
+    );
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.setViewportSize({ width: 800, height: 500 });
+
+    const response = await page.goto(routes.home.href());
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator("canvas").first()).toBeVisible();
+    await expect.poll(() => litPixelRatio(page)).toBeGreaterThan(0.1);
+
+    for (let i = 1; i <= 10; i++) {
+      await page.setViewportSize({ width: 800 + i * 10, height: 500 + i * 10 });
+      await page.waitForTimeout(10);
+    }
+
+    await expect.poll(() => litPixelRatio(page)).toBeGreaterThan(0.1);
+  });
+});


### PR DESCRIPTION
## Summary

- Cap the particle scene at 60 FPS while active and 30 FPS after 5 seconds of inactivity.
- Stop unnecessary rendering under reduced motion and skip particle effects when they are not doing any work.
- Reduce rendering cost with half-resolution bloom, a lower pixel-ratio cap, fewer particles on lower-end devices, and smaller maximum particle sizes.
- Update the brand color animation at 10 FPS and remove the full-width backdrop blur that was forcing extra work every frame.
- Let the browser choose the GPU and fall back to the static page when the required WebGL extension is unavailable.
- Keep the particle canvas visible and correctly sized during window resizing.
- Add tests for frame pacing and canvas resizing under reduced motion.

## Results

Measured on an M-series laptop with a 120 Hz display:

| | Before | After |
| --- | ---: | ---: |
| Active WebGL renders/second | 119 | 59 |
| Idle WebGL renders/second | 120 | 30 |
| Idle CPU usage | ~82% of one core | ~34% of one core |
