### PR TITLE
Reduce runtime asset memory pressure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ CONVERTKIT_KEY="..."
 # Not used locally, but make sure this is set in GitHub for production
 FASTLY_API_TOKEN="..."
 FASTLY_SERVICE_ID="..."
+# Optional memory/throughput tuning for runtime image work. These defaults keep
+# native image operations bounded while still allowing limited parallelism.
+REMIX_IMAGE_CONCURRENCY="2"
+REMIX_SHARP_THREADS="2"
+REMIX_SHARP_CACHE_MEMORY_MB="16"
+
 # Optional. The newsletter archive (https://github.com/remix-run/newsletter) is
 # currently a private repository, so unauthenticated tarball fetches will fail.
 # Create a fine-scoped token at https://github.com/settings/tokens and set it

--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,6 @@ CONVERTKIT_KEY="..."
 # Not used locally, but make sure this is set in GitHub for production
 FASTLY_API_TOKEN="..."
 FASTLY_SERVICE_ID="..."
-# Optional memory/throughput tuning for runtime image work. These defaults keep
-# native image operations bounded while still allowing limited parallelism.
-REMIX_IMAGE_CONCURRENCY="2"
-REMIX_SHARP_THREADS="2"
-REMIX_SHARP_CACHE_MEMORY_MB="16"
-
 # Optional. The newsletter archive (https://github.com/remix-run/newsletter) is
 # currently a private repository, so unauthenticated tarball fetches will fail.
 # Create a fine-scoped token at https://github.com/settings/tokens and set it

--- a/app/actions/blog-og-image.test.ts
+++ b/app/actions/blog-og-image.test.ts
@@ -41,13 +41,25 @@ describe("Blog OG image route", () => {
   });
 
   it("returns a cacheable PNG for valid params", async (t) => {
-    t.mock.method(globalThis, "fetch", async () => {
-      let png = Buffer.from(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
-        "base64",
-      );
-      return new Response(png, { headers: { "Content-Type": "image/png" } });
-    });
+    let originalFetch = globalThis.fetch;
+    t.mock.method(
+      globalThis,
+      "fetch",
+      async (...args: Parameters<typeof fetch>) => {
+        let [input] = args;
+        if (!String(input).includes("/authors/")) {
+          return originalFetch(...args);
+        }
+
+        let png = Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+          "base64",
+        );
+        return new Response(png, {
+          headers: { "Content-Type": "image/png" },
+        });
+      },
+    );
     let router = createRouteTestRouter();
     router.map(routes, rootController);
 

--- a/app/actions/blog-og-image.tsx
+++ b/app/actions/blog-og-image.tsx
@@ -2,11 +2,9 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import getEmojiRegex from "emoji-regex";
 import * as s from "remix/data-schema";
-import { Resvg } from "@resvg/resvg-js";
-import satori from "satori";
-import sharp from "sharp";
 import { createAction } from "remix/router";
 import { routes } from "../routes.ts";
+import { sharp, withNativeImageOperation } from "../utils/native-image.ts";
 
 type ParsedOgImageQuery =
   | { success: true; value: OgImageQuery }
@@ -31,8 +29,10 @@ export let blogOgImageAction = createAction(
 
     let pngData;
     try {
-      let svg = await createOgImageSVG(request, parsedQuery.value);
-      pngData = await renderSvgToPng(svg);
+      pngData = await withNativeImageOperation(async () => {
+        let svg = await createOgImageSVG(request, parsedQuery.value);
+        return renderSvgToPng(svg);
+      });
     } catch (error) {
       let message = error instanceof Error ? error.message : String(error);
       return new Response(message || "Failed to generate image", {
@@ -95,7 +95,10 @@ export function parseOgImageQuery(request: Request): ParsedOgImageQuery {
 }
 
 async function createOgImageSVG(request: Request, data: OgImageQuery) {
-  let ogImageAssets = await getOgImageAssets();
+  let [{ default: satori }, ogImageAssets] = await Promise.all([
+    import("satori"),
+    getOgImageAssets(),
+  ]);
   let rootNode = createOgRootNode(request, data, ogImageAssets);
   return satori(rootNode, {
     width: 2400,
@@ -268,6 +271,7 @@ function toArrayBuffer(buffer: Buffer): ArrayBuffer {
 }
 
 async function renderSvgToPng(svg: string): Promise<Uint8Array> {
+  let { Resvg } = await import("@resvg/resvg-js");
   let png = new Resvg(svg).render().asPng();
   return sharp(png).png({ compressionLevel: 9, effort: 6 }).toBuffer();
 }

--- a/app/actions/newsletter/archive.test.ts
+++ b/app/actions/newsletter/archive.test.ts
@@ -1,6 +1,9 @@
-import { describe, it } from "remix/test";
-import { expect } from "remix/assert";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { gzipSync } from "node:zlib";
+import { expect } from "remix/assert";
+import { describe, it } from "remix/test";
 
 import { routes } from "../../routes.ts";
 import {
@@ -368,6 +371,35 @@ describe("createGitHubNewsletterRepository", () => {
     await expect(repo.listSummaries()).rejects.toBeInstanceOf(
       NewsletterUpstreamUnavailableError,
     );
+  });
+
+  it("serves images from a filesystem-backed snapshot", async (t) => {
+    let imageCacheDir = await mkdtemp(
+      path.join(os.tmpdir(), "remix-newsletter-test-"),
+    );
+    t.after(() => rm(imageCacheDir, { recursive: true, force: true }));
+    let repo = createGitHubNewsletterRepository({
+      token: "[REDACTED:SECRET]",
+      imageCacheDir,
+      fetchImpl: fakeTarballFetch([
+        issueFile(1, "2024-01-01", "![Cover](cover.png)"),
+        imageFile(1, "cover.png"),
+      ]),
+    });
+
+    await repo.listSummaries();
+    let cacheGenerations = await readdir(imageCacheDir);
+    expect(cacheGenerations).toHaveLength(1);
+    let cachedImagePath = path.join(
+      imageCacheDir,
+      cacheGenerations[0],
+      "newsletter-1",
+      "cover.png",
+    );
+    await writeFile(cachedImagePath, "filesystem-image");
+
+    let image = await repo.getImage(1, "cover.png");
+    expect(new TextDecoder().decode(image?.bytes)).toBe("filesystem-image");
   });
 
   it("returns null for missing issues and missing/unsafe images", async () => {

--- a/app/actions/newsletter/archive.ts
+++ b/app/actions/newsletter/archive.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import parseFrontMatter from "front-matter";
 import { detectMimeType } from "remix/mime";
 import { parseTar } from "remix/tar-parser";
@@ -11,7 +15,8 @@ import { env } from "../../utils/env.ts";
  * Issues live in the private `remix-run/newsletter` GitHub repository under
  * `newsletters/newsletter-<N>/<YYYY-MM-DD>-remix-newsletter-<N>.md`, with any
  * images beside the markdown. We fetch a single repository tarball at runtime,
- * parse it once, and keep a parsed snapshot in memory.
+ * parse it once, and keep parsed content plus image file references in memory.
+ * The live repository stores image bytes in a process-local disk cache.
  */
 
 const NEWSLETTER_REPO_OWNER = "remix-run";
@@ -80,7 +85,8 @@ interface ParsedIssue {
 interface NewsletterSnapshot {
   issues: ParsedIssue[];
   summaries: NewsletterSummary[];
-  files: Map<string, Uint8Array>;
+  files: Map<string, Uint8Array | string>;
+  imageCacheDirectory?: string;
 }
 
 export interface RawTarFile {
@@ -163,9 +169,11 @@ export function parseNewsletterSnapshot(
   issues.sort((a, b) => b.number - a.number);
   issues = issues.slice(0, MAX_ISSUES);
 
-  let fileMap = new Map<string, Uint8Array>();
+  let fileMap = new Map<string, Uint8Array | string>();
   for (let file of files) {
-    let [directory, filename] = file.name.split("/");
+    let parts = file.name.split("/");
+    if (parts.length !== 2) continue;
+    let [directory, filename] = parts;
     if (
       !directory ||
       !filename ||
@@ -319,6 +327,7 @@ export function createGitHubNewsletterRepository(
     token?: string;
     fetchImpl?: typeof fetch;
     ttlMs?: number;
+    imageCacheDir?: string;
     onRefreshError?: (
       error: unknown,
       context: { servingStale: boolean },
@@ -331,9 +340,11 @@ export function createGitHubNewsletterRepository(
   let token = options.token;
   let fetchImpl = options.fetchImpl ?? globalThis.fetch;
   let ttlMs = options.ttlMs ?? FRESH_TTL_MS;
+  let imageCacheDir = options.imageCacheDir;
   let onRefreshError = options.onRefreshError;
 
   let snapshot: NewsletterSnapshot | null = null;
+  let retiredImageCacheDirectory: string | undefined;
   let expiresAt = 0;
   let refreshPromise: Promise<NewsletterSnapshot> | null = null;
 
@@ -341,8 +352,24 @@ export function createGitHubNewsletterRepository(
     try {
       let files = await fetchTarballFiles(fetchImpl, owner, repo, ref, token);
       let next = parseNewsletterSnapshot(files);
+      if (imageCacheDir) {
+        await persistNewsletterImages(next, imageCacheDir);
+      }
+
+      let previousSnapshot = snapshot;
       snapshot = next;
       expiresAt = Date.now() + ttlMs;
+      if (retiredImageCacheDirectory) {
+        void rm(retiredImageCacheDirectory, {
+          recursive: true,
+          force: true,
+        }).catch((error) =>
+          console.error("[newsletter] Failed to remove retired image cache", {
+            error,
+          }),
+        );
+      }
+      retiredImageCacheDirectory = previousSnapshot?.imageCacheDirectory;
       return next;
     } catch (error) {
       onRefreshError?.(error, { servingStale: snapshot != null });
@@ -394,10 +421,21 @@ export function createGitHubNewsletterRepository(
       if (!Number.isInteger(number) || number <= 0) return null;
       if (!isSafeImageFilename(filename)) return null;
       let snap = await getSnapshot();
-      let bytes = snap.files.get(`newsletter-${number}/${filename}`);
-      if (!bytes) return null;
+      let cachedImage = snap.files.get(`newsletter-${number}/${filename}`);
+      if (!cachedImage) return null;
       let mimeType = detectMimeType(filename);
       if (!mimeType || !isSafeImageContentType(mimeType)) return null;
+
+      let bytes;
+      try {
+        bytes =
+          typeof cachedImage === "string"
+            ? new Uint8Array(await readFile(cachedImage))
+            : cachedImage;
+      } catch (error) {
+        if (isFileNotFoundError(error)) return null;
+        throw error;
+      }
       return { filename, contentType: mimeType, bytes };
     },
   };
@@ -460,11 +498,47 @@ async function fetchTarballFiles(
   return collectNewsletterFiles(stream);
 }
 
+async function persistNewsletterImages(
+  snapshot: NewsletterSnapshot,
+  cacheRoot: string,
+) {
+  let cacheDirectory = path.join(cacheRoot, randomUUID());
+  try {
+    for (let [key, bytes] of snapshot.files) {
+      if (typeof bytes === "string") continue;
+
+      let filePath = path.join(cacheDirectory, key);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, bytes);
+      snapshot.files.set(key, filePath);
+    }
+    snapshot.imageCacheDirectory = cacheDirectory;
+  } catch (error) {
+    await rm(cacheDirectory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function isFileNotFoundError(
+  error: unknown,
+): error is NodeJS.ErrnoException & { code: "ENOENT" | "ENOTDIR" } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
 /**
  * Shared live repository. Reusing one process-wide instance keeps the in-memory
  * cache and concurrent-refresh dedupe effective across requests.
  */
 export const liveNewsletterRepository = createGitHubNewsletterRepository({
+  imageCacheDir: path.join(
+    os.tmpdir(),
+    "remix-website-newsletter",
+    `process-${process.pid}`,
+  ),
   onRefreshError(error, { servingStale }) {
     console.error("[newsletter] GitHub archive refresh failed", {
       servingStale,

--- a/app/data/md.ts
+++ b/app/data/md.ts
@@ -6,7 +6,6 @@
  *   - MIT https://github.com/ggoodman/nostalgie/blob/45f3f6356684287a214dab667064ec9776def933/LICENSE
  *   - https://github.com/ggoodman/nostalgie/blob/45f3f6356684287a214dab667064ec9776def933/src/worker/mdxCompiler.ts
  */
-import { getHighlighter, toShikiTheme } from "shiki";
 import rangeParser from "parse-numeric-range";
 import parseFrontMatter from "front-matter";
 import type * as Hast from "hast";
@@ -167,10 +166,12 @@ type InternalPlugin<
 > = Unified.Plugin<[], Input, Output>;
 
 async function loadPlugins() {
-  let [{ visit, SKIP }, { htmlEscape }] = await Promise.all([
-    import("unist-util-visit"),
-    import("escape-goat"),
-  ]);
+  let [{ visit, SKIP }, { htmlEscape }, { getHighlighter, toShikiTheme }] =
+    await Promise.all([
+      import("unist-util-visit"),
+      import("escape-goat"),
+      import("shiki"),
+    ]);
 
   const stripLinkExtPlugin: InternalPlugin<
     UnistNode.Root,

--- a/app/middleware/asset-entry.test.ts
+++ b/app/middleware/asset-entry.test.ts
@@ -1,0 +1,20 @@
+import * as path from "node:path";
+import { expect } from "remix/assert";
+import { createRouter } from "remix/router";
+import { describe, it } from "remix/test";
+
+import { loadAssetEntry } from "./asset-entry.ts";
+
+describe("asset entry middleware", () => {
+  it("does not resolve the document asset graph for health or asset requests", async () => {
+    let missingEntry = path.join(import.meta.dirname, "missing-entry.ts");
+    let router = createRouter({ middleware: [loadAssetEntry(missingEntry)] });
+    router.get("/healthcheck", () => new Response("OK"));
+    router.get("/assets/*path", () => new Response("asset"));
+
+    for (let pathname of ["/healthcheck", "/assets/app/entry.ts"]) {
+      let response = await router.fetch(new URL(pathname, "http://localhost"));
+      expect(response.status).toBe(200);
+    }
+  });
+});

--- a/app/middleware/asset-entry.ts
+++ b/app/middleware/asset-entry.ts
@@ -24,6 +24,7 @@ interface StylesheetAsset {
 }
 
 let assetEntryKey = createContextKey<AssetEntry>();
+let productionDefaultEntryPromise: Promise<AssetEntry> | undefined;
 let defaultEntry = path.resolve(
   import.meta.dirname,
   "../actions/public/entry.ts",
@@ -61,45 +62,61 @@ export function loadAssetEntry(
   entry = defaultEntry,
 ): Middleware<AssetEntryContextEntry> {
   return async (context, next) => {
-    let [fonts, src, preloads, stylesheets] = await Promise.all([
-      Promise.all(
-        Object.entries(fontEntries).map(async ([name, fontEntry]) => {
-          let href = await assets.getHref(fontEntry);
-          return [name, { href }] as const;
-        }),
-      ).then(
-        (entries) => Object.fromEntries(entries) as Record<FontName, FontAsset>,
-      ),
-      assets.getHref(entry),
-      assets.getPreloads(entry).catch((error) => {
-        // Surface asset compilation errors without breaking HTML rendering.
-        console.error(error);
-        return [];
-      }),
-      Promise.all(
-        Object.entries(stylesheetEntries).map(
-          async ([name, stylesheetEntry]) => {
-            let href = await assets.getHref(stylesheetEntry);
-            return [name, { href }] as const;
-          },
-        ),
-      ).then(
-        (entries) =>
-          Object.fromEntries(entries) as Record<
-            StylesheetName,
-            StylesheetAsset
-          >,
-      ),
-    ]);
+    if (shouldBypassAssetEntry(context.url.pathname)) return next();
 
-    context.set(assetEntryKey, {
-      fonts,
-      src,
-      preloads,
-      stylesheets,
-    });
+    context.set(assetEntryKey, await getResolvedAssetEntry(entry));
     return next();
   };
+}
+
+function getResolvedAssetEntry(entry: string): Promise<AssetEntry> {
+  if (process.env.NODE_ENV !== "production" || entry !== defaultEntry) {
+    return resolveAssetEntry(entry);
+  }
+
+  productionDefaultEntryPromise ??= resolveAssetEntry(entry).catch((error) => {
+    productionDefaultEntryPromise = undefined;
+    throw error;
+  });
+  return productionDefaultEntryPromise;
+}
+
+async function resolveAssetEntry(entry: string): Promise<AssetEntry> {
+  let [fonts, src, preloads, stylesheets] = await Promise.all([
+    Promise.all(
+      Object.entries(fontEntries).map(async ([name, fontEntry]) => {
+        let href = await assets.getHref(fontEntry);
+        return [name, { href }] as const;
+      }),
+    ).then(
+      (entries) => Object.fromEntries(entries) as Record<FontName, FontAsset>,
+    ),
+    assets.getHref(entry),
+    assets.getPreloads(entry).catch((error) => {
+      // Surface asset compilation errors without breaking HTML rendering.
+      console.error(error);
+      return [];
+    }),
+    Promise.all(
+      Object.entries(stylesheetEntries).map(async ([name, stylesheetEntry]) => {
+        let href = await assets.getHref(stylesheetEntry);
+        return [name, { href }] as const;
+      }),
+    ).then(
+      (entries) =>
+        Object.fromEntries(entries) as Record<StylesheetName, StylesheetAsset>,
+    ),
+  ]);
+
+  return { fonts, src, preloads, stylesheets };
+}
+
+function shouldBypassAssetEntry(pathname: string) {
+  return (
+    pathname === "/healthcheck" ||
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/")
+  );
 }
 
 export function getAssetEntry(

--- a/app/middleware/render.ts
+++ b/app/middleware/render.ts
@@ -7,6 +7,7 @@ import { renderToStream, type ResolveFrameContext } from "remix/ui/server";
 import { assets } from "../utils/assets.ts";
 
 const isDevelopment = process.env.NODE_ENV === "development";
+const isProduction = process.env.NODE_ENV === "production";
 
 export interface AppRenderer {
   (node: RemixNode, init?: ResponseInit): Response;
@@ -185,6 +186,11 @@ function createCrossOriginFrameHeaders(headers: Headers) {
   return crossOriginHeaders;
 }
 
+let productionClientEntryPromises = new Map<
+  string,
+  Promise<{ href: string; exportName: string; preloads: string[] }>
+>();
+
 async function resolveClientEntry(
   entryId: string,
   component: { readonly name: string },
@@ -204,6 +210,21 @@ async function resolveClientEntry(
     return { href: sourceId, exportName };
   }
 
+  if (!isProduction) return resolveFileClientEntry(sourceId, exportName);
+
+  let cacheKey = `${sourceId}\0${exportName}`;
+  let existing = productionClientEntryPromises.get(cacheKey);
+  if (existing) return existing;
+
+  let promise = resolveFileClientEntry(sourceId, exportName).catch((error) => {
+    productionClientEntryPromises.delete(cacheKey);
+    throw error;
+  });
+  productionClientEntryPromises.set(cacheKey, promise);
+  return promise;
+}
+
+async function resolveFileClientEntry(sourceId: string, exportName: string) {
   let [href, preloads] = await Promise.all([
     assets.getHref(sourceId),
     assets.getPreloads(sourceId),

--- a/app/utils/assets.ts
+++ b/app/utils/assets.ts
@@ -5,7 +5,8 @@ import { createAssetServer, defineFileTransform } from "remix/assets";
 import { loadConfig } from "remix/cli";
 import { createFsFileStorage } from "remix/file-storage/fs";
 import { uiHmr } from "remix/ui-hmr/assets";
-import sharp from "sharp";
+
+import { sharp, withNativeImageOperation } from "./native-image.ts";
 
 let nodeEnv = process.env.NODE_ENV ?? "development";
 let isDevelopment = nodeEnv === "development";
@@ -101,18 +102,20 @@ export function getWebpHref(filePath: string, width?: number) {
 function createWebpTransform(width?: number) {
   return defineFileTransform({
     extensions: webpInputExtensions,
-    async transform(bytes) {
-      let image = sharp(bytes).rotate();
-      if (width) {
-        image.resize({ width, withoutEnlargement: true });
-      }
+    transform(bytes) {
+      return withNativeImageOperation(async () => {
+        let image = sharp(bytes).rotate();
+        if (width) {
+          image.resize({ width, withoutEnlargement: true });
+        }
 
-      let content = await image
-        .webp({ quality: 80, smartSubsample: true })
-        .toBuffer();
-      if (!width && content.byteLength >= bytes.byteLength) return bytes;
+        let content = await image
+          .webp({ quality: 80, smartSubsample: true })
+          .toBuffer();
+        if (!width && content.byteLength >= bytes.byteLength) return bytes;
 
-      return { content, extension: ".webp" };
+        return { content, extension: ".webp" };
+      });
     },
   });
 }

--- a/app/utils/blog-image-assets.ts
+++ b/app/utils/blog-image-assets.ts
@@ -1,8 +1,9 @@
 import * as path from "node:path";
-import sharp, { type Metadata } from "sharp";
+import type { Metadata } from "sharp";
 import { createMatcher } from "remix/route-pattern/match";
 
 import { assets, getWebpHref } from "./assets.ts";
+import { sharp, withNativeImageOperation } from "./native-image.ts";
 
 let imageSourceMatcher = createMatcher("http(s)://remix.run/:directory/*path");
 
@@ -55,7 +56,9 @@ async function createImageAsset(
     let filePath = path.join("public", directory, match.params.path);
     let extension = path.extname(filePath).toLowerCase();
     let [metadata, originalSrc] = await Promise.all([
-      sharp(path.resolve(import.meta.dirname, "../..", filePath)).metadata(),
+      withNativeImageOperation(() =>
+        sharp(path.resolve(import.meta.dirname, "../..", filePath)).metadata(),
+      ),
       assets.getHref(filePath),
     ]);
     let dimensions = getOrientedDimensions(metadata);

--- a/app/utils/native-image.test.ts
+++ b/app/utils/native-image.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "remix/assert";
+import { describe, it } from "remix/test";
+
+import {
+  nativeImageOperationConcurrency,
+  withNativeImageOperation,
+} from "./native-image.ts";
+
+describe("native image operation limit", () => {
+  it("queues work above the configured operation concurrency", async () => {
+    let active = 0;
+    let highestActive = 0;
+    let releases: Array<() => void> = [];
+
+    let operations = Array.from(
+      { length: nativeImageOperationConcurrency + 1 },
+      () =>
+        withNativeImageOperation(async () => {
+          active++;
+          highestActive = Math.max(highestActive, active);
+          await new Promise<void>((resolve) => releases.push(resolve));
+          active--;
+        }),
+    );
+
+    await waitFor(() => releases.length === nativeImageOperationConcurrency);
+    expect(active).toBe(nativeImageOperationConcurrency);
+    expect(highestActive).toBe(nativeImageOperationConcurrency);
+
+    releases.shift()!();
+    await waitFor(() => releases.length === nativeImageOperationConcurrency);
+    expect(highestActive).toBe(nativeImageOperationConcurrency);
+
+    for (let release of releases) release();
+    await Promise.all(operations);
+    expect(active).toBe(0);
+  });
+});
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for image operation state");
+}

--- a/app/utils/native-image.ts
+++ b/app/utils/native-image.ts
@@ -1,0 +1,68 @@
+import sharp from "sharp";
+
+export const nativeImageOperationConcurrency = readIntegerEnvironmentValue(
+  "REMIX_IMAGE_CONCURRENCY",
+  2,
+  { minimum: 1 },
+);
+const sharpThreadConcurrency = readIntegerEnvironmentValue(
+  "REMIX_SHARP_THREADS",
+  2,
+  { minimum: 1 },
+);
+const sharpCacheMemoryMb = readIntegerEnvironmentValue(
+  "REMIX_SHARP_CACHE_MEMORY_MB",
+  16,
+  { minimum: 0 },
+);
+
+sharp.cache({ memory: sharpCacheMemoryMb });
+sharp.concurrency(sharpThreadConcurrency);
+
+let activeOperations = 0;
+let waiters: Array<() => void> = [];
+
+/**
+ * Bounds concurrent native image work across asset transforms, metadata reads,
+ * and generated Open Graph images. Sharp's own concurrency setting controls
+ * worker threads within one operation; this controls the number of operations.
+ */
+export async function withNativeImageOperation<T>(
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  if (activeOperations < nativeImageOperationConcurrency) {
+    activeOperations++;
+  } else {
+    await new Promise<void>((resolve) => waiters.push(resolve));
+  }
+
+  try {
+    return await operation();
+  } finally {
+    let next = waiters.shift();
+    if (next) {
+      next();
+    } else {
+      activeOperations--;
+    }
+  }
+}
+
+export { sharp };
+
+function readIntegerEnvironmentValue(
+  name: string,
+  fallback: number,
+  { minimum }: { minimum: number },
+) {
+  let rawValue = process.env[name];
+  if (rawValue === undefined || rawValue === "") return fallback;
+
+  let value = Number(rawValue);
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(
+      `${name} must be an integer greater than or equal to ${minimum}`,
+    );
+  }
+  return value;
+}

--- a/app/utils/native-image.ts
+++ b/app/utils/native-image.ts
@@ -1,23 +1,9 @@
 import sharp from "sharp";
 
-export const nativeImageOperationConcurrency = readIntegerEnvironmentValue(
-  "REMIX_IMAGE_CONCURRENCY",
-  2,
-  { minimum: 1 },
-);
-const sharpThreadConcurrency = readIntegerEnvironmentValue(
-  "REMIX_SHARP_THREADS",
-  2,
-  { minimum: 1 },
-);
-const sharpCacheMemoryMb = readIntegerEnvironmentValue(
-  "REMIX_SHARP_CACHE_MEMORY_MB",
-  16,
-  { minimum: 0 },
-);
+export const nativeImageOperationConcurrency = 2;
 
-sharp.cache({ memory: sharpCacheMemoryMb });
-sharp.concurrency(sharpThreadConcurrency);
+sharp.cache({ memory: 16 });
+sharp.concurrency(2);
 
 let activeOperations = 0;
 let waiters: Array<() => void> = [];
@@ -49,20 +35,3 @@ export async function withNativeImageOperation<T>(
 }
 
 export { sharp };
-
-function readIntegerEnvironmentValue(
-  name: string,
-  fallback: number,
-  { minimum }: { minimum: number },
-) {
-  let rawValue = process.env[name];
-  if (rawValue === undefined || rawValue === "") return fallback;
-
-  let value = Number(rawValue);
-  if (!Number.isInteger(value) || value < minimum) {
-    throw new Error(
-      `${name} must be an integer greater than or equal to ${minimum}`,
-    );
-  }
-  return value;
-}


### PR DESCRIPTION
## Summary

- bound concurrent native image work across asset transforms, metadata reads, and OG generation
- lower Sharp thread and memory-cache limits in code while preserving runtime image transforms
- memoize immutable production asset and client-entry resolution, and bypass document asset work for health/asset requests
- defer Satori, Resvg, and Shiki initialization until their features are used
- move retained newsletter image payloads to a process-local filesystem cache

This keeps `remix/assets` and dynamic image compilation as the production architecture.

## Validation

- `pnpm run build`
- `pnpm run test:ci` (219 tests)
- `pnpm exec oxlint --threads=1 .`
- `pnpm remix doctor`
- `pnpm exec remix test app/utils/native-image.test.ts --concurrency 1`
- `pnpm run typecheck`