### PR TITLE
Fix intermittent homepage loading and deployment caching

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -65,6 +65,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     steps:
-      - name: 🧹 Purge All
+      - name: 🧹 Purge documents and public files
         run: |
-          curl -D - -X POST --location "https://api.fastly.com/service/${{ secrets.FASTLY_SERVICE_ID }}/purge_all" -H "Accept: application/json" -H "Fastly-Key: ${{ secrets.FASTLY_API_TOKEN }}" -H "fastly-soft-purge: 1"
+          # A second key purge closes Fastly's edge/shield propagation race.
+          for attempt in 1 2; do
+            for key in documents static-assets; do
+              curl --fail-with-body --silent --show-error \
+                --request POST \
+                --header "Accept: application/json" \
+                --header "Fastly-Key: ${{ secrets.FASTLY_API_TOKEN }}" \
+                "https://api.fastly.com/service/${{ secrets.FASTLY_SERVICE_ID }}/purge/$key"
+            done
+
+            if [ "$attempt" -eq 1 ]; then
+              sleep 2
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Preview runs the TypeScript server with the production asset configuration.
 pnpm run push:stage
 ```
 
+### CDN caching
+
+The app keeps browsers conservative while serving shared content from Fastly:
+
+| Response                                    | Cache policy                                                                        | Deploy purge    |
+| ------------------------------------------- | ----------------------------------------------------------------------------------- | --------------- |
+| Rendered HTML                               | Browsers revalidate; Fastly caches for 5 minutes with 1 week stale-while-revalidate | `documents`     |
+| Root `public/` files                        | Browsers and Fastly cache for 1 hour                                                | `static-assets` |
+| Fingerprinted `/assets/*`                   | Browsers and Fastly cache immutable URLs for 1 year                                 | Never           |
+| Personalized, mutation, and error responses | `private, no-store`                                                                 | Not cached      |
+
+`app/middleware/render.ts` applies the document policy unless an action sets its own `Cache-Control`. `app/router.ts` tags root `public/` files. The production workflow completes the Fly rollout, then purges the `documents` and `static-assets` surrogate keys twice to cover Fastly edge/shield propagation.
+
+Surrogate keys are public cache tags, not credentials; Fastly normally removes them before responding to browsers. Purge requests are authorized with the GitHub Actions `FASTLY_API_TOKEN` secret. Fingerprinted assets are not purged so older documents and open tabs can continue loading their matching assets.
+
 ## Contributing
 
 - Create a branch from the latest target branch.

--- a/app/actions/blog/controller.test.ts
+++ b/app/actions/blog/controller.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 import blogController from "./controller.tsx";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 
@@ -16,8 +15,6 @@ describe("Blog route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
-
     let html = await response.text();
 
     expect(html).toContain("<title>Remix Blog</title>");

--- a/app/actions/blog/controller.tsx
+++ b/app/actions/blog/controller.tsx
@@ -19,7 +19,7 @@ import {
   getAuthorImageAsset,
   getBlogImageAsset,
 } from "../../utils/blog-image-assets.ts";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
+import { CACHE } from "../../utils/cache-control.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { getBlogPost, getRawBlogPostMarkdown } from "../../data/blog.ts";
 import { StatusErrorDocument } from "../../ui/not-found-page.tsx";
@@ -31,9 +31,7 @@ export default createController(routes.blog, {
     async index({ render, request }) {
       let posts = await loadBlogPostListings();
 
-      return render(<Page posts={posts} requestUrl={request.url} />, {
-        headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-      });
+      return render(<Page posts={posts} requestUrl={request.url} />);
     },
 
     async post({ params, render, request }) {
@@ -49,7 +47,7 @@ export default createController(routes.blog, {
         try {
           return new Response(getRawBlogPostMarkdown(slug), {
             headers: {
-              "Cache-Control": CACHE_CONTROL.DEFAULT,
+              "Cache-Control": CACHE.RESOURCE,
               "Content-Type": "text/markdown; charset=utf-8",
             },
           });
@@ -82,7 +80,6 @@ export default createController(routes.blog, {
           images={images}
           socialImageUrl={getPostSocialImageUrl(post, slug, request.url)}
         />,
-        { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
       );
     },
 

--- a/app/actions/blog/markdown.test.ts
+++ b/app/actions/blog/markdown.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 import blogController from "./controller.tsx";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 
@@ -22,7 +21,9 @@ describe("Blog markdown routes", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "text/markdown; charset=utf-8",
     );
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "max-age=300, stale-while-revalidate=604800",
+    );
 
     let markdown = await response.text();
     expect(markdown.startsWith("---\n")).toBe(true);

--- a/app/actions/blog/post-page.test.ts
+++ b/app/actions/blog/post-page.test.ts
@@ -6,7 +6,6 @@ import {
   getAuthorImageAsset,
   getBlogImageAsset,
 } from "../../utils/blog-image-assets.ts";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 
@@ -25,8 +24,6 @@ describe("Blog post route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
-
     let html = await response.text();
     expect(html).toContain(`<title>${post.title} | Remix</title>`);
     expect(html).toContain('rel="alternate"');

--- a/app/actions/blog/post-page.tsx
+++ b/app/actions/blog/post-page.tsx
@@ -13,6 +13,7 @@ import {
 import { breakpointMedia, theme } from "../../ui/public/theme.ts";
 import { NewsletterSignupCta } from "../../ui/newsletter-signup.tsx";
 import type { BlogImageAsset } from "../../utils/blog-image-assets.ts";
+import { CACHE } from "../../utils/cache-control.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { routes } from "../../routes.ts";
 import type { getBlogPost } from "../../data/blog.ts";
@@ -26,7 +27,7 @@ export const NOT_FOUND_RESPONSE = {
   status: 404,
   statusText: "Not Found",
   headers: {
-    "Cache-Control": "no-store",
+    "Cache-Control": CACHE.PRIVATE,
   },
 };
 

--- a/app/actions/blog/rss.ts
+++ b/app/actions/blog/rss.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { Feed } from "feed";
 import parseFrontMatter from "front-matter";
 import { routes } from "../../routes.ts";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
+import { CACHE } from "../../utils/cache-control.ts";
 
 interface BlogRssFrontmatter {
   title?: string;
@@ -89,7 +89,7 @@ export function buildBlogRssResponse(posts: BlogRssPost[]) {
   return new Response(feed.rss2(), {
     headers: {
       "Content-Type": "application/xml",
-      "Cache-Control": CACHE_CONTROL.DEFAULT,
+      "Cache-Control": CACHE.RESOURCE,
     },
   });
 }

--- a/app/actions/brand.test.ts
+++ b/app/actions/brand.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
 import rootController from "./controller.tsx";
-import { CACHE_CONTROL } from "../utils/cache-control.ts";
 import { routes } from "../routes.ts";
 import { createRouteTestRouter } from "../../test/setup.ts";
 
@@ -17,8 +16,6 @@ describe("Brand route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
-
     let html = await response.text();
     expect(html).toContain('href="/_brand/remix-brand-assets.zip"');
   });

--- a/app/actions/catchall.tsx
+++ b/app/actions/catchall.tsx
@@ -3,6 +3,7 @@ import semver from "semver";
 
 import type { AppRenderer } from "../middleware/render.ts";
 import { StatusErrorDocument } from "../ui/not-found-page.tsx";
+import { CACHE } from "../utils/cache-control.ts";
 
 const SAFE_STATIC_FILE_EXTENSIONS = [
   ".html",
@@ -55,7 +56,7 @@ export function catchallHandler({
     status: 404,
     statusText: "Not Found",
     headers: {
-      "Cache-Control": "no-store",
+      "Cache-Control": CACHE.PRIVATE,
     },
   });
 }

--- a/app/actions/controller.tsx
+++ b/app/actions/controller.tsx
@@ -3,7 +3,7 @@ import { createController } from "remix/router";
 import { routes } from "../routes.ts";
 import { assetPaths } from "../utils/public/asset-paths.ts";
 import { assets } from "../utils/assets.ts";
-import { CACHE_CONTROL } from "../utils/cache-control.ts";
+import { CACHE } from "../utils/cache-control.ts";
 import { getNewsletterSubscriptionStatus } from "./newsletter/subscription.tsx";
 import { LandingNewsletterSubscribeForm } from "./public/remix-landing/components/feature-section.tsx";
 import { blogOgImageAction } from "./blog-og-image.tsx";
@@ -20,9 +20,7 @@ export default createController(routes, {
     blogOgImage: blogOgImageAction,
 
     brand({ render, request }) {
-      return render(<BrandPage requestUrl={request.url} />, {
-        headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-      });
+      return render(<BrandPage requestUrl={request.url} />);
     },
 
     home({ render, request }) {
@@ -30,12 +28,7 @@ export default createController(routes, {
       let pageUrl = `${requestUrl.origin}${routes.home.href()}`;
       let previewImage = `${requestUrl.origin}${assetPaths.marketing.defaultOgImage}`;
 
-      return render(
-        <HomePage pageUrl={pageUrl} previewImage={previewImage} />,
-        {
-          headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-        },
-      );
+      return render(<HomePage pageUrl={pageUrl} previewImage={previewImage} />);
     },
 
     homeNewsletterSignup({ render, request }) {
@@ -43,7 +36,7 @@ export default createController(routes, {
         <LandingNewsletterSubscribeForm
           status={getNewsletterSubscriptionStatus(request)}
         />,
-        { headers: { "Cache-Control": "no-store" } },
+        { headers: { "Cache-Control": CACHE.PRIVATE } },
       );
     },
 
@@ -52,7 +45,7 @@ export default createController(routes, {
     healthcheck() {
       return new Response("OK", {
         headers: {
-          "Cache-Control": "no-store",
+          "Cache-Control": CACHE.PRIVATE,
           "Content-Type": "text/plain; charset=utf-8",
         },
       });

--- a/app/actions/home.test.ts
+++ b/app/actions/home.test.ts
@@ -3,7 +3,6 @@ import { expect } from "remix/assert";
 
 import rootController from "./controller.tsx";
 import { routes } from "../routes.ts";
-import { CACHE_CONTROL } from "../utils/cache-control.ts";
 import { createRouteTestRouter } from "../../test/setup.ts";
 
 describe("home route", () => {
@@ -19,7 +18,9 @@ describe("home route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Surrogate-Control")).toBe(null);
+    expect(response.headers.get("Surrogate-Key")).toBe(null);
     let html = await response.text();
     expect(html).toContain('data-rmx-target="newsletter-subscribe"');
     expect(html).toContain('data-rmx-reset-scroll="false"');
@@ -36,7 +37,13 @@ describe("home route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(response.headers.get("Surrogate-Control")).toBe(
+      "max-age=300, stale-while-revalidate=604800",
+    );
+    expect(response.headers.get("Surrogate-Key")).toBe("documents");
 
     let html = await response.text();
     expect(html).toContain(

--- a/app/actions/jam/y2025/controller.test.ts
+++ b/app/actions/jam/y2025/controller.test.ts
@@ -2,7 +2,6 @@ import { expect } from "remix/assert";
 import { describe, it } from "remix/test";
 
 import { routes } from "../../../routes.ts";
-import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
 import { createRouteTestRouter } from "../../../../test/setup.ts";
 import jam2025Controller, { getEventStatus } from "./controller.tsx";
 
@@ -24,14 +23,14 @@ describe("Remix Jam 2025 routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     let html = await response.text();
     expect(html).toContain('data-rmx-target="newsletter-subscribe"');
     expect(html).toContain('data-rmx-reset-scroll="false"');
     expect(html).toContain("You're good to go");
   });
 
-  it("keeps the index response as a cacheable document", async () => {
+  it("renders the index document", async () => {
     let router = createRouteTestRouter();
     router.map(routes.jam.y2025, jam2025Controller);
 
@@ -40,7 +39,6 @@ describe("Remix Jam 2025 routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(await response.text()).toContain("<html");
   });
 });

--- a/app/actions/jam/y2025/controller.tsx
+++ b/app/actions/jam/y2025/controller.tsx
@@ -3,7 +3,7 @@ import { css, type Handle, type RemixNode } from "remix/ui";
 
 import { getSchedule } from "../../../data/jam-schedule.ts";
 import { routes } from "../../../routes.ts";
-import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
+import { CACHE } from "../../../utils/cache-control.ts";
 import { NewsletterSubscribeFrameHost } from "../../../ui/public/newsletter-subscribe.tsx";
 import { getNewsletterSubscriptionStatus } from "../../newsletter/subscription.tsx";
 import { Jam2025CocPage } from "./coc.tsx";
@@ -25,8 +25,6 @@ import { breakpointMedia, theme } from "../../../ui/public/theme.ts";
 
 type EventStatus = "before" | "live" | "after";
 
-let cacheHeaders = { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } };
-
 export default createController(routes.jam.y2025, {
   actions: {
     index({ render, request }) {
@@ -40,7 +38,6 @@ export default createController(routes.jam.y2025, {
         >
           <Jam2025Page eventStatus={getEventStatus()} />
         </JamDocument>,
-        cacheHeaders,
       );
     },
 
@@ -49,16 +46,16 @@ export default createController(routes.jam.y2025, {
         <JamNewsletterSubscribeForm
           status={getNewsletterSubscriptionStatus(request)}
         />,
-        { headers: { "Cache-Control": "no-store" } },
+        { headers: { "Cache-Control": CACHE.PRIVATE } },
       );
     },
 
     coc({ render, request }) {
-      return render(<Jam2025CocPage requestUrl={request.url} />, cacheHeaders);
+      return render(<Jam2025CocPage requestUrl={request.url} />);
     },
 
     faq({ render, request }) {
-      return render(<Jam2025FaqPage requestUrl={request.url} />, cacheHeaders);
+      return render(<Jam2025FaqPage requestUrl={request.url} />);
     },
 
     async lineup({ render, request }) {
@@ -67,7 +64,6 @@ export default createController(routes.jam.y2025, {
           requestUrl={request.url}
           schedule={await getSchedule()}
         />,
-        cacheHeaders,
       );
     },
   },

--- a/app/actions/jam/y2025/gallery/controller.tsx
+++ b/app/actions/jam/y2025/gallery/controller.tsx
@@ -3,7 +3,6 @@ import { createController } from "remix/router";
 import { getPhotos } from "../../../../data/jam-storefront.ts";
 import { jam2025GalleryDownloadHandler } from "./download.ts";
 import type { AppRenderer } from "../../../../middleware/render.ts";
-import { CACHE_CONTROL } from "../../../../utils/cache-control.ts";
 import { routes } from "../../../../routes.ts";
 import { JamDocument } from "../document.tsx";
 import {
@@ -144,11 +143,6 @@ function renderGalleryPage({
         )}
       </main>
     </JamDocument>,
-    {
-      headers: {
-        "Cache-Control": CACHE_CONTROL.DEFAULT,
-      },
-    },
   );
 }
 

--- a/app/actions/jam/y2025/gallery/download.ts
+++ b/app/actions/jam/y2025/gallery/download.ts
@@ -1,5 +1,5 @@
 import type { AppContext } from "../../../../router.ts";
-import { CACHE_CONTROL } from "../../../../utils/cache-control.ts";
+import { CACHE } from "../../../../utils/cache-control.ts";
 import { transformShopifyImageUrl } from "../public/shared.tsx";
 import { getGalleryPhotos, getSelectedPhotoIndex } from "./controller.tsx";
 
@@ -39,7 +39,7 @@ export async function jam2025GalleryDownloadHandler({ request }: AppContext) {
 
   return new Response(upstreamResponse.body, {
     headers: {
-      "Cache-Control": CACHE_CONTROL.DEFAULT,
+      "Cache-Control": CACHE.RESOURCE,
       "Content-Type": contentType,
       "Content-Disposition": `attachment; filename="remix-jam-2025-photo-${selectedPhotoIndex + 1}.${extension}"`,
     },

--- a/app/actions/jam/y2025/ticket/controller.test.ts
+++ b/app/actions/jam/y2025/ticket/controller.test.ts
@@ -27,7 +27,7 @@ describe("Jam 2025 ticket submission", () => {
     });
 
     expect(response.status).toBe(400);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(await response.text()).toContain("Invalid ticket selection");
   });
 

--- a/app/actions/jam/y2025/ticket/controller.tsx
+++ b/app/actions/jam/y2025/ticket/controller.tsx
@@ -1,7 +1,7 @@
 import { createController } from "remix/router";
 
 import { createCart, getProduct } from "../../../../data/jam-storefront.ts";
-import { CACHE_CONTROL } from "../../../../utils/cache-control.ts";
+import { CACHE } from "../../../../utils/cache-control.ts";
 import { routes } from "../../../../routes.ts";
 import { documentRedirect } from "../../../document-redirect.ts";
 import { Jam2025TicketPage, parseTicketPurchaseSubmission } from "./page.tsx";
@@ -15,7 +15,6 @@ export default createController(routes.jam.y2025.ticket, {
           product={await getProduct("remix-jam-2025")}
           requestUrl={request.url}
         />,
-        { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
       );
     },
 
@@ -55,7 +54,7 @@ export default createController(routes.jam.y2025.ticket, {
           product={product}
           requestUrl={request.url}
         />,
-        { status: 400, headers: { "Cache-Control": "no-store" } },
+        { status: 400, headers: { "Cache-Control": CACHE.PRIVATE } },
       );
     },
   },

--- a/app/actions/jam/y2026/controller.test.ts
+++ b/app/actions/jam/y2026/controller.test.ts
@@ -4,7 +4,6 @@ import { expect } from "remix/assert";
 import { DOCUMENT_REDIRECT_HEADER } from "../../public/document-redirect.ts";
 import { routes } from "../../../routes.ts";
 import { env } from "../../../utils/env.ts";
-import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
 import { createRouteTestRouter } from "../../../../test/setup.ts";
 import jam2026Controller from "./controller.tsx";
 import jam2026TicketController from "./ticket/controller.tsx";
@@ -27,7 +26,6 @@ describe("Remix Jam 2026 routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(response.headers.get("Vary")).toContain("x-remix-target");
     expect(response.headers.get("Vary")).toContain("x-remix-ssr-frame");
 
@@ -52,7 +50,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     let html = await response.text();
     expect(html).toContain('data-rmx-target="newsletter-subscribe"');
     expect(html).toContain('data-rmx-reset-scroll="false"');
@@ -83,7 +81,6 @@ describe("Remix Jam 2026 routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(response.headers.get("Vary")).toContain("x-remix-target");
     expect(response.headers.get("Vary")).toContain("x-remix-ssr-frame");
 
@@ -137,7 +134,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Location")).toBe(
       routes.jam.y2026.index.href(),
     );
@@ -181,7 +178,6 @@ describe("Remix Jam 2026 routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(response.headers.get("Vary")).toContain("x-remix-target");
     expect(response.headers.get("Vary")).toContain("x-remix-ssr-frame");
 
@@ -206,7 +202,6 @@ describe("Remix Jam 2026 routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(response.headers.get("Vary")).toContain("x-remix-target");
     expect(response.headers.get("Vary")).toContain("x-remix-ssr-frame");
 
@@ -231,7 +226,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
 
     let html = await response.text();
 
@@ -256,7 +251,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Location")).toBe(
       "https://jam.remix.run/checkouts/2026",
     );
@@ -275,7 +270,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(204);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Location")).toBe(null);
     expect(response.headers.get(DOCUMENT_REDIRECT_HEADER)).toBe(
       "https://jam.remix.run/checkouts/2026",
@@ -289,7 +284,6 @@ describe("Remix Jam 2026 routes", () => {
     let response = await router.fetch(appUrl(routes.jam.y2026.ticket.index));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     expect(response.headers.get("Set-Cookie")).toBe(null);
 
     let html = await response.text();
@@ -308,7 +302,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
 
     let setCookie = response.headers.get("Set-Cookie");
     expect(setCookie).not.toBe(null);
@@ -358,7 +352,6 @@ describe("Remix Jam 2026 routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Set-Cookie")).toBe(null);
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
 
     let html = await response.text();
 
@@ -378,7 +371,7 @@ describe("Remix Jam 2026 routes", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Set-Cookie")).toContain("Max-Age=0");
 
     let html = await response.text();

--- a/app/actions/jam/y2026/controller.tsx
+++ b/app/actions/jam/y2026/controller.tsx
@@ -5,7 +5,7 @@ import { redirect } from "remix/response/redirect";
 import { createController } from "remix/router";
 
 import { getProduct } from "../../../data/jam-storefront.ts";
-import { CACHE_CONTROL } from "../../../utils/cache-control.ts";
+import { CACHE } from "../../../utils/cache-control.ts";
 import type { AppRenderer } from "../../../middleware/render.ts";
 import { routes } from "../../../routes.ts";
 import { getNewsletterSubscriptionStatus } from "../../newsletter/subscription.tsx";
@@ -39,7 +39,7 @@ export default createController(routes.jam.y2026, {
         <Jam2026NewsletterSignup
           status={getNewsletterSubscriptionStatus(request)}
         />,
-        { headers: { "Cache-Control": "no-store" } },
+        { headers: { "Cache-Control": CACHE.PRIVATE } },
       );
     },
 
@@ -56,7 +56,7 @@ export default createController(routes.jam.y2026, {
       return redirect(routes.jam.y2026.index.href(), {
         status: 303,
         headers: new SuperHeaders({
-          cacheControl: "no-store",
+          cacheControl: CACHE.PRIVATE,
           setCookie: await serializeJam2026ThemePreference(result.value.theme),
         }),
       });
@@ -70,7 +70,7 @@ export default createController(routes.jam.y2026, {
  * with the modal open.
  */
 export async function renderJam2026Page({
-  cacheControl = CACHE_CONTROL.DEFAULT,
+  cacheControl,
   discount,
   render,
   request,
@@ -109,9 +109,9 @@ export async function renderJam2026Page({
     };
   }
 
+  // Never let a shared cache store a response that hands out a Set-Cookie.
   let headers = new SuperHeaders({
-    // Never let a shared cache store a response that hands out a Set-Cookie.
-    cacheControl: discount.setCookie ? "no-store" : cacheControl,
+    cacheControl: discount.setCookie ? CACHE.PRIVATE : cacheControl,
     vary: ["Cookie", "x-remix-target", "x-remix-ssr-frame"],
   });
   if (discount.setCookie) headers.append("Set-Cookie", discount.setCookie);

--- a/app/actions/jam/y2026/ticket/controller.tsx
+++ b/app/actions/jam/y2026/ticket/controller.tsx
@@ -3,6 +3,7 @@ import { createController } from "remix/router";
 
 import { getProduct } from "../../../../data/jam-storefront.ts";
 import { routes } from "../../../../routes.ts";
+import { CACHE } from "../../../../utils/cache-control.ts";
 import { documentRedirect } from "../../../document-redirect.ts";
 import { renderJam2026Page } from "../controller.tsx";
 import {
@@ -31,7 +32,7 @@ export default createController(routes.jam.y2026.ticket, {
           throw new Error("Shopify cart did not return a checkout URL");
         }
 
-        let headers = new SuperHeaders({ cacheControl: "no-store" });
+        let headers = new SuperHeaders({ cacheControl: CACHE.PRIVATE });
         // The code is consumed by the Shopify cart, so stop carrying it.
         if (discount.code) {
           headers.append("Set-Cookie", await clearJam2026DiscountCode());
@@ -41,7 +42,7 @@ export default createController(routes.jam.y2026.ticket, {
       }
 
       return renderJam2026Page({
-        cacheControl: "no-store",
+        cacheControl: CACHE.PRIVATE,
         discount,
         render,
         request,

--- a/app/actions/newsletter/controller.test.tsx
+++ b/app/actions/newsletter/controller.test.tsx
@@ -2,7 +2,6 @@ import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
 import { routes } from "../../routes.ts";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 import { createNewsletterController } from "./controller.tsx";
 import {
@@ -112,7 +111,6 @@ describe("Newsletter index route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     let html = await response.text();
 
     expect(html).toContain("<title>Remix Newsletter</title>");
@@ -203,7 +201,6 @@ describe("Newsletter index route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
     let html = await response.text();
     expect(html).toContain(`action="${routes.newsletter.subscribe.href()}"`);
     expect(html).not.toContain("<title>");
@@ -218,7 +215,7 @@ describe("Newsletter index route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     let html = await response.text();
     expect(html).toContain(`action="${routes.newsletter.subscribe.href()}"`);
     expect(html).toContain("The archive is temporarily unavailable.");
@@ -242,7 +239,6 @@ describe("Newsletter issue route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
     let html = await response.text();
 
     // Issue content starts with its title and the md-prose container.
@@ -341,7 +337,9 @@ describe("Newsletter image route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("image/png");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "max-age=300, stale-while-revalidate=604800",
+    );
     expect(response.headers.get("Content-Length")).toBe(
       String(pngImage().bytes.byteLength),
     );

--- a/app/actions/newsletter/controller.tsx
+++ b/app/actions/newsletter/controller.tsx
@@ -12,7 +12,7 @@ import {
 import { routes } from "../../routes.ts";
 import { NewsletterSubscribeFrame } from "./signup-frame.tsx";
 import { StatusErrorDocument } from "../../ui/not-found-page.tsx";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
+import { CACHE } from "../../utils/cache-control.ts";
 import { NewsletterIndexPage, NewsletterIssuePage } from "./pages.tsx";
 import {
   getNewsletterSubscriptionStatus,
@@ -50,12 +50,10 @@ export function createNewsletterController(repository: NewsletterRepository) {
             subscriptionStatus={subscriptionStatus}
           />,
           {
-            headers: {
-              "Cache-Control":
-                unavailable || subscriptionStatus
-                  ? "no-store"
-                  : CACHE_CONTROL.DEFAULT,
-            },
+            headers:
+              unavailable || subscriptionStatus
+                ? { "Cache-Control": CACHE.PRIVATE }
+                : undefined,
           },
         );
       },
@@ -65,7 +63,7 @@ export function createNewsletterController(repository: NewsletterRepository) {
           <NewsletterSubscribeFrame
             status={getNewsletterSubscriptionStatus(request)}
           />,
-          { headers: { "Cache-Control": "no-store" } },
+          { headers: { "Cache-Control": CACHE.PRIVATE } },
         );
       },
 
@@ -119,7 +117,6 @@ export function createNewsletterController(repository: NewsletterRepository) {
             issue={issue}
             html={html}
           />,
-          { headers: { "Cache-Control": CACHE_CONTROL.DEFAULT } },
         );
       },
 
@@ -162,7 +159,7 @@ export function createNewsletterController(repository: NewsletterRepository) {
         return new Response(Uint8Array.from(image.bytes), {
           headers: {
             "Content-Type": image.contentType,
-            "Cache-Control": CACHE_CONTROL.DEFAULT,
+            "Cache-Control": CACHE.RESOURCE,
             "Content-Length": String(image.bytes.byteLength),
           },
         });
@@ -195,13 +192,13 @@ function newsletterErrorLogger(): Middleware {
 const NOT_FOUND_RESPONSE = {
   status: 404,
   statusText: "Not Found",
-  headers: { "Cache-Control": "no-store" },
+  headers: { "Cache-Control": CACHE.PRIVATE },
 } as const;
 
 const UNAVAILABLE_RESPONSE = {
   status: 503,
   statusText: "Service Unavailable",
-  headers: { "Cache-Control": "no-store" },
+  headers: { "Cache-Control": CACHE.PRIVATE },
 } as const;
 
 function withoutNewsletterTitle(markdown: string): string {

--- a/app/actions/newsletter/subscribe.test.ts
+++ b/app/actions/newsletter/subscribe.test.ts
@@ -91,7 +91,7 @@ describe("Newsletter subscribe route", () => {
       { accept: "text/html" },
     );
     expect(success.status).toBe(303);
-    expect(success.headers.get("Cache-Control")).toBe("no-store");
+    expect(success.headers.get("Cache-Control")).toBe("private, no-store");
     expect(success.headers.get("Location")).toBe(
       `${routes.newsletter.index.href()}?subscription=success`,
     );
@@ -101,7 +101,7 @@ describe("Newsletter subscribe route", () => {
     let resultPage = await router.fetch(
       new URL(success.headers.get("Location")!, "http://localhost:3000"),
     );
-    expect(resultPage.headers.get("Cache-Control")).toBe("no-store");
+    expect(resultPage.headers.get("Cache-Control")).toBe("private, no-store");
     let resultHtml = await resultPage.text();
     expect(resultHtml).toContain('role="status"');
     expect(resultHtml).toContain("check your email");
@@ -130,7 +130,7 @@ describe("Newsletter subscribe route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Vary")).toBe("x-remix-target");
     let html = await response.text();
     expect(html).toContain('role="status"');
@@ -152,7 +152,7 @@ describe("Newsletter subscribe route", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Vary")).toBe("x-remix-target");
     expect(response.headers.get("Location")).toBe(
       `${routes.jam.y2025.newsletterSignup.href()}?subscription=success`,

--- a/app/actions/newsletter/subscription.tsx
+++ b/app/actions/newsletter/subscription.tsx
@@ -11,6 +11,7 @@ import {
   type NewsletterSubscribeFrameContext,
   type NewsletterSubscriptionStatus,
 } from "../../ui/public/newsletter-subscribe.tsx";
+import { CACHE } from "../../utils/cache-control.ts";
 import { env } from "../../utils/env.ts";
 import { isAllowedNewsletterTagId } from "../../utils/public/newsletter-tags.ts";
 
@@ -99,7 +100,7 @@ let newsletterSubmission = s.object({
 });
 
 const newsletterTargetResponseHeaders = {
-  "Cache-Control": "no-store",
+  "Cache-Control": CACHE.PRIVATE,
   Vary: "x-remix-target",
 } as const;
 
@@ -138,14 +139,14 @@ function createSubscriptionResponse(
   if (request.headers.get("Accept")?.includes("application/json")) {
     return Response.json(body, {
       status,
-      headers: { "Cache-Control": "no-store" },
+      headers: { "Cache-Control": CACHE.PRIVATE },
     });
   }
 
   let location = new URL(routes.newsletter.index.href(), request.url);
   location.searchParams.set("subscription", getSubscriptionStatus(body));
   let response = redirect(`${location.pathname}${location.search}`, 303);
-  response.headers.set("Cache-Control", "no-store");
+  response.headers.set("Cache-Control", CACHE.PRIVATE);
   return response;
 }
 

--- a/app/actions/public/remix-landing/components/loading-screen.tsx
+++ b/app/actions/public/remix-landing/components/loading-screen.tsx
@@ -6,7 +6,7 @@ import {
   RUNNER_WEBP_SRC,
 } from "../runner-media.ts";
 
-const LOADING_SCREEN_FAILSAFE_MS = 8_000;
+export const LOADING_SCREEN_FAILSAFE_MS = 8_000;
 
 const overlayStyles = css({
   position: "fixed",

--- a/app/actions/public/remix-landing/components/loading-screen.tsx
+++ b/app/actions/public/remix-landing/components/loading-screen.tsx
@@ -6,6 +6,8 @@ import {
   RUNNER_WEBP_SRC,
 } from "../runner-media.ts";
 
+const LOADING_SCREEN_FAILSAFE_MS = 8_000;
+
 const overlayStyles = css({
   position: "fixed",
   inset: "0",
@@ -14,6 +16,43 @@ const overlayStyles = css({
   zIndex: "50",
   background: "#000",
   pointerEvents: "none",
+  // The page content is useful without JavaScript or WebGL. Never let a stale
+  // deploy asset or an unexpected client error leave this overlay up forever.
+  animation: `loading-screen-failsafe 1ms linear ${LOADING_SCREEN_FAILSAFE_MS}ms forwards`,
+  "@keyframes loading-screen-failsafe": {
+    to: {
+      opacity: "0",
+      visibility: "hidden",
+    },
+  },
+  "@keyframes loading-screen-appear": {
+    from: { opacity: "0" },
+    to: { opacity: "1" },
+  },
+  "& picture": {
+    opacity: "0",
+    animation: "loading-screen-appear 200ms ease-out 250ms forwards",
+  },
+  "@keyframes loading-screen-dismiss": {
+    from: { opacity: "1" },
+    to: {
+      opacity: "0",
+      visibility: "hidden",
+    },
+  },
+  "&.is-dismissed": {
+    animation: "loading-screen-dismiss 600ms ease-out forwards",
+  },
+  "&.is-skipped": {
+    display: "none",
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    "&.is-dismissed": {
+      visibility: "hidden",
+      opacity: "0",
+      animation: "none",
+    },
+  },
 });
 
 const runnerStyles = css({
@@ -32,7 +71,6 @@ const loadingScreenStatusClassNames: Record<
   skipped: "is-skipped",
 };
 
-// Dismiss animation lives in `home.css` under `.loading-screen-overlay`.
 export function LoadingScreen(handle: Handle<{ status: LoadingScreenStatus }>) {
   return () => {
     const statusClassName = loadingScreenStatusClassNames[handle.props.status];

--- a/app/actions/public/remix-landing/components/particle-canvas.tsx
+++ b/app/actions/public/remix-landing/components/particle-canvas.tsx
@@ -380,6 +380,16 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
     }
 
     const animate = () => {
+      try {
+        renderFrame();
+      } catch (error) {
+        initFailed = true;
+        disposeScene();
+        handle.props.onError(error);
+      }
+    };
+
+    function renderFrame() {
       if (!engine || !particles || !restBaker || !mouseSim) return;
 
       const now = performance.now();
@@ -752,7 +762,7 @@ export function ParticleCanvas(handle: Handle<ParticleCanvasProps>) {
         }
       });
       frameId = requestAnimationFrame(animate);
-    };
+    }
 
     frameId = requestAnimationFrame(animate);
   }

--- a/app/actions/public/remix-landing/landing-enhancements.tsx
+++ b/app/actions/public/remix-landing/landing-enhancements.tsx
@@ -4,6 +4,7 @@ import { LandingNav } from "./components/landing-nav.tsx";
 import { LabelOverlay } from "./components/label-overlay.tsx";
 import {
   LoadingScreen,
+  LOADING_SCREEN_FAILSAFE_MS,
   type LoadingScreenStatus,
 } from "./components/loading-screen.tsx";
 import { ScrollLogo } from "./components/scroll-logo.tsx";
@@ -115,6 +116,12 @@ const LANDING_SECTION_IDS = [
 type ParticleCanvasComponent =
   typeof import("./components/particle-canvas.tsx").ParticleCanvas;
 
+function loadingScreenIsHidden(overlay: Element | null) {
+  if (!overlay) return false;
+  const style = getComputedStyle(overlay);
+  return style.display === "none" || style.visibility === "hidden";
+}
+
 function konamiKeyMatches(event: KeyboardEvent, expected: string): boolean {
   if (expected.startsWith("Arrow")) return event.key === expected;
   if (expected === "Enter") return event.key === "Enter";
@@ -144,7 +151,15 @@ export let RemixLandingEnhancements = clientEntry(
     let ParticleCanvas: ParticleCanvasComponent | null = null;
     let particleCanvasLoad: Promise<void> | null = null;
     let loadingScreenDismissal: Promise<void> | null = null;
-    let loadingScreenStatus: LoadingScreenStatus = "visible";
+    let loadingScreenFailsafeTimer: ReturnType<typeof setTimeout> | null = null;
+    let loadingScreenStatus: LoadingScreenStatus =
+      typeof document !== "undefined" &&
+      (performance.now() >= LOADING_SCREEN_FAILSAFE_MS ||
+        loadingScreenIsHidden(
+          document.querySelector(".loading-screen-overlay"),
+        ))
+        ? "skipped"
+        : "visible";
     const projectedLabelsRef = { current: [] as ProjectedLabel[] };
     const labelOpacityRef = { current: 0 };
     const morphValueRef = { current: 0 };
@@ -320,14 +335,26 @@ export let RemixLandingEnhancements = clientEntry(
       }, KONAMI_IDLE_MS);
     }
 
+    function clearLoadingScreenFailsafe() {
+      if (loadingScreenFailsafeTimer !== null) {
+        clearTimeout(loadingScreenFailsafeTimer);
+        loadingScreenFailsafeTimer = null;
+      }
+    }
+
+    function skipLoadingScreen() {
+      loadingScreenStatus = "skipped";
+      clearLoadingScreenFailsafe();
+      return handle.update();
+    }
+
     function dismissLoadingScreen() {
       return (loadingScreenDismissal ??= (async () => {
         const overlay = document.querySelector(".loading-screen-overlay");
         if (!overlay) return;
 
-        if (getComputedStyle(overlay).visibility === "hidden") {
-          loadingScreenStatus = "skipped";
-          await handle.update();
+        if (loadingScreenIsHidden(overlay)) {
+          await skipLoadingScreen();
           return;
         }
 
@@ -352,14 +379,17 @@ export let RemixLandingEnhancements = clientEntry(
         }
         if (handle.signal.aborted) return;
 
-        // The CSS fail-safe may have elapsed while this task was waiting.
-        if (getComputedStyle(overlay).visibility === "hidden") {
-          loadingScreenStatus = "skipped";
-          await handle.update();
+        // The CSS or JS fail-safe may have elapsed while this task was waiting.
+        if (
+          loadingScreenStatus !== "visible" ||
+          loadingScreenIsHidden(overlay)
+        ) {
+          await skipLoadingScreen();
           return;
         }
 
         loadingScreenStatus = "dismissed";
+        clearLoadingScreenFailsafe();
         const signal = await handle.update();
         if (signal.aborted) return;
 
@@ -427,6 +457,21 @@ export let RemixLandingEnhancements = clientEntry(
 
     handle.queueTask((signal) => {
       if (signal.aborted || handle.signal.aborted) return;
+
+      if (loadingScreenStatus === "visible") {
+        loadingScreenFailsafeTimer = setTimeout(
+          () => {
+            loadingScreenFailsafeTimer = null;
+            if (!handle.signal.aborted && loadingScreenStatus === "visible") {
+              void skipLoadingScreen();
+            }
+          },
+          Math.max(0, LOADING_SCREEN_FAILSAFE_MS - performance.now()),
+        );
+        handle.signal.addEventListener("abort", clearLoadingScreenFailsafe, {
+          once: true,
+        });
+      }
 
       try {
         isHydrated = true;

--- a/app/actions/public/remix-landing/landing-enhancements.tsx
+++ b/app/actions/public/remix-landing/landing-enhancements.tsx
@@ -325,7 +325,13 @@ export let RemixLandingEnhancements = clientEntry(
         const overlay = document.querySelector(".loading-screen-overlay");
         if (!overlay) return;
 
-        const animation = overlay.getAnimations({ subtree: true })[0];
+        if (getComputedStyle(overlay).visibility === "hidden") {
+          loadingScreenStatus = "skipped";
+          await handle.update();
+          return;
+        }
+
+        const animation = overlay.querySelector("picture")?.getAnimations()[0];
         let visibleMs = LOADING_SCREEN_MIN_VISIBLE_MS;
         if (animation) {
           const now = Number(document.timeline.currentTime ?? 0);
@@ -345,6 +351,13 @@ export let RemixLandingEnhancements = clientEntry(
           await new Promise((resolve) => setTimeout(resolve, remainingMs));
         }
         if (handle.signal.aborted) return;
+
+        // The CSS fail-safe may have elapsed while this task was waiting.
+        if (getComputedStyle(overlay).visibility === "hidden") {
+          loadingScreenStatus = "skipped";
+          await handle.update();
+          return;
+        }
 
         loadingScreenStatus = "dismissed";
         const signal = await handle.update();
@@ -415,39 +428,45 @@ export let RemixLandingEnhancements = clientEntry(
     handle.queueTask((signal) => {
       if (signal.aborted || handle.signal.aborted) return;
 
-      isHydrated = true;
-      initReducedMotion(handle.signal, () => {
+      try {
+        isHydrated = true;
+        initReducedMotion(handle.signal, () => {
+          syncMorphToScroll();
+          handle.update();
+        });
         syncMorphToScroll();
+        startBrandCycle();
+        void loadParticleCanvas().then(() => {
+          if (!handle.signal.aborted) handle.update();
+        });
+
+        window.addEventListener("scroll", scheduleMorphSync, {
+          signal: handle.signal,
+        });
+        window.addEventListener(
+          "resize",
+          () => {
+            scroll.sectionStops = null;
+            scheduleMorphSync();
+          },
+          { signal: handle.signal },
+        );
+        window.addEventListener("keydown", onKeydown, {
+          signal: handle.signal,
+        });
+
+        handle.signal.addEventListener("abort", () => {
+          window.cancelAnimationFrame(scroll.frame);
+          clearKonamiIdleTimer();
+          konami.index = 0;
+        });
+
         handle.update();
-      });
-      syncMorphToScroll();
-      startBrandCycle();
-      void loadParticleCanvas().then(() => {
-        if (!handle.signal.aborted) handle.update();
-      });
-
-      window.addEventListener("scroll", scheduleMorphSync, {
-        signal: handle.signal,
-      });
-      window.addEventListener(
-        "resize",
-        () => {
-          scroll.sectionStops = null;
-          scheduleMorphSync();
-        },
-        { signal: handle.signal },
-      );
-      window.addEventListener("keydown", onKeydown, {
-        signal: handle.signal,
-      });
-
-      handle.signal.addEventListener("abort", () => {
-        window.cancelAnimationFrame(scroll.frame);
-        clearKonamiIdleTimer();
-        konami.index = 0;
-      });
-
-      handle.update();
+      } catch (error) {
+        isHydrated = false;
+        console.error(error);
+        void dismissLoadingScreen();
+      }
     });
 
     return () => {

--- a/app/actions/remix-history/controller.test.ts
+++ b/app/actions/remix-history/controller.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 
 import remixHistoryController from "./controller.tsx";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
 import { routes } from "../../routes.ts";
 import { createRouteTestRouter } from "../../../test/setup.ts";
 
@@ -17,6 +16,5 @@ describe("Remix history route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
-    expect(response.headers.get("Cache-Control")).toBe(CACHE_CONTROL.DEFAULT);
   });
 });

--- a/app/actions/remix-history/controller.tsx
+++ b/app/actions/remix-history/controller.tsx
@@ -12,14 +12,10 @@ import { TimelineSection } from "./timeline-section.tsx";
 import { theme } from "../../ui/public/theme.ts";
 import { getSocialHeadTags } from "../../utils/social-head-tags.ts";
 import { routes } from "../../routes.ts";
-import { CACHE_CONTROL } from "../../utils/cache-control.ts";
-
 export default createController(routes.remixHistory, {
   actions: {
     index({ render, request }) {
-      return render(<RemixHistoryPage requestUrl={request.url} />, {
-        headers: { "Cache-Control": CACHE_CONTROL.DEFAULT },
-      });
+      return render(<RemixHistoryPage requestUrl={request.url} />);
     },
   },
 });

--- a/app/middleware/rate-limit.test.ts
+++ b/app/middleware/rate-limit.test.ts
@@ -17,7 +17,7 @@ describe("rateLimit", () => {
     expect(blocked.status).toBe(429);
     expect(await blocked.text()).toBe("Too Many Requests");
     expect(blocked.headers.get("Retry-After")).toBe("60");
-    expect(blocked.headers.get("Cache-Control")).toBe("no-store");
+    expect(blocked.headers.get("Cache-Control")).toBe("private, no-store");
 
     now += 1_000;
     expect((await request(router, "10.0.0.1")).headers.get("Retry-After")).toBe(

--- a/app/middleware/rate-limit.ts
+++ b/app/middleware/rate-limit.ts
@@ -1,5 +1,7 @@
 import type { Middleware } from "remix/router";
 
+import { CACHE } from "../utils/cache-control.ts";
+
 interface RateLimitOptions {
   windowMs?: number;
   max?: number;
@@ -56,7 +58,7 @@ export function rateLimit({
       return new Response("Too Many Requests", {
         status: 429,
         headers: {
-          "Cache-Control": "no-store",
+          "Cache-Control": CACHE.PRIVATE,
           "Content-Type": "text/plain; charset=utf-8",
           "Retry-After": String(retryAfterSeconds),
           "X-Remix-Response": "yes",

--- a/app/middleware/render.ts
+++ b/app/middleware/render.ts
@@ -5,6 +5,7 @@ import { type RemixNode } from "remix/ui";
 import { renderToStream, type ResolveFrameContext } from "remix/ui/server";
 
 import { assets } from "../utils/assets.ts";
+import { CACHE } from "../utils/cache-control.ts";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
@@ -38,6 +39,10 @@ export let renderMiddleware = renderWith(
         // Frame navigations fetch HTML programmatically, so production cache
         // headers can hide server changes during development.
         response.headers.set("Cache-Control", "no-store");
+      } else if (!response.headers.has("Cache-Control")) {
+        for (let [name, value] of Object.entries(CACHE.DOCUMENT)) {
+          response.headers.set(name, value);
+        }
       }
       return response;
     },

--- a/app/middleware/root-public-files.ts
+++ b/app/middleware/root-public-files.ts
@@ -1,0 +1,30 @@
+import { staticFiles } from "remix/middleware/static";
+import type { Middleware } from "remix/router";
+
+import { CACHE } from "../utils/cache-control.ts";
+
+/**
+ * Serves stable URLs from root `public/` and labels only those responses for
+ * targeted Fastly purges. Browser modules live under `/assets/` and are served
+ * by the separate asset server, so they never receive this purge tag.
+ */
+export function rootPublicFiles(): Middleware {
+  const serveStaticFiles = staticFiles("public", {
+    cacheControl: CACHE.ROOT_PUBLIC_FILE,
+    index: false,
+  });
+
+  return async (context, next) => {
+    let fellThrough = false;
+    const response = await serveStaticFiles(context, () => {
+      fellThrough = true;
+      return next();
+    });
+
+    if (!fellThrough && response) {
+      response.headers.set("Surrogate-Key", CACHE.STATIC_ASSET_TAG);
+    }
+
+    return response;
+  };
+}

--- a/app/router.test.ts
+++ b/app/router.test.ts
@@ -20,7 +20,7 @@ describe("app router", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "text/plain; charset=utf-8",
     );
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(response.headers.get("Referrer-Policy")).toBe(
       "strict-origin-when-cross-origin",
@@ -29,7 +29,18 @@ describe("app router", () => {
       "camera=(), geolocation=(), microphone=()",
     );
     expect(response.headers.has("Strict-Transport-Security")).toBe(false);
+    expect(response.headers.get("Surrogate-Key")).toBe(null);
     expect(await response.text()).toBe("OK");
+  });
+
+  it("tags root public files for targeted CDN purging", async () => {
+    let response = await router.fetch("http://localhost/favicon.ico");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "no-store, must-revalidate",
+    );
+    expect(response.headers.get("Surrogate-Key")).toBe("static-assets");
   });
 
   it("does not serve shared assets outside the asset server", async () => {

--- a/app/router.ts
+++ b/app/router.ts
@@ -13,6 +13,7 @@ import { staticFiles } from "remix/middleware/static";
 
 import { rateLimit } from "./middleware/rate-limit.ts";
 import { loadAssetEntry } from "./middleware/asset-entry.ts";
+import { CACHE } from "./utils/cache-control.ts";
 import { renderMiddleware } from "./middleware/render.ts";
 import { securityHeaders } from "./middleware/security-headers.ts";
 import { createRedirectRoutes, loadRedirectsFromFile } from "./redirects.ts";
@@ -62,12 +63,7 @@ function createAppMiddleware() {
     securityHeaders(),
     compression(),
     ignoreChromeDevToolsRequest,
-    staticFiles("public", {
-      cacheControl: isDev
-        ? "no-store, must-revalidate"
-        : "public, max-age=3600",
-      index: false,
-    }),
+    rootPublicFiles(),
     cop(),
     rateLimit({
       windowMs: 2 * 60 * 1000,
@@ -81,6 +77,27 @@ function createAppMiddleware() {
     renderMiddleware,
     isTest ? logger({ log() {} }) : logger(),
   );
+}
+
+function rootPublicFiles(): Middleware {
+  let serveStaticFiles = staticFiles("public", {
+    cacheControl: isDev ? "no-store, must-revalidate" : "public, max-age=3600",
+    index: false,
+  });
+
+  return async (context, next) => {
+    let fellThrough = false;
+    let response = await serveStaticFiles(context, () => {
+      fellThrough = true;
+      return next();
+    });
+
+    if (!fellThrough && response) {
+      response.headers.set("Surrogate-Key", CACHE.STATIC_ASSET_TAG);
+    }
+
+    return response;
+  };
 }
 
 export type AppContext = MiddlewareContext<

--- a/app/router.ts
+++ b/app/router.ts
@@ -9,12 +9,11 @@ import {
 } from "remix/router";
 import { formData } from "remix/middleware/form-data";
 import { logger } from "remix/middleware/logger";
-import { staticFiles } from "remix/middleware/static";
 
 import { rateLimit } from "./middleware/rate-limit.ts";
 import { loadAssetEntry } from "./middleware/asset-entry.ts";
-import { CACHE } from "./utils/cache-control.ts";
 import { renderMiddleware } from "./middleware/render.ts";
+import { rootPublicFiles } from "./middleware/root-public-files.ts";
 import { securityHeaders } from "./middleware/security-headers.ts";
 import { createRedirectRoutes, loadRedirectsFromFile } from "./redirects.ts";
 import { routes } from "./routes.ts";
@@ -77,27 +76,6 @@ function createAppMiddleware() {
     renderMiddleware,
     isTest ? logger({ log() {} }) : logger(),
   );
-}
-
-function rootPublicFiles(): Middleware {
-  let serveStaticFiles = staticFiles("public", {
-    cacheControl: isDev ? "no-store, must-revalidate" : "public, max-age=3600",
-    index: false,
-  });
-
-  return async (context, next) => {
-    let fellThrough = false;
-    let response = await serveStaticFiles(context, () => {
-      fellThrough = true;
-      return next();
-    });
-
-    if (!fellThrough && response) {
-      response.headers.set("Surrogate-Key", CACHE.STATIC_ASSET_TAG);
-    }
-
-    return response;
-  };
 }
 
 export type AppContext = MiddlewareContext<

--- a/app/styles/public/home.css
+++ b/app/styles/public/home.css
@@ -59,39 +59,6 @@ body {
   background: var(--brand-cycle);
 }
 
-/* Delay the runner so fast WebGL starts can skip it without flashing. */
-@keyframes loading-screen-appear {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.loading-screen-overlay picture {
-  opacity: 0;
-  animation: loading-screen-appear 200ms ease-out 250ms forwards;
-}
-
-@keyframes loading-screen-dismiss {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-    visibility: hidden;
-  }
-}
-
-.loading-screen-overlay.is-dismissed {
-  animation: loading-screen-dismiss 600ms ease-out forwards;
-}
-
-.loading-screen-overlay.is-skipped {
-  display: none;
-}
-
 @media (prefers-reduced-motion: reduce) {
   :root {
     --brand-cycle: #2dacf9;
@@ -105,11 +72,5 @@ body {
     transition-duration: 0.001ms !important;
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
-  }
-
-  .loading-screen-overlay.is-dismissed {
-    visibility: hidden;
-    opacity: 0;
-    animation: none;
   }
 }

--- a/app/utils/cache-control.ts
+++ b/app/utils/cache-control.ts
@@ -1,4 +1,5 @@
 let isDevelopment = process.env.NODE_ENV === "development";
+let isNonProduction = process.env.NODE_ENV !== "production";
 
 export const CACHE = {
   DOCUMENT: {
@@ -10,5 +11,8 @@ export const CACHE = {
   RESOURCE: isDevelopment
     ? "no-store"
     : "max-age=300, stale-while-revalidate=604800",
+  ROOT_PUBLIC_FILE: isNonProduction
+    ? "no-store, must-revalidate"
+    : "public, max-age=3600",
   STATIC_ASSET_TAG: "static-assets",
 } as const;

--- a/app/utils/cache-control.ts
+++ b/app/utils/cache-control.ts
@@ -1,17 +1,14 @@
-export const CACHE_CONTROL = {
-  /**
-   * Keep it in the browser (and CDN) for 5 minutes so when they click
-   * back/forward/etc. it's super fast. SWR for 1 week on CDN so it stays fast,
-   * but people get typos/fixes and stuff too.
-   */
-  DEFAULT:
-    process.env.NODE_ENV === "development"
-      ? "no-store"
-      : "max-age=300, stale-while-revalidate=604800",
-  /**
-   * Keep it in the browser (and CDN) for 1 day, we won't be updating these as
-   * often until the conf is a bit closer, and we can prevent over-fetching from
-   * Sessionize which is pretty slow.
-   */
-  conf: `max-age=${60 * 60 * 24}, stale-while-revalidate=604800`,
-};
+let isDevelopment = process.env.NODE_ENV === "development";
+
+export const CACHE = {
+  DOCUMENT: {
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    "Surrogate-Control": "max-age=300, stale-while-revalidate=604800",
+    "Surrogate-Key": "documents",
+  },
+  PRIVATE: "private, no-store",
+  RESOURCE: isDevelopment
+    ? "no-store"
+    : "max-age=300, stale-while-revalidate=604800",
+  STATIC_ASSET_TAG: "static-assets",
+} as const;

--- a/test/home.test.e2e.ts
+++ b/test/home.test.e2e.ts
@@ -30,6 +30,32 @@ async function litPixelRatio(page: Page) {
 }
 
 describe("Home", () => {
+  it("reveals the server-rendered page when browser assets fail", async (t) => {
+    const page = await t.serve(
+      await createTestServer(swallowAbortErrors(createAppRouter())),
+    );
+    await page.route("**/assets/**", (route) => route.abort("failed"));
+
+    const response = await page.goto(routes.home.href());
+    expect(response?.ok()).toBe(true);
+
+    const overlay = page.locator(".loading-screen-overlay");
+    await expect(overlay).toBeVisible();
+    await overlay.evaluate((element) => {
+      const animations = element.getAnimations();
+      if (animations.length === 0) {
+        throw new Error("Loading screen is missing its fail-safe animation");
+      }
+      for (const animation of animations) {
+        const endTime = Number(animation.effect?.getComputedTiming().endTime);
+        animation.currentTime = endTime + 1;
+      }
+    });
+
+    await expect(overlay).toBeHidden();
+    await expect(page.locator("main")).toBeVisible();
+  });
+
   it("keeps the particle scene visible after resizing with reduced motion", async (t) => {
     const page = await t.serve(
       await createTestServer(swallowAbortErrors(createAppRouter())),

--- a/test/home.test.e2e.ts
+++ b/test/home.test.e2e.ts
@@ -56,6 +56,70 @@ describe("Home", () => {
     await expect(page.locator("main")).toBeVisible();
   });
 
+  it("keeps the server-rendered page visible when browser assets arrive late", async (t) => {
+    const page = await t.serve(
+      await createTestServer(swallowAbortErrors(createAppRouter())),
+    );
+    let releaseParticleCanvas = () => {};
+    const particleCanvasReleased = new Promise<void>((resolve) => {
+      releaseParticleCanvas = resolve;
+    });
+    let markParticleCanvasRequested = () => {};
+    const particleCanvasRequested = new Promise<void>((resolve) => {
+      markParticleCanvasRequested = resolve;
+    });
+    await page.route("**/assets/**", async (route) => {
+      if (route.request().url().includes("particle-canvas")) {
+        markParticleCanvasRequested();
+        await particleCanvasReleased;
+      }
+      await route.continue();
+    });
+
+    const response = await page.goto(routes.home.href());
+    expect(response?.ok()).toBe(true);
+    await particleCanvasRequested;
+    const overlay = page.locator(".loading-screen-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toBeHidden({ timeout: 10_000 });
+    await expect(page.locator("main")).toBeVisible();
+    await page.evaluate(() => {
+      const root = document.documentElement;
+      root.dataset.loadingScreenReappeared = "false";
+      const checkOverlay = () => {
+        const element = document.querySelector(".loading-screen-overlay");
+        if (!element) return;
+        const style = getComputedStyle(element);
+        if (
+          style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          Number(style.opacity) > 0
+        ) {
+          root.dataset.loadingScreenReappeared = "true";
+        }
+      };
+      new MutationObserver(checkOverlay).observe(root, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+      const sampleAnimationFrames = () => {
+        checkOverlay();
+        requestAnimationFrame(sampleAnimationFrames);
+      };
+      requestAnimationFrame(sampleAnimationFrames);
+    });
+
+    releaseParticleCanvas();
+    await expect(page.locator("canvas").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(overlay).toBeHidden();
+    expect(
+      await page.locator("html").getAttribute("data-loading-screen-reappeared"),
+    ).toBe("false");
+  });
+
   it("keeps the particle scene visible after resizing with reduced motion", async (t) => {
     const page = await t.serve(
       await createTestServer(swallowAbortErrors(createAppRouter())),


### PR DESCRIPTION
## Summary

- make the homepage loading screen fail open when browser assets or WebGL initialization fail
- apply one shared document cache policy: browser revalidation with Fastly edge caching
- keep personalized, mutation, and error responses out of shared caches with `private, no-store`
- tag rendered documents and root `public/` files for targeted post-deploy Fastly purges
- preserve immutable fingerprinted `/assets/*` across deployments instead of purging the entire CDN cache
- document the caching and purge model in the README

## Why

Previously, stale HTML could survive a deployment while its fingerprinted browser assets were removed by a Fastly purge-all. That mismatch could leave the homepage loading screen visible indefinitely.

The new deployment order completes the Fly rollout, purges document and stable public-file tags, and retains old immutable assets. The loading UI also has independent fail-open protections.

## Validation

- `pnpm run validate`
- Remix Doctor: clean
- lint and TypeScript: clean
- 220 tests passed
