### PR TITLE
Improve newsletter archive cold starts and resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Keep the Remix 3 website implementation lean, stable, and behaviorally aligned w
 
 Remaining differences vs the previous production site (small, shippable items):
 
-- **Newsletter cold starts**: Expired in-memory snapshots now revalidate in the background, but a fresh process still downloads the full GitHub archive before serving newsletter content.
+- **Newsletter origin dependency**: Cold metadata and uncached image reads still depend on GitHub. Metadata keeps six-hour SWR; images load by immutable Git SHA into a bounded 64 MiB cache. The eventual replacement is a newsletter-repo build that publishes a static manifest and images to a bucket/CDN.
 - **Link prefetch parity**: Intent/predictive prefetch is not yet mirrored across Remix pages.
 - **Analytics on in-app transitions**: Verify one pageview per navigation when using client-side navigation.
 - **Client navigation shape**: Keep Jam on top-level client navigation unless a future route needs an independently updating region.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Keep the Remix 3 website implementation lean, stable, and behaviorally aligned w
 
 Remaining differences vs the previous production site (small, shippable items):
 
+- **Newsletter cold starts**: Expired in-memory snapshots now revalidate in the background, but a fresh process still downloads the full GitHub archive before serving newsletter content.
 - **Link prefetch parity**: Intent/predictive prefetch is not yet mirrored across Remix pages.
 - **Analytics on in-app transitions**: Verify one pageview per navigation when using client-side navigation.
 - **Client navigation shape**: Keep Jam on top-level client navigation unless a future route needs an independently updating region.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Keep the Remix 3 website implementation lean, stable, and behaviorally aligned w
 - **`app/router.ts`** — `createRouter`, root middleware stack, `router.map(...)` wiring, and the `GET /assets/*` route that delegates to `app/utils/assets.ts`.
 - **Production / `pnpm run preview`** — runs the same TypeScript server entry as development (`server.ts`) through `remix/node-tsx`; there is no separate Vite SSR bundle.
 - **HMR / `pnpm run hmr`** - runs the server in development mode with HMR enabled, for use during heavy UI iteration.
+- HTML compression must flush streamed chunks for both gzip/deflate and Brotli; otherwise pending server content can delay the initial document.
 
 ## Keep These Non-Obvious Invariants
 

--- a/app/actions/newsletter/archive.test.ts
+++ b/app/actions/newsletter/archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
 import { gzipSync } from "node:zlib";
+import { setImmediate } from "node:timers/promises";
 
 import { routes } from "../../routes.ts";
 import {
@@ -308,93 +309,147 @@ describe("createGitHubNewsletterRepository", () => {
     expect(calls).toBe(1);
   });
 
-  it("serves cached snapshot within TTL and refetches after expiry", async () => {
+  it(
+    "serves stale summaries, issues, and images during one background refresh",
+    { timeout: 5_000 },
+    async (t) => {
+      let now = 0;
+      t.mock.method(Date, "now", () => now);
+      let calls = 0;
+      let refresh = deferred<Response>();
+      t.after(() => refresh.resolve(new Response(null, { status: 503 })));
+      let repo = createGitHubNewsletterRepository({
+        token: "test-token",
+        ttlMs: 1_000,
+        fetchImpl: async () => {
+          calls++;
+          if (calls === 2) return refresh.promise;
+          return fakeTarballFetch([
+            issueFile(1, "2024-01-01", "![Cover](cover.png)"),
+            imageFile(1, "cover.png"),
+          ])();
+        },
+      });
+
+      let first = await repo.listSummaries();
+      now = 999;
+      expect(await repo.listSummaries()).toEqual(first);
+      expect(calls).toBe(1);
+
+      now = 1_000;
+      // These must finish before GitHub responds, including requests arriving
+      // after the refresh has already started.
+      expect(await repo.listSummaries()).toEqual(first);
+      let [summaries, issue, image] = await Promise.all([
+        repo.listSummaries(),
+        repo.getIssue(1),
+        repo.getImage(1, "cover.png"),
+      ]);
+      expect(summaries).toEqual(first);
+      expect(issue?.number).toBe(1);
+      expect(image?.bytes).toEqual(new TextEncoder().encode("fake-image"));
+      expect(calls).toBe(2);
+
+      refresh.resolve(await fakeTarballFetch([issueFile(2, "2024-02-02")])());
+      // Wait for the new snapshot to become observable, not a fixed sleep for
+      // the asynchronous gzip/tar pipeline.
+      while (!(await repo.getIssue(2))) {
+        await setImmediate(undefined, { signal: t.signal });
+      }
+      expect((await repo.listSummaries()).map((s) => s.number)).toEqual([2]);
+      expect(await repo.getIssue(1)).toBe(null);
+      expect(await repo.getImage(1, "cover.png")).toBe(null);
+      expect(calls).toBe(2);
+    },
+  );
+
+  it("deduplicates concurrent cold loads", async () => {
     let calls = 0;
+    let initial = deferred<Response>();
     let repo = createGitHubNewsletterRepository({
       token: "test-token",
-      ttlMs: 50,
       fetchImpl: async () => {
         calls++;
-        return fakeTarballFetch([issueFile(1, "2024-01-01")])();
+        return initial.promise;
       },
     });
 
-    let first = await repo.listSummaries();
-    expect(first.map((s) => s.number)).toEqual([1]);
-    await repo.listSummaries();
-    expect(calls).toBe(1); // served from cache
-
-    await new Promise((r) => setTimeout(r, 60));
-    let third = await repo.listSummaries();
-    expect(third.map((s) => s.number)).toEqual([1]);
-    expect(calls).toBe(2); // refetched after TTL
-  });
-
-  it("deduplicates concurrent refreshes", async () => {
-    let calls = 0;
-    let repo = createGitHubNewsletterRepository({
-      token: "test-token",
-      ttlMs: 1000,
-      fetchImpl: async () => {
-        calls++;
-        // Resolve on a later tick so two concurrent calls share one refresh.
-        return new Promise<Response>((resolve) =>
-          setTimeout(
-            () => resolve(fakeTarballFetch([issueFile(1, "2024-01-01")])()),
-            0,
-          ),
-        );
-      },
-    });
-
-    let [a, b] = await Promise.all([
-      repo.listSummaries(),
-      repo.listSummaries(),
-    ]);
-    expect(a.map((s) => s.number)).toEqual([1]);
-    expect(b.map((s) => s.number)).toEqual([1]);
+    let a = repo.listSummaries();
+    let b = repo.getIssue(1);
+    expect(calls).toBe(1);
+    initial.resolve(await fakeTarballFetch([issueFile(1, "2024-01-01")])());
+    expect((await a).map((s) => s.number)).toEqual([1]);
+    expect((await b)?.number).toBe(1);
     expect(calls).toBe(1);
   });
 
-  it("retains stale data and reports when a refresh fails", async () => {
+  it(
+    "retains stale data after a failed refresh and retries after the TTL",
+    { timeout: 5_000 },
+    async (t) => {
+      let now = 0;
+      t.mock.method(Date, "now", () => now);
+      let calls = 0;
+      let refresh = deferred<Response>();
+      t.after(() => refresh.resolve(new Response(null, { status: 503 })));
+      let reported = deferred<{
+        error: unknown;
+        servingStale: boolean;
+      }>();
+      let repo = createGitHubNewsletterRepository({
+        token: "test-token",
+        ttlMs: 1_000,
+        fetchImpl: async () => {
+          calls++;
+          if (calls === 2) return refresh.promise;
+          return fakeTarballFetch([issueFile(calls, "2024-01-01")])();
+        },
+        onRefreshError(error, { servingStale }) {
+          reported.resolve({ error, servingStale });
+        },
+      });
+
+      let first = await repo.listSummaries();
+      now = 1_000;
+      expect(await repo.listSummaries()).toEqual(first);
+      refresh.resolve(new Response("nope", { status: 404 }));
+      let { error, servingStale } = await reported.promise;
+      expect(servingStale).toBe(true);
+      expect((error as Error).message).toBe(
+        "Failed to fetch newsletter tarball (404)",
+      );
+
+      now = 1_999;
+      expect(await repo.listSummaries()).toEqual(first);
+      expect(calls).toBe(2);
+
+      now = 2_000;
+      expect(await repo.listSummaries()).toEqual(first);
+      while (!(await repo.getIssue(3))) {
+        await setImmediate(undefined, { signal: t.signal });
+      }
+      expect((await repo.listSummaries()).map((s) => s.number)).toEqual([3]);
+      expect(calls).toBe(3);
+    },
+  );
+
+  it("throws on a failed cold load and allows the next request to retry", async () => {
     let calls = 0;
-    let refreshErrors: Array<{ error: unknown; servingStale: boolean }> = [];
     let repo = createGitHubNewsletterRepository({
       token: "test-token",
-      ttlMs: 50,
       fetchImpl: async () => {
         calls++;
-        if (calls === 1) {
-          return fakeTarballFetch([issueFile(2, "2024-02-02")])();
-        }
-        return new Response("nope", { status: 404 });
+        return calls === 1
+          ? new Response("nope", { status: 404 })
+          : fakeTarballFetch([issueFile(1, "2024-01-01")])();
       },
-      onRefreshError(error, { servingStale }) {
-        refreshErrors.push({ error, servingStale });
-      },
-    });
-
-    let first = await repo.listSummaries();
-    expect(first.map((s) => s.number)).toEqual([2]);
-    await new Promise((r) => setTimeout(r, 60));
-    let second = await repo.listSummaries();
-    expect(second.map((s) => s.number)).toEqual([2]); // stale retained
-    expect(refreshErrors.length).toBe(1);
-    expect(refreshErrors[0].servingStale).toBe(true);
-    expect((refreshErrors[0].error as Error).message).toBe(
-      "Failed to fetch newsletter tarball (404)",
-    );
-  });
-
-  it("throws UpstreamUnavailableError when the first fetch fails", async () => {
-    let repo = createGitHubNewsletterRepository({
-      token: "test-token",
-      fetchImpl: async () => new Response("nope", { status: 404 }),
     });
 
     await expect(repo.listSummaries()).rejects.toBeInstanceOf(
       NewsletterUpstreamUnavailableError,
     );
+    expect((await repo.listSummaries()).map((s) => s.number)).toEqual([1]);
+    expect(calls).toBe(2);
   });
 
   it("returns null for missing issues and missing/unsafe images", async () => {
@@ -459,6 +514,14 @@ describe("collectNewsletterFiles", () => {
     );
   });
 });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
 
 // Build an uncompressed POSIX tar archive from a list of entries. Sufficient
 // for parseTar; headers we don't care about are zeroed except name/size/type.

--- a/app/actions/newsletter/archive.test.ts
+++ b/app/actions/newsletter/archive.test.ts
@@ -1,24 +1,21 @@
 import { describe, it } from "remix/test";
 import { expect } from "remix/assert";
-import { gzipSync } from "node:zlib";
+import { createHash } from "node:crypto";
 import { setImmediate } from "node:timers/promises";
 
 import { routes } from "../../routes.ts";
 import {
-  collectNewsletterFiles,
   createGitHubNewsletterRepository,
   extractNewsletterPreviewImage,
   isSafeImageFilename,
   parseNewsletterSnapshot,
   NewsletterUpstreamUnavailableError,
-  type RawTarFile,
 } from "./archive.ts";
 
 function md(
   number: number,
-  date: string,
   body = "Hello world.",
-  previewText?: string,
+  previewText?: unknown,
 ): string {
   let preview =
     previewText === undefined
@@ -27,146 +24,87 @@ function md(
   return `---\ntitle: Remix Newsletter #${number}\n${preview}---\n\n# Remix Newsletter #${number}\n\n${body}\n`;
 }
 
-function issueFile(number: number, date: string, body?: string): RawTarFile {
-  return {
-    name: `repo-sha/newsletters/newsletter-${number}/${date}-remix-newsletter-${number}.md`,
-    type: "file",
-    bytes: new TextEncoder().encode(md(number, date, body)),
-  };
-}
-
-function imageFile(
-  number: number,
-  filename: string,
-  bytes?: Uint8Array,
-): RawTarFile {
-  return {
-    name: `repo-sha/newsletters/newsletter-${number}/${filename}`,
-    type: "file",
-    bytes: bytes ?? new TextEncoder().encode("fake-image"),
-  };
-}
-
 describe("parseNewsletterSnapshot", () => {
   it("parses issues newest-first with UTC dates and ignores non-integer dirs", () => {
     let snapshot = parseNewsletterSnapshot([
       {
         name: "newsletter-3/2025-01-02-remix-newsletter-3.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(3, "2025-01-02")),
+        markdown: md(3),
       },
       {
         name: "newsletter-1/2024-09-10-remix-newsletter-1.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(1, "2024-09-10")),
+        markdown: md(1),
       },
       {
         name: "newsletter-2/2024-12-01-remix-newsletter-2.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(2, "2024-12-12")),
+        markdown: md(2),
       },
       {
         name: "newsletter-notanumber/2024-01-01-remix-newsletter-1.md",
-        type: "file",
-        bytes: new TextEncoder().encode("x"),
+        markdown: "x",
       },
-      {
-        name: "newsletter-2/notes.txt",
-        type: "file",
-        bytes: new TextEncoder().encode("ignore me"),
-      },
+      { name: "newsletter-2/notes.txt", sha: "a".repeat(40) },
     ]);
-
-    expect(snapshot.issues.map((i) => i.number)).toEqual([3, 2, 1]);
+    expect(snapshot.issues.map((issue) => issue.number)).toEqual([3, 2, 1]);
     expect(snapshot.issues[0].date.toISOString()).toBe(
       "2025-01-02T00:00:00.000Z",
     );
-    // Non-image files are not retained in the response file map.
     expect(snapshot.files.has("newsletter-2/notes.txt")).toBe(false);
-    expect(snapshot.issues.some((i) => i.number === 0)).toBe(false);
   });
 
   it("skips only issues explicitly marked as drafts", () => {
     let snapshot = parseNewsletterSnapshot([
       {
         name: "newsletter-1/2025-01-01-remix-newsletter-1.md",
-        type: "file",
-        bytes: new TextEncoder().encode(
-          md(1, "2025-01-01").replace("title:", "draft: true\ntitle:"),
-        ),
+        markdown: md(1).replace("title:", "draft: true\ntitle:"),
       },
       {
         name: "newsletter-2/2025-01-02-remix-newsletter-2.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(2, "2025-01-02")),
+        markdown: md(2),
       },
       {
         name: "newsletter-3/2025-01-03-remix-newsletter-3.md",
-        type: "file",
-        bytes: new TextEncoder().encode(
-          md(3, "2025-01-03").replace("title:", "draft: false\ntitle:"),
-        ),
+        markdown: md(3).replace("title:", "draft: false\ntitle:"),
       },
     ]);
-
     expect(snapshot.issues.map((issue) => issue.number)).toEqual([3, 2]);
     expect(snapshot.summaries.map((summary) => summary.number)).toEqual([3, 2]);
   });
 
-  it("skips issues whose markdown filename does not match the issue or date contract", () => {
+  it("skips filenames that do not match the issue or date contract", () => {
     let snapshot = parseNewsletterSnapshot([
-      {
-        name: "newsletter-5/random.md",
-        type: "file",
-        bytes: new TextEncoder().encode("no date here"),
-      },
+      { name: "newsletter-5/random.md", markdown: "no date here" },
       {
         name: "newsletter-6/2025-02-31-remix-newsletter-6.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(6, "2025-02-31")),
+        markdown: md(6),
       },
       {
         name: "newsletter-7/2025-03-04-remix-newsletter-8.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(7, "2025-03-04")),
+        markdown: md(7),
       },
     ]);
-
     expect(snapshot.issues).toEqual([]);
   });
 
-  it("precomputes summary text and available preview-image metadata", () => {
+  it("precomputes preview text and image metadata without downloading images", () => {
     let snapshot = parseNewsletterSnapshot([
-      {
-        name: "newsletter-7/draft.md",
-        type: "file",
-        bytes: new TextEncoder().encode("# Unpublished draft"),
-      },
+      { name: "newsletter-7/draft.md", markdown: "# Unpublished draft" },
       {
         name: "newsletter-7/2025-03-04-remix-newsletter-7.md",
-        type: "file",
-        bytes: new TextEncoder().encode(
-          md(
-            7,
-            "2025-03-04",
-            "![Header art](header.jpg)\n\nThis is the lead paragraph about Remix.",
-            "Generated preview from frontmatter.",
-          ),
+        markdown: md(
+          7,
+          "![Header art](header.jpg)\n\nLead paragraph.",
+          "Frontmatter preview.",
         ),
       },
-      {
-        name: "newsletter-7/header.jpg",
-        type: "file",
-        bytes: new TextEncoder().encode("image"),
-      },
+      { name: "newsletter-7/header.jpg", sha: "a".repeat(40) },
     ]);
-
     expect(snapshot.issues[0].title).toBe("Remix Newsletter #7");
     expect(snapshot.summaries).toEqual([
       {
         number: 7,
         date: new Date("2025-03-04T00:00:00.000Z"),
-        preview: "Generated preview from frontmatter.",
+        preview: "Frontmatter preview.",
         image: {
           src: routes.newsletter.image.href({
             number: 7,
@@ -177,27 +115,18 @@ describe("parseNewsletterSnapshot", () => {
       },
     ]);
   });
-});
 
-describe("frontmatter previews", () => {
   it("does not derive preview text from the body when metadata is missing or malformed", () => {
     let snapshot = parseNewsletterSnapshot([
       {
         name: "newsletter-1/2024-01-01-remix-newsletter-1.md",
-        type: "file",
-        bytes: new TextEncoder().encode(
-          md(1, "2024-01-01", "This body must not become the preview."),
-        ),
+        markdown: md(1, "Not a preview"),
       },
       {
         name: "newsletter-2/2024-02-01-remix-newsletter-2.md",
-        type: "file",
-        bytes: new TextEncoder().encode(
-          `---\ntitle: Remix Newsletter #2\npreviewText: 42\n---\n\n# Remix Newsletter #2\n\nThis body must not become the preview.\n`,
-        ),
+        markdown: md(2, "Not a preview", 42),
       },
     ]);
-
     expect(snapshot.summaries.map((summary) => summary.preview)).toEqual([
       "",
       "",
@@ -224,121 +153,194 @@ describe("extractNewsletterPreviewImage", () => {
 
 describe("isSafeImageFilename", () => {
   it("allows safe raster types and blocks svg, path traversal, and dirs", () => {
-    expect(isSafeImageFilename("cover.png")).toBe(true);
-    expect(isSafeImageFilename("photo.JPEG")).toBe(true);
-    expect(isSafeImageFilename("anim.gif")).toBe(true);
-    expect(isSafeImageFilename("pic.webp")).toBe(true);
-    expect(isSafeImageFilename("icon.svg")).toBe(false);
-    expect(isSafeImageFilename("../cover.png")).toBe(false);
-    expect(isSafeImageFilename("dir/cover.png")).toBe(false);
-    expect(isSafeImageFilename("noext")).toBe(false);
+    for (let filename of ["cover.png", "photo.JPEG", "anim.gif", "pic.webp"]) {
+      expect(isSafeImageFilename(filename)).toBe(true);
+    }
+    for (let filename of [
+      "icon.svg",
+      "../cover.png",
+      "dir/cover.png",
+      "noext",
+    ]) {
+      expect(isSafeImageFilename(filename)).toBe(false);
+    }
   });
 });
 
 describe("createGitHubNewsletterRepository", () => {
-  function fakeTarballFetch(files: RawTarFile[]) {
-    return async () => {
-      // Encode the files as a minimal tar archive and gzip it so the
-      // repository's DecompressionStream('gzip') pipeline can decode it.
-      let gz = gzipSync(buildTar(files));
-      return new Response(gz, { status: 200 });
-    };
-  }
-
-  it("only sends authorization to the GitHub API, never codeload", async () => {
-    let requests: Array<{
-      url: string;
-      authorization: string | null;
-      redirect: RequestRedirect | undefined;
-    }> = [];
-    let token = ["dedicated", "newsletter", "token"].join("-");
-    let gz = gzipSync(buildTar([issueFile(1, "2024-01-01")]));
+  it("loads cold summaries and issues with two metadata requests and no image downloads", async () => {
+    let issue = issueFile(1, "2024-01-01", "![Cover](cover.png)");
+    let image = imageFile(1, "cover.png");
+    let upstream = fakeGitHubFetch([issue, image]);
+    let requests: Array<{ url: string; init?: RequestInit }> = [];
+    let token = ["test", "newsletter", "token"].join("-");
     let repo = createGitHubNewsletterRepository({
       token,
       fetchImpl: async (input, init) => {
-        requests.push({
-          url: String(input),
-          authorization: new Headers(init?.headers).get("Authorization"),
-          redirect: init?.redirect,
-        });
-        if (requests.length === 1) {
-          return new Response(null, {
-            status: 302,
-            headers: {
-              Location:
-                "https://codeload.github.com/remix-run/newsletter/legacy.tar.gz/main?token=signed",
-            },
-          });
-        }
-        return new Response(gz, { status: 200 });
+        requests.push({ url: String(input), init });
+        return upstream(input, init);
       },
     });
 
-    await repo.listSummaries();
-
-    expect(requests).toEqual([
-      {
-        url: "https://api.github.com/repos/remix-run/newsletter/tarball/main",
-        authorization: `Bearer ${token}`,
-        redirect: "manual",
-      },
-      {
-        url: "https://codeload.github.com/remix-run/newsletter/legacy.tar.gz/main?token=signed",
-        authorization: null,
-        redirect: "error",
-      },
+    let [summaries, loadedIssue] = await Promise.all([
+      repo.listSummaries(),
+      repo.getIssue(1),
     ]);
+    expect(summaries.map((summary) => summary.number)).toEqual([1]);
+    expect(loadedIssue?.markdown).toBe(new TextDecoder().decode(issue.bytes));
+    expect(summaries[0].image?.src).toBe(
+      routes.newsletter.image.href({ number: 1, filename: "cover.png" }),
+    );
+    expect(requests).toHaveLength(2);
+    expect(requests[0].url).toBe(
+      "https://api.github.com/repos/remix-run/newsletter/git/trees/main?recursive=1",
+    );
+    expect(requests[1].url).toBe("https://api.github.com/graphql");
+    let query = JSON.parse(String(requests[1].init?.body)).query as string;
+    expect(query).toContain(issue.sha);
+    expect(query).not.toContain(image.sha);
+    expect(query).not.toContain("main");
+    for (let request of requests) {
+      expect(request.init?.redirect).toBe("error");
+      expect(new Headers(request.init?.headers).get("Authorization")).toBe(
+        `Bearer ${token}`,
+      );
+    }
+    expect(
+      new Headers(requests[0].init?.headers).get("X-GitHub-Api-Version"),
+    ).toBe("2026-03-10");
+    expect(
+      new Headers(requests[1].init?.headers).get("X-GitHub-Api-Version"),
+    ).toBe(null);
+
+    await repo.getIssue(1);
+    await repo.listSummaries();
+    expect(requests).toHaveLength(2);
   });
 
-  it("rejects redirects outside GitHub codeload without forwarding authorization", async () => {
+  it("rejects API redirects without forwarding authorization", async () => {
     let calls = 0;
     let repo = createGitHubNewsletterRepository({
-      token: ["dedicated", "newsletter", "token"].join("-"),
-      fetchImpl: async () => {
+      token: "test",
+      fetchImpl: async (_input, init) => {
         calls++;
+        expect(init?.redirect).toBe("error");
         return new Response(null, {
           status: 302,
-          headers: { Location: "https://example.com/archive.tar.gz" },
+          headers: { Location: "https://example.com/archive" },
         });
       },
     });
-
     await expect(repo.listSummaries()).rejects.toBeInstanceOf(
       NewsletterUpstreamUnavailableError,
     );
     expect(calls).toBe(1);
   });
 
+  it("only exposes regular files directly inside newsletter directories", async () => {
+    let files = [
+      issueFile(1, "2024-01-01", "![Missing](linked.png)\n![Cover](cover.png)"),
+      imageFile(1, "cover.png"),
+      { ...imageFile(1, "linked.png"), mode: "120000" },
+      fixtureFile("README.md", "private root file"),
+      fixtureFile(
+        "examples/newsletters/newsletter-2/2024-02-02-remix-newsletter-2.md",
+        md(2),
+      ),
+      fixtureFile(
+        "newsletters/newsletter-1/nested/hidden.png",
+        "private nested image",
+      ),
+    ];
+    let repo = createGitHubNewsletterRepository({
+      fetchImpl: fakeGitHubFetch(files),
+    });
+    expect(
+      (await repo.listSummaries()).map((summary) => summary.number),
+    ).toEqual([1]);
+    expect((await repo.getIssue(1))?.image?.src).toBe(
+      routes.newsletter.image.href({ number: 1, filename: "cover.png" }),
+    );
+    expect(await repo.getImage(1, "linked.png")).toBe(null);
+    expect(await repo.getImage(1, "nested/hidden.png")).toBe(null);
+  });
+
+  it("fetches images on demand and deduplicates concurrent requests by Git SHA", async (t) => {
+    let image = imageFile(1, "cover.png");
+    let upstream = fakeGitHubFetch([
+      issueFile(1, "2024-01-01"),
+      image,
+      { ...image, name: "newsletters/newsletter-1/copy.png" },
+    ]);
+    let download = deferred<Response>();
+    t.after(() => download.resolve(new Response(null, { status: 503 })));
+    let started = deferred<void>();
+    let imageCalls = 0;
+    let repo = createGitHubNewsletterRepository({
+      token: "test",
+      fetchImpl: async (input, init) => {
+        if (String(input).includes("/git/blobs/")) {
+          imageCalls++;
+          expect(String(input)).toBe(
+            `https://api.github.com/repos/remix-run/newsletter/git/blobs/${image.sha}`,
+          );
+          expect(new Headers(init?.headers).get("Accept")).toBe(
+            "application/vnd.github.raw+json",
+          );
+          expect(new Headers(init?.headers).get("Authorization")).toBe(
+            "Bearer test",
+          );
+          expect(init?.redirect).toBe("error");
+          started.resolve();
+          return download.promise;
+        }
+        return upstream(input, init);
+      },
+    });
+    await repo.listSummaries();
+    expect(imageCalls).toBe(0);
+    let a = repo.getImage(1, "cover.png");
+    let b = repo.getImage(1, "copy.png");
+    await started.promise;
+    // Image fetches must not block the already-loaded archive.
+    expect(
+      (await repo.listSummaries()).map((summary) => summary.number),
+    ).toEqual([1]);
+    expect(imageCalls).toBe(1);
+    download.resolve(new Response(Uint8Array.from(image.bytes)));
+    expect((await a)?.bytes).toEqual(image.bytes);
+    expect((await b)?.filename).toBe("copy.png");
+    await repo.getImage(1, "cover.png");
+    expect(imageCalls).toBe(1);
+  });
+
   it(
-    "serves stale summaries, issues, and images during one background refresh",
+    "serves stale summaries, issues, and cached images during one background refresh",
     { timeout: 5_000 },
     async (t) => {
       let now = 0;
       t.mock.method(Date, "now", () => now);
+      let upstream = fakeGitHubFetch([
+        issueFile(1, "2024-01-01", "![Cover](cover.png)"),
+        imageFile(1, "cover.png"),
+      ]);
       let calls = 0;
       let refresh = deferred<Response>();
       t.after(() => refresh.resolve(new Response(null, { status: 503 })));
       let repo = createGitHubNewsletterRepository({
-        token: "test-token",
         ttlMs: 1_000,
-        fetchImpl: async () => {
-          calls++;
-          if (calls === 2) return refresh.promise;
-          return fakeTarballFetch([
-            issueFile(1, "2024-01-01", "![Cover](cover.png)"),
-            imageFile(1, "cover.png"),
-          ])();
+        fetchImpl: async (input, init) => {
+          if (String(input).includes("/git/trees/") && ++calls === 2)
+            return refresh.promise;
+          return upstream(input, init);
         },
       });
-
       let first = await repo.listSummaries();
+      await repo.getImage(1, "cover.png");
       now = 999;
       expect(await repo.listSummaries()).toEqual(first);
       expect(calls).toBe(1);
-
       now = 1_000;
-      // These must finish before GitHub responds, including requests arriving
-      // after the refresh has already started.
       expect(await repo.listSummaries()).toEqual(first);
       let [summaries, issue, image] = await Promise.all([
         repo.listSummaries(),
@@ -350,170 +352,364 @@ describe("createGitHubNewsletterRepository", () => {
       expect(image?.bytes).toEqual(new TextEncoder().encode("fake-image"));
       expect(calls).toBe(2);
 
-      refresh.resolve(await fakeTarballFetch([issueFile(2, "2024-02-02")])());
-      // Wait for the new snapshot to become observable, not a fixed sleep for
-      // the asynchronous gzip/tar pipeline.
-      while (!(await repo.getIssue(2))) {
+      upstream = fakeGitHubFetch([issueFile(2, "2024-02-02")]);
+      refresh.resolve(
+        await upstream(
+          "https://api.github.com/repos/remix-run/newsletter/git/trees/main",
+        ),
+      );
+      while (!(await repo.getIssue(2)))
         await setImmediate(undefined, { signal: t.signal });
-      }
-      expect((await repo.listSummaries()).map((s) => s.number)).toEqual([2]);
+      expect(
+        (await repo.listSummaries()).map((summary) => summary.number),
+      ).toEqual([2]);
       expect(await repo.getIssue(1)).toBe(null);
       expect(await repo.getImage(1, "cover.png")).toBe(null);
       expect(calls).toBe(2);
     },
   );
 
-  it("deduplicates concurrent cold loads", async () => {
-    let calls = 0;
-    let initial = deferred<Response>();
-    let repo = createGitHubNewsletterRepository({
-      token: "test-token",
-      fetchImpl: async () => {
-        calls++;
-        return initial.promise;
-      },
-    });
-
-    let a = repo.listSummaries();
-    let b = repo.getIssue(1);
-    expect(calls).toBe(1);
-    initial.resolve(await fakeTarballFetch([issueFile(1, "2024-01-01")])());
-    expect((await a).map((s) => s.number)).toEqual([1]);
-    expect((await b)?.number).toBe(1);
-    expect(calls).toBe(1);
-  });
-
   it(
-    "retains stale data after a failed refresh and retries after the TTL",
+    "reuses unchanged image blobs across refreshes and downloads changed images",
     { timeout: 5_000 },
     async (t) => {
       let now = 0;
       t.mock.method(Date, "now", () => now);
-      let calls = 0;
-      let refresh = deferred<Response>();
-      t.after(() => refresh.resolve(new Response(null, { status: 503 })));
-      let reported = deferred<{
-        error: unknown;
-        servingStale: boolean;
-      }>();
+      let image = imageFile(1, "cover.png");
+      let upstream = fakeGitHubFetch([issueFile(1, "2024-01-01"), image]);
+      let downloads = 0;
       let repo = createGitHubNewsletterRepository({
-        token: "test-token",
         ttlMs: 1_000,
-        fetchImpl: async () => {
-          calls++;
-          if (calls === 2) return refresh.promise;
-          return fakeTarballFetch([issueFile(calls, "2024-01-01")])();
-        },
-        onRefreshError(error, { servingStale }) {
-          reported.resolve({ error, servingStale });
+        fetchImpl: async (input, init) => {
+          if (String(input).includes("/git/blobs/")) downloads++;
+          return upstream(input, init);
         },
       });
+      await repo.getImage(1, "cover.png");
+      now = 1_000;
+      upstream = fakeGitHubFetch([
+        issueFile(1, "2024-01-01"),
+        issueFile(2, "2024-02-02"),
+        image,
+      ]);
+      while (!(await repo.getIssue(2)))
+        await setImmediate(undefined, { signal: t.signal });
+      await repo.getImage(1, "cover.png");
+      expect(downloads).toBe(1);
 
+      now = 2_000;
+      let replacement = imageFile(1, "cover.png", "updated-image");
+      upstream = fakeGitHubFetch([
+        issueFile(1, "2024-01-01"),
+        issueFile(3, "2024-03-03"),
+        replacement,
+      ]);
+      while (!(await repo.getIssue(3)))
+        await setImmediate(undefined, { signal: t.signal });
+      expect((await repo.getImage(1, "cover.png"))?.bytes).toEqual(
+        replacement.bytes,
+      );
+      expect(downloads).toBe(2);
+    },
+  );
+
+  it(
+    "retains stale data after a partial GraphQL refresh and retries after the TTL",
+    { timeout: 5_000 },
+    async (t) => {
+      let now = 0;
+      t.mock.method(Date, "now", () => now);
+      let upstream = fakeGitHubFetch([issueFile(1, "2024-01-01")]);
+      let calls = 0;
+      let fail = false;
+      let reported = deferred<boolean>();
+      let repo = createGitHubNewsletterRepository({
+        ttlMs: 1_000,
+        fetchImpl: async (input, init) => {
+          if (String(input).includes("/git/trees/")) calls++;
+          if (fail && String(input).endsWith("/graphql")) {
+            let result = await (await upstream(input, init)).json();
+            return Response.json({
+              ...result,
+              errors: [{ message: "Partial result" }],
+            });
+          }
+          return upstream(input, init);
+        },
+        onRefreshError(_error, { servingStale }) {
+          reported.resolve(servingStale);
+        },
+      });
       let first = await repo.listSummaries();
+      upstream = fakeGitHubFetch([issueFile(2, "2024-02-02")]);
+      fail = true;
       now = 1_000;
       expect(await repo.listSummaries()).toEqual(first);
-      refresh.resolve(new Response("nope", { status: 404 }));
-      let { error, servingStale } = await reported.promise;
-      expect(servingStale).toBe(true);
-      expect((error as Error).message).toBe(
-        "Failed to fetch newsletter tarball (404)",
-      );
-
+      expect(await reported.promise).toBe(true);
       now = 1_999;
       expect(await repo.listSummaries()).toEqual(first);
       expect(calls).toBe(2);
-
+      fail = false;
       now = 2_000;
       expect(await repo.listSummaries()).toEqual(first);
-      while (!(await repo.getIssue(3))) {
+      while (!(await repo.getIssue(2)))
         await setImmediate(undefined, { signal: t.signal });
-      }
-      expect((await repo.listSummaries()).map((s) => s.number)).toEqual([3]);
       expect(calls).toBe(3);
     },
   );
 
   it("throws on a failed cold load and allows the next request to retry", async () => {
     let calls = 0;
+    let upstream = fakeGitHubFetch([issueFile(1, "2024-01-01")]);
     let repo = createGitHubNewsletterRepository({
-      token: "test-token",
-      fetchImpl: async () => {
-        calls++;
-        return calls === 1
-          ? new Response("nope", { status: 404 })
-          : fakeTarballFetch([issueFile(1, "2024-01-01")])();
+      fetchImpl: async (input, init) =>
+        ++calls === 1
+          ? new Response(null, { status: 404 })
+          : upstream(input, init),
+    });
+    await expect(repo.listSummaries()).rejects.toBeInstanceOf(
+      NewsletterUpstreamUnavailableError,
+    );
+    expect(
+      (await repo.listSummaries()).map((summary) => summary.number),
+    ).toEqual([1]);
+    expect(calls).toBe(3);
+  });
+
+  for (let failure of [
+    "tree truncated",
+    "blob truncated",
+    "missing blob",
+    "wrong blob size",
+    "invalid SHA",
+    "oversized file",
+  ]) {
+    it(`rejects an incomplete or invalid snapshot: ${failure}`, async () => {
+      let upstream = fakeGitHubFetch([issueFile(1, "2024-01-01")]);
+      let repo = createGitHubNewsletterRepository({
+        fetchImpl: async (input, init) => {
+          let result = await (await upstream(input, init)).json();
+          if (String(input).includes("/git/trees/")) {
+            if (failure === "tree truncated") result.truncated = true;
+            if (failure === "invalid SHA")
+              result.tree[0].sha = "../../other-repo";
+            if (failure === "oversized file")
+              result.tree[0].size = 8 * 1024 * 1024 + 1;
+          } else {
+            if (failure === "blob truncated")
+              result.data.repository.file0.isTruncated = true;
+            if (failure === "missing blob") result.data.repository.file0 = null;
+            if (failure === "wrong blob size")
+              result.data.repository.file0.text += "extra";
+          }
+          return Response.json(result);
+        },
+      });
+      await expect(repo.listSummaries()).rejects.toBeInstanceOf(
+        NewsletterUpstreamUnavailableError,
+      );
+    });
+  }
+
+  it("identifies the Markdown path when a blob size does not match", async () => {
+    let issue = issueFile(1, "2024-01-01");
+    let upstream = fakeGitHubFetch([issue]);
+    let reportedError: unknown;
+    let repo = createGitHubNewsletterRepository({
+      fetchImpl: async (input, init) => {
+        let response = await upstream(input, init);
+        if (!String(input).endsWith("/graphql")) return response;
+        let result = await response.json();
+        result.data.repository.file0.text += "extra";
+        return Response.json(result);
+      },
+      onRefreshError(error) {
+        reportedError = error;
       },
     });
 
     await expect(repo.listSummaries()).rejects.toBeInstanceOf(
       NewsletterUpstreamUnavailableError,
     );
-    expect((await repo.listSummaries()).map((s) => s.number)).toEqual([1]);
+    expect((reportedError as Error).message).toContain(issue.name);
+  });
+
+  for (let failure of [
+    "HTTP error",
+    "stream error",
+    "oversized Content-Length",
+    "oversized body",
+  ]) {
+    it(
+      `does not cache an image failure or discard Markdown: ${failure}`,
+      { timeout: 5_000 },
+      async () => {
+        let image = imageFile(1, "cover.png");
+        let upstream = fakeGitHubFetch([issueFile(1, "2024-01-01"), image]);
+        let downloads = 0;
+        let imageErrors = 0;
+        let refreshErrors = 0;
+        let cancelled = deferred<void>();
+        let repo = createGitHubNewsletterRepository({
+          fetchImpl: async (input, init) => {
+            if (String(input).includes("/git/blobs/") && ++downloads === 1) {
+              if (failure === "HTTP error")
+                return new Response(null, { status: 503 });
+              return new Response(
+                new ReadableStream({
+                  start(controller) {
+                    if (failure === "stream error") {
+                      controller.error(new Error("Download interrupted"));
+                    } else if (failure === "oversized body") {
+                      controller.enqueue(new Uint8Array(8 * 1024 * 1024 + 1));
+                    }
+                    // Leave oversized streams open: hitting the limit must cancel them.
+                  },
+                  cancel() {
+                    cancelled.resolve();
+                  },
+                }),
+                failure === "oversized Content-Length"
+                  ? {
+                      headers: {
+                        "Content-Length": String(8 * 1024 * 1024 + 1),
+                      },
+                    }
+                  : undefined,
+              );
+            }
+            return upstream(input, init);
+          },
+          onImageError() {
+            imageErrors++;
+          },
+          onRefreshError() {
+            refreshErrors++;
+          },
+        });
+        await expect(repo.getImage(1, "cover.png")).rejects.toBeInstanceOf(
+          NewsletterUpstreamUnavailableError,
+        );
+        if (failure.startsWith("oversized")) await cancelled.promise;
+        expect((await repo.getIssue(1))?.number).toBe(1);
+        expect((await repo.getImage(1, "cover.png"))?.bytes).toEqual(
+          image.bytes,
+        );
+        expect(downloads).toBe(2);
+        expect(imageErrors).toBe(1);
+        expect(refreshErrors).toBe(0);
+      },
+    );
+  }
+
+  it("returns null for missing issues and missing/unsafe images without blob requests", async () => {
+    let upstream = fakeGitHubFetch([
+      issueFile(1, "2024-01-01"),
+      imageFile(1, "icon.svg"),
+    ]);
+    let calls = 0;
+    let repo = createGitHubNewsletterRepository({
+      fetchImpl: async (input, init) => {
+        calls++;
+        return upstream(input, init);
+      },
+    });
+    expect(await repo.getIssue(0)).toBe(null);
+    expect(await repo.getImage(1, "../cover.png")).toBe(null);
+    expect(await repo.getImage(1, "icon.svg")).toBe(null);
+    expect(calls).toBe(0);
+    expect(await repo.getIssue(999)).toBe(null);
+    expect(await repo.getImage(1, "missing.png")).toBe(null);
     expect(calls).toBe(2);
   });
-
-  it("returns null for missing issues and missing/unsafe images", async () => {
-    let repo = createGitHubNewsletterRepository({
-      token: "test-token",
-      fetchImpl: fakeTarballFetch([
-        issueFile(1, "2024-01-01", "![Cover](cover.png)"),
-        imageFile(1, "cover.png"),
-        imageFile(1, "icon.svg"),
-      ]),
-    });
-
-    expect(await repo.getIssue(999)).toBe(null);
-    expect(await repo.getIssue(1)).toMatchObject({
-      image: {
-        src: routes.newsletter.image.href({
-          number: 1,
-          filename: "cover.png",
-        }),
-        alt: "Cover",
-      },
-    });
-    expect(await repo.getImage(1, "missing.png")).toBe(null);
-    expect(await repo.getImage(1, "icon.svg")).toBe(null);
-    let image = await repo.getImage(1, "cover.png");
-    expect(image).not.toBe(null);
-    expect(image!.contentType).toBe("image/png");
-  });
 });
 
-describe("collectNewsletterFiles", () => {
-  it("only collects entries rooted under newsletters/", async () => {
-    let tar = buildTar([
-      {
-        name: "repo-sha/README.md",
-        type: "file",
-        bytes: new TextEncoder().encode("root"),
-      },
-      {
-        name: "repo-sha/newsletters/newsletter-1/2024-01-01-remix-newsletter-1.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(1, "2024-01-01")),
-      },
-      {
-        name: "repo-sha/newsletters/newsletter-1/cover.png",
-        type: "file",
-        bytes: new TextEncoder().encode("png"),
-      },
-      {
-        name: "repo-sha/examples/newsletters/newsletter-2/2024-02-02-remix-newsletter-2.md",
-        type: "file",
-        bytes: new TextEncoder().encode(md(2, "2024-02-02")),
-      },
-    ]);
+interface FixtureFile {
+  name: string;
+  bytes: Uint8Array;
+  sha: string;
+  mode?: string;
+}
 
-    let files = await collectNewsletterFiles(tar);
-    expect(files.map((f) => f.name).sort()).toEqual(
-      [
-        "newsletter-1/2024-01-01-remix-newsletter-1.md",
-        "newsletter-1/cover.png",
-      ].sort(),
-    );
-  });
-});
+function fixtureFile(name: string, content: string): FixtureFile {
+  let bytes = new TextEncoder().encode(content);
+  let sha = createHash("sha1")
+    .update(`blob ${bytes.byteLength}\0`)
+    .update(bytes)
+    .digest("hex");
+  return { name, bytes, sha };
+}
+
+function issueFile(number: number, date: string, body?: string): FixtureFile {
+  return fixtureFile(
+    `newsletters/newsletter-${number}/${date}-remix-newsletter-${number}.md`,
+    md(number, body),
+  );
+}
+
+function imageFile(
+  number: number,
+  filename: string,
+  contents = "fake-image",
+): FixtureFile {
+  return fixtureFile(`newsletters/newsletter-${number}/${filename}`, contents);
+}
+
+/** Substitute GitHub only; the actual loader, parsing, and caches stay real. */
+function fakeGitHubFetch(files: FixtureFile[]): typeof fetch {
+  return async (input, init) => {
+    let url = new URL(String(input));
+    if (url.pathname.includes("/git/trees/")) {
+      return Response.json({
+        truncated: false,
+        tree: files.map((file) => ({
+          path: file.name,
+          type: "blob",
+          mode: file.mode ?? "100644",
+          sha: file.sha,
+          size: file.bytes.byteLength,
+          // Consumers must construct their own API URLs, not follow this field.
+          url: "https://example.com/untrusted-blob-url",
+        })),
+      });
+    }
+    if (url.pathname === "/graphql") {
+      let { query } = JSON.parse(String(init?.body)) as { query: string };
+      let fields = [
+        ...query.matchAll(/(\w+):\s*object\(oid:\s*"([a-f0-9]+)"\)/g),
+      ];
+      return Response.json({
+        data: {
+          repository: Object.fromEntries(
+            fields.map(([, alias, sha]) => {
+              let file = files.find((file) => file.sha === sha);
+              return [
+                alias,
+                file
+                  ? {
+                      text: file.name.endsWith(".md")
+                        ? new TextDecoder().decode(file.bytes)
+                        : null,
+                      isTruncated: false,
+                    }
+                  : null,
+              ];
+            }),
+          ),
+        },
+      });
+    }
+    if (url.pathname.includes("/git/blobs/")) {
+      let file = files.find(
+        (file) => file.sha === url.pathname.split("/").pop(),
+      );
+      return file
+        ? new Response(Uint8Array.from(file.bytes))
+        : new Response(null, { status: 404 });
+    }
+    throw new Error(`Unexpected GitHub request: ${url.pathname}`);
+  };
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -521,48 +717,4 @@ function deferred<T>() {
     resolve = fulfill;
   });
   return { promise, resolve };
-}
-
-// Build an uncompressed POSIX tar archive from a list of entries. Sufficient
-// for parseTar; headers we don't care about are zeroed except name/size/type.
-function buildTar(entries: RawTarFile[]): Uint8Array {
-  let BLOCK = 512;
-  let chunks: Uint8Array[] = [];
-  for (let entry of entries) {
-    let header = new Uint8Array(BLOCK);
-    let nameBytes = new TextEncoder().encode(entry.name);
-    header.set(nameBytes.slice(0, 100), 0);
-    header.set(encodeOctal(0o644, 8), 100);
-    header.set(encodeOctal(entry.bytes.byteLength, 12), 124);
-    header[156] = "0".charCodeAt(0); // regular file
-    header.set(new TextEncoder().encode("ustar\0"), 257);
-    // Checksum: treat the 8-byte checksum field as spaces during computation.
-    for (let i = 148; i < 156; i++) header[i] = 0x20;
-    let checksum = 0;
-    for (let i = 0; i < BLOCK; i++) checksum += header[i];
-    header.set(encodeOctal(checksum, 7), 148);
-    header[155] = 0;
-    chunks.push(header);
-    chunks.push(entry.bytes);
-    let padding = (BLOCK - (entry.bytes.byteLength % BLOCK)) % BLOCK;
-    if (padding > 0) chunks.push(new Uint8Array(padding));
-  }
-  chunks.push(new Uint8Array(BLOCK * 2)); // end of archive
-  let total = chunks.reduce((n, c) => n + c.byteLength, 0);
-  let out = new Uint8Array(total);
-  let offset = 0;
-  for (let c of chunks) {
-    out.set(c, offset);
-    offset += c.byteLength;
-  }
-  return out;
-}
-
-function encodeOctal(value: number, width: number): Uint8Array {
-  let str = value.toString(8).padStart(width - 1, "0");
-  let bytes = new TextEncoder().encode(str);
-  let out = new Uint8Array(width);
-  out.set(bytes, 0);
-  out[width - 1] = 0;
-  return out;
 }

--- a/app/actions/newsletter/archive.ts
+++ b/app/actions/newsletter/archive.ts
@@ -1,6 +1,12 @@
 import parseFrontMatter from "front-matter";
 import { detectMimeType } from "remix/mime";
-import { parseTar } from "remix/tar-parser";
+import { LRUCache } from "lru-cache";
+
+import {
+  NEWSLETTER_MARKDOWN_PATTERN,
+  type NewsletterFile,
+} from "./file-contract.ts";
+import { createGitHubNewsletterSource } from "./github.ts";
 
 import { routes } from "../../routes.ts";
 import { env } from "../../utils/env.ts";
@@ -10,9 +16,9 @@ import { env } from "../../utils/env.ts";
  *
  * Issues live in the private `remix-run/newsletter` GitHub repository under
  * `newsletters/newsletter-<N>/<YYYY-MM-DD>-remix-newsletter-<N>.md`, with any
- * images beside the markdown. We fetch a single repository tarball at runtime,
- * parse it once, and keep a parsed snapshot in memory. Expired snapshots remain
- * available while one shared refresh runs in the background.
+ * images beside the markdown. We fetch the file tree and batch only Markdown
+ * into a snapshot. Images are fetched on demand by immutable Git SHA and cached
+ * separately. Expired snapshots remain available during a shared refresh.
  */
 
 const NEWSLETTER_REPO_OWNER = "remix-run";
@@ -24,9 +30,7 @@ const SAFE_IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "gif", "webp"] as const;
 
 const FRESH_TTL_MS = 6 * 60 * 60 * 1000;
 const MAX_ISSUES = 200;
-const MAX_FILES = 1_000;
-const MAX_FILE_BYTES = 8 * 1024 * 1024;
-const MAX_ARCHIVE_BYTES = 64 * 1024 * 1024;
+const MAX_CACHED_IMAGE_BYTES = 64 * 1024 * 1024;
 
 export interface NewsletterSummary {
   number: number;
@@ -81,24 +85,17 @@ interface ParsedIssue {
 interface NewsletterSnapshot {
   issues: ParsedIssue[];
   summaries: NewsletterSummary[];
-  files: Map<string, Uint8Array>;
-}
-
-export interface RawTarFile {
-  name: string;
-  type: string;
-  bytes: Uint8Array;
+  files: Map<string, string>;
 }
 
 /**
- * Pure snapshot parser. Accepts the flattened set of tar entries whose names
- * are rooted at the repository's `newsletters/` directory and returns a sorted
- * (newest-first) snapshot. Exported for unit testing without live GitHub.
+ * Parse Markdown and image references rooted at the repository's newsletters/
+ * directory into a newest-first snapshot, without downloading any images.
  */
 export function parseNewsletterSnapshot(
-  files: RawTarFile[],
+  files: NewsletterFile[],
 ): NewsletterSnapshot {
-  let issueDirs = new Map<number, Map<string, RawTarFile>>();
+  let issueDirs = new Map<number, Map<string, NewsletterFile>>();
 
   for (let file of files) {
     let parts = file.name.split("/");
@@ -121,21 +118,19 @@ export function parseNewsletterSnapshot(
 
   let issues: ParsedIssue[] = [];
   for (let [number, bucket] of issueDirs) {
-    let filenamePattern = new RegExp(
-      `^(\\d{4})-(\\d{2})-(\\d{2})-remix-newsletter-${number}\\.md$`,
-    );
-    let markdownEntry: RawTarFile | undefined;
+    let markdown: string | undefined;
     let dateMatch: RegExpMatchArray | null = null;
     for (let file of bucket.values()) {
-      let filename = file.name.split("/").pop()!;
-      let match = filename.match(filenamePattern);
-      if (!match) continue;
-      markdownEntry = file;
+      let match = file.name.match(NEWSLETTER_MARKDOWN_PATTERN);
+      if (!match || Number(match[1]) !== number || !("markdown" in file)) {
+        continue;
+      }
+      markdown = file.markdown;
       dateMatch = match;
       break;
     }
-    if (!markdownEntry || !dateMatch) continue;
-    let [, yearValue, monthValue, dayValue] = dateMatch;
+    if (markdown === undefined || !dateMatch) continue;
+    let [, , yearValue, monthValue, dayValue] = dateMatch;
     let year = Number(yearValue);
     let month = Number(monthValue);
     let day = Number(dayValue);
@@ -148,7 +143,6 @@ export function parseNewsletterSnapshot(
       continue;
     }
 
-    let markdown = new TextDecoder().decode(markdownEntry.bytes);
     let frontmatter = readNewsletterFrontmatter(markdown);
     if (frontmatter.draft === true) continue;
     let title = extractTitle(markdown, number);
@@ -165,18 +159,19 @@ export function parseNewsletterSnapshot(
   issues.sort((a, b) => b.number - a.number);
   issues = issues.slice(0, MAX_ISSUES);
 
-  let fileMap = new Map<string, Uint8Array>();
+  let fileMap = new Map<string, string>();
   for (let file of files) {
     let [directory, filename] = file.name.split("/");
     if (
       !directory ||
       !filename ||
       !/^newsletter-\d+$/.test(directory) ||
-      !isSafeImageFilename(filename)
+      !isSafeImageFilename(filename) ||
+      !("sha" in file)
     ) {
       continue;
     }
-    fileMap.set(file.name, file.bytes);
+    fileMap.set(file.name, file.sha);
   }
 
   let summaries = issues.map((issue) => {
@@ -201,38 +196,6 @@ export function parseNewsletterSnapshot(
   });
 
   return { issues, summaries, files: fileMap };
-}
-
-/**
- * Collect tar entries rooted under `newsletters/` into the flat relative paths
- * the snapshot parser expects (`newsletter-<N>/<filename>`).
- */
-export async function collectNewsletterFiles(
-  archive: ReadableStream<Uint8Array> | Uint8Array,
-): Promise<RawTarFile[]> {
-  let files: RawTarFile[] = [];
-  let totalBytes = 0;
-  await parseTar(archive, (entry) => {
-    if (entry.header.type === "directory" || entry.name.endsWith("/")) return;
-    let match = entry.name.match(/^[^/]+\/newsletters\/(.+)$/);
-    if (!match) return;
-    if (files.length >= MAX_FILES) {
-      throw new Error("Newsletter archive contains too many files");
-    }
-    if (entry.size > MAX_FILE_BYTES) {
-      throw new Error("Newsletter archive contains an oversized file");
-    }
-    totalBytes += entry.size;
-    if (totalBytes > MAX_ARCHIVE_BYTES) {
-      throw new Error("Newsletter archive is too large");
-    }
-
-    let relativePath = match[1];
-    return entry.bytes().then((bytes) => {
-      files.push({ name: relativePath, type: entry.header.type, bytes });
-    });
-  });
-  return files;
 }
 
 interface NewsletterFrontmatter {
@@ -326,6 +289,7 @@ export function createGitHubNewsletterRepository(
       error: unknown,
       context: { servingStale: boolean },
     ) => void;
+    onImageError?: (error: unknown) => void;
   } = {},
 ): NewsletterRepository {
   let owner = options.owner ?? NEWSLETTER_REPO_OWNER;
@@ -335,6 +299,32 @@ export function createGitHubNewsletterRepository(
   let fetchImpl = options.fetchImpl ?? globalThis.fetch;
   let ttlMs = options.ttlMs ?? FRESH_TTL_MS;
   let onRefreshError = options.onRefreshError;
+  let onImageError = options.onImageError;
+  let source = createGitHubNewsletterSource({
+    owner,
+    repo,
+    ref,
+    token,
+    fetchImpl,
+  });
+  let imageCache = new LRUCache<string, Uint8Array>({
+    max: 1_000,
+    maxSize: MAX_CACHED_IMAGE_BYTES,
+    sizeCalculation: (bytes) => Math.max(1, bytes.byteLength),
+    // Eviction must not fail an image response whose download is in progress.
+    ignoreFetchAbort: true,
+    async fetchMethod(sha) {
+      try {
+        return await source.getImage(sha);
+      } catch (error) {
+        onImageError?.(error);
+        throw new NewsletterUpstreamUnavailableError(
+          "Newsletter image is currently unavailable",
+          { cause: error },
+        );
+      }
+    },
+  });
 
   let snapshot: NewsletterSnapshot | null = null;
   let expiresAt = 0;
@@ -342,7 +332,7 @@ export function createGitHubNewsletterRepository(
 
   async function refresh(): Promise<NewsletterSnapshot> {
     try {
-      let files = await fetchTarballFiles(fetchImpl, owner, repo, ref, token);
+      let files = await source.listFiles();
       let next = parseNewsletterSnapshot(files);
       snapshot = next;
       expiresAt = Date.now() + ttlMs;
@@ -399,10 +389,11 @@ export function createGitHubNewsletterRepository(
       if (!Number.isInteger(number) || number <= 0) return null;
       if (!isSafeImageFilename(filename)) return null;
       let snap = await getSnapshot();
-      let bytes = snap.files.get(`newsletter-${number}/${filename}`);
-      if (!bytes) return null;
+      let sha = snap.files.get(`newsletter-${number}/${filename}`);
+      if (!sha) return null;
       let mimeType = detectMimeType(filename);
       if (!mimeType || !isSafeImageContentType(mimeType)) return null;
+      let bytes = await imageCache.forceFetch(sha);
       return { filename, contentType: mimeType, bytes };
     },
   };
@@ -415,66 +406,19 @@ export function resolveNewsletterImageUrl(number: number, url: string): string {
   return routes.newsletter.image.href({ number, filename: match[1] });
 }
 
-async function fetchTarballFiles(
-  fetchImpl: typeof fetch,
-  owner: string,
-  repo: string,
-  ref: string,
-  token: string | undefined,
-): Promise<RawTarFile[]> {
-  let tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
-  let headers: Record<string, string> = {
-    Accept: "application/vnd.github.v3.raw",
-  };
-  if (token) headers.Authorization = `Bearer ${token}`;
-
-  let signal = AbortSignal.timeout(15_000);
-  let response = await fetchImpl(tarballUrl, {
-    headers,
-    redirect: "manual",
-    signal,
-  });
-
-  if (response.status >= 300 && response.status < 400) {
-    let location = response.headers.get("Location");
-    if (!location) {
-      throw new Error("Newsletter tarball redirect had no location");
-    }
-
-    let redirectUrl = new URL(location, tarballUrl);
-    if (
-      redirectUrl.protocol !== "https:" ||
-      redirectUrl.hostname !== "codeload.github.com"
-    ) {
-      throw new Error("Newsletter tarball redirect had an unexpected origin");
-    }
-
-    // GitHub returns a short-lived signed codeload URL. Deliberately omit all
-    // request headers so the repository token cannot cross the API boundary.
-    response = await fetchImpl(redirectUrl, {
-      redirect: "error",
-      signal,
-    });
-  }
-
-  if (!response.ok || !response.body) {
-    throw new Error(`Failed to fetch newsletter tarball (${response.status})`);
-  }
-
-  let stream = response.body.pipeThrough(new DecompressionStream("gzip"));
-  return collectNewsletterFiles(stream);
-}
-
 /**
  * Shared live repository. Reusing one process-wide instance keeps the in-memory
  * cache and concurrent-refresh dedupe effective across requests.
  */
 export const liveNewsletterRepository = createGitHubNewsletterRepository({
   onRefreshError(error, { servingStale }) {
-    console.error("[newsletter] GitHub archive refresh failed", {
+    console.error("[newsletter] GitHub refresh failed", {
       servingStale,
       error,
     });
+  },
+  onImageError(error) {
+    console.error("[newsletter] GitHub image fetch failed", { error });
   },
   token: env.NEWSLETTER_GITHUB_TOKEN,
 });

--- a/app/actions/newsletter/archive.ts
+++ b/app/actions/newsletter/archive.ts
@@ -11,7 +11,8 @@ import { env } from "../../utils/env.ts";
  * Issues live in the private `remix-run/newsletter` GitHub repository under
  * `newsletters/newsletter-<N>/<YYYY-MM-DD>-remix-newsletter-<N>.md`, with any
  * images beside the markdown. We fetch a single repository tarball at runtime,
- * parse it once, and keep a parsed snapshot in memory.
+ * parse it once, and keep a parsed snapshot in memory. Expired snapshots remain
+ * available while one shared refresh runs in the background.
  */
 
 const NEWSLETTER_REPO_OWNER = "remix-run";
@@ -362,13 +363,15 @@ export function createGitHubNewsletterRepository(
 
   async function getSnapshot(): Promise<NewsletterSnapshot> {
     if (snapshot && Date.now() < expiresAt) return snapshot;
-    if (refreshPromise) return refreshPromise;
-    refreshPromise = refresh();
-    try {
-      return await refreshPromise;
-    } finally {
-      refreshPromise = null;
+    if (!refreshPromise) {
+      refreshPromise = refresh().finally(() => {
+        refreshPromise = null;
+      });
+      // Warm requests don't await the refresh. Errors are reported in refresh();
+      // cold callers still receive the original promise and its rejection.
+      void refreshPromise.catch(() => {});
     }
+    return snapshot ?? refreshPromise;
   }
 
   return {

--- a/app/actions/newsletter/controller.test.tsx
+++ b/app/actions/newsletter/controller.test.tsx
@@ -144,7 +144,7 @@ describe("Newsletter index route", () => {
     );
   });
 
-  it("eagerly loads the first four archive images", async () => {
+  it("loads four images eagerly and decodes all asynchronously", async () => {
     let repo = fakeRepository({
       summaries: Array.from({ length: 5 }, (_, index) => {
         let number = index + 1;
@@ -177,6 +177,9 @@ describe("Newsletter index route", () => {
       );
 
     expect(images).toHaveLength(5);
+    for (let image of images) {
+      expect(image).toContain('decoding="async"');
+    }
     expect(
       images.slice(0, 4).every((image) => image.includes('loading="eager"')),
     ).toBe(true);

--- a/app/actions/newsletter/controller.test.tsx
+++ b/app/actions/newsletter/controller.test.tsx
@@ -111,8 +111,12 @@ describe("Newsletter index route", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Surrogate-Control")).toContain(
+      "stale-while-revalidate",
+    );
     let html = await response.text();
 
+    expect(html).not.toContain('role="status"');
     expect(html).toContain("<title>Remix Newsletter</title>");
     expect(html).toContain('style="color-scheme: light dark;"');
     expect(html).not.toContain('data-theme="dark"');

--- a/app/actions/newsletter/file-contract.ts
+++ b/app/actions/newsletter/file-contract.ts
@@ -1,0 +1,8 @@
+/** Markdown contents and image references, never image bytes. */
+export type NewsletterFile =
+  | { name: string; markdown: string }
+  | { name: string; sha: string };
+
+/** Relative path under newsletters/ for one published issue's Markdown. */
+export const NEWSLETTER_MARKDOWN_PATTERN =
+  /^newsletter-(\d+)\/(\d{4})-(\d{2})-(\d{2})-remix-newsletter-\1\.md$/;

--- a/app/actions/newsletter/github.ts
+++ b/app/actions/newsletter/github.ts
@@ -1,0 +1,192 @@
+import * as s from "remix/data-schema";
+
+import {
+  NEWSLETTER_MARKDOWN_PATTERN,
+  type NewsletterFile,
+} from "./file-contract.ts";
+
+const MAX_FILES = 1_000;
+const MAX_FILE_BYTES = 8 * 1024 * 1024;
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+const treeSchema = s.object({
+  truncated: s.literal(false),
+  tree: s.array(
+    s.object({
+      path: s.string(),
+      mode: s.string(),
+      type: s.string(),
+      sha: s.string().refine((value) => /^[a-f0-9]{40}$/.test(value)),
+      size: s.optional(
+        s.number().refine((value) => Number.isSafeInteger(value) && value >= 0),
+      ),
+    }),
+  ),
+});
+
+const markdownSchema = s.object({
+  text: s.string(),
+  isTruncated: s.literal(false),
+});
+
+/** All authenticated requests stay on api.github.com; redirects are rejected. */
+export function createGitHubNewsletterSource(options: {
+  owner: string;
+  repo: string;
+  ref: string;
+  token?: string;
+  fetchImpl: typeof fetch;
+}) {
+  let repoPath = `/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.repo)}`;
+
+  async function request(path: string, init: RequestInit) {
+    let headers = new Headers(init.headers);
+    if (path !== "/graphql") {
+      headers.set("X-GitHub-Api-Version", "2026-03-10");
+    }
+    if (options.token) headers.set("Authorization", `Bearer ${options.token}`);
+    let response = await options.fetchImpl(`https://api.github.com${path}`, {
+      ...init,
+      headers,
+      redirect: "error",
+    });
+    if (!response.ok || !response.body) {
+      await response.body?.cancel();
+      throw new Error(
+        `Failed to fetch newsletter GitHub data (${response.status})`,
+      );
+    }
+    return response;
+  }
+
+  return {
+    async listFiles(): Promise<NewsletterFile[]> {
+      // One deadline covers both requests. Blob SHAs pin all content to the
+      // same tree even if main advances while we're building the snapshot.
+      let signal = AbortSignal.timeout(15_000);
+      let response = await request(
+        `${repoPath}/git/trees/${encodeURIComponent(options.ref)}?recursive=1`,
+        { headers: { Accept: "application/vnd.github+json" }, signal },
+      );
+      let tree = s.parse(
+        treeSchema,
+        JSON.parse(
+          new TextDecoder().decode(
+            await readBytes(response, MAX_RESPONSE_BYTES),
+          ),
+        ),
+      );
+      let files = tree.tree.filter(
+        (file) =>
+          file.type === "blob" &&
+          (file.mode === "100644" || file.mode === "100755") &&
+          /^newsletters\/newsletter-\d+\/[^/]+$/.test(file.path),
+      );
+      if (files.length > MAX_FILES) {
+        throw new Error("Newsletter repository contains too many files");
+      }
+      if (
+        files.some(
+          (file) => file.size === undefined || file.size > MAX_FILE_BYTES,
+        )
+      ) {
+        throw new Error(
+          "Newsletter repository contains an oversized or unsized file",
+        );
+      }
+
+      let markdownFiles = files.filter((file) =>
+        NEWSLETTER_MARKDOWN_PATTERN.test(
+          file.path.slice("newsletters/".length),
+        ),
+      );
+      let markdownByPath = new Map<string, string>();
+      if (markdownFiles.length > 0) {
+        // Batch only Markdown blobs: requesting text on every tree entry also
+        // makes GitHub inspect every binary image, which is much slower.
+        let query = `query($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            ${markdownFiles
+              .map(
+                (file, index) =>
+                  `file${index}: object(oid: "${file.sha}") { ... on Blob { text isTruncated } }`,
+              )
+              .join("\n")}
+          }
+        }`;
+        let response = await request("/graphql", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            query,
+            variables: { owner: options.owner, repo: options.repo },
+          }),
+          signal,
+        });
+        let result = JSON.parse(
+          new TextDecoder().decode(
+            await readBytes(response, MAX_RESPONSE_BYTES),
+          ),
+        );
+        // GraphQL may return partial data with HTTP 200. Never replace a good
+        // snapshot with a partial archive or silently drop a truncated issue.
+        if (result.errors != null)
+          throw new Error("Newsletter GitHub query failed");
+        for (let [index, file] of markdownFiles.entries()) {
+          let blob = s.parse(
+            markdownSchema,
+            result.data?.repository?.[`file${index}`],
+          );
+          let receivedSize = new TextEncoder().encode(blob.text).byteLength;
+          if (receivedSize !== file.size) {
+            throw new Error(
+              `Newsletter Markdown size did not match its Git blob: ${file.path} (expected ${file.size} bytes, received ${receivedSize})`,
+            );
+          }
+          markdownByPath.set(file.path, blob.text);
+        }
+      }
+
+      return files.map((file) => {
+        let name = file.path.slice("newsletters/".length);
+        let markdown = markdownByPath.get(file.path);
+        return markdown === undefined
+          ? { name, sha: file.sha }
+          : { name, markdown };
+      });
+    },
+
+    async getImage(sha: string): Promise<Uint8Array> {
+      let response = await request(`${repoPath}/git/blobs/${sha}`, {
+        headers: { Accept: "application/vnd.github.raw+json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      return readBytes(response, MAX_FILE_BYTES);
+    },
+  };
+}
+
+async function readBytes(
+  response: Response,
+  limit: number,
+): Promise<Uint8Array> {
+  if (Number(response.headers.get("Content-Length")) > limit) {
+    await response.body!.cancel();
+    throw new Error("Newsletter GitHub response is too large");
+  }
+  let size = 0;
+  let body = response.body!.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        size += chunk.byteLength;
+        if (size > limit)
+          throw new Error("Newsletter GitHub response is too large");
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+  return new Response(body).bytes();
+}

--- a/app/actions/newsletter/pages.tsx
+++ b/app/actions/newsletter/pages.tsx
@@ -169,8 +169,15 @@ function NewsletterArchive(
       mix={css({ marginBlockStart: "64px" })}
     >
       {handle.props.unavailable ? (
-        <p mix={[pageBodyStyle, newsletterSecondaryTextStyle]}>
-          The archive is temporarily unavailable. Please check back soon.
+        <p role="alert" mix={[pageBodyStyle, newsletterSecondaryTextStyle]}>
+          The archive is temporarily unavailable. Please check back soon.{" "}
+          <a
+            href={routes.newsletter.index.href()}
+            rmx-document
+            mix={newsletterArchiveLinkStyle}
+          >
+            Try again
+          </a>
         </p>
       ) : handle.props.summaries.length === 0 ? (
         <p mix={[pageBodyStyle, newsletterSecondaryTextStyle]}>
@@ -278,6 +285,16 @@ let newsletterContainerStyle = {
   [breakpointMedia.md]: { paddingInline: "32px" },
   [breakpointMedia.lg]: { paddingInline: "40px" },
 } as const;
+
+let newsletterArchiveLinkStyle = css({
+  color: theme.colors.action.primary,
+  textDecoration: "underline",
+  textUnderlineOffset: "3px",
+  "&:focus-visible": {
+    outline: `2px solid ${theme.colors.action.primary}`,
+    outlineOffset: "4px",
+  },
+});
 
 let newsletterSecondaryTextStyle = css({
   color: theme.colors.text.marketingSecondary,

--- a/app/actions/newsletter/pages.tsx
+++ b/app/actions/newsletter/pages.tsx
@@ -251,7 +251,7 @@ function NewsletterArchive(
                       [breakpointMedia.md]: { borderRadius: "6px" },
                     })}
                     loading={index < 4 ? "eager" : "lazy"}
-                    decoding={index === 0 ? "sync" : "async"}
+                    decoding="async"
                     fetchpriority={index === 0 ? "high" : undefined}
                   />
                 ) : null}

--- a/app/router.test.ts
+++ b/app/router.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "remix/assert";
+import { createTestServer } from "remix/node-fetch-server/test";
 import { beforeEach, describe, it } from "remix/test";
 
 import { createAppRouter } from "./router.ts";
@@ -10,6 +11,64 @@ describe("app router", () => {
   beforeEach(() => {
     router = createAppRouter();
   });
+
+  for (let encoding of ["gzip", "deflate", "br"]) {
+    it(
+      `flushes ${encoding} HTML before the response stream finishes`,
+      { timeout: 5_000 },
+      async (t) => {
+        let finish!: () => void;
+        let pending = new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+        let encoder = new TextEncoder();
+        router.get(
+          "/streamed-html",
+          () =>
+            new Response(
+              new ReadableStream({
+                async start(controller) {
+                  controller.enqueue(encoder.encode("<main>"));
+                  await pending;
+                  controller.enqueue(encoder.encode("</main>"));
+                  controller.close();
+                },
+              }),
+              { headers: { "Content-Type": "text/html; charset=utf-8" } },
+            ),
+        );
+        let server = await createTestServer((request) => router.fetch(request));
+        t.after(() => {
+          finish();
+          return server.close();
+        });
+
+        // Exercise the HTTP adapter and real decompression, not just headers.
+        let response = await fetch(new URL("/streamed-html", server.baseUrl), {
+          headers: { "Accept-Encoding": encoding },
+          signal: t.signal,
+        });
+        expect(response.headers.get("Content-Encoding")).toBe(encoding);
+        let reader = response
+          .body!.pipeThrough(new TextDecoderStream())
+          .getReader();
+        let html = "";
+        while (!html.includes("<main>")) {
+          let { value, done } = await reader.read();
+          expect(done).toBe(false);
+          html += value;
+        }
+        // We must receive the first chunk before allowing the rest to exist.
+        finish();
+        while (true) {
+          let { value, done } = await reader.read();
+          if (done) break;
+          html += value;
+        }
+        expect(html).toBe("<main></main>");
+      },
+    );
+  }
 
   it("serves the healthcheck route", async () => {
     let response = await router.fetch(

--- a/app/router.ts
+++ b/app/router.ts
@@ -1,3 +1,4 @@
+import { constants } from "node:zlib";
 import { asyncContext } from "remix/middleware/async-context";
 import { compression } from "remix/middleware/compression";
 import { cop } from "remix/middleware/cop";
@@ -60,7 +61,21 @@ let ignoreChromeDevToolsRequest: Middleware = (context, next) => {
 function createAppMiddleware() {
   return createMiddleware(
     securityHeaders(),
-    compression(),
+    compression({
+      // TODO: Remove this workaround once Remix ships the upstream fix for
+      // HTML compression flushing. Until then, flush chunks as they become
+      // available rather than waiting for the entire response stream to finish.
+      zlib(response) {
+        return response.headers.get("Content-Type")?.startsWith("text/html")
+          ? { flush: constants.Z_SYNC_FLUSH }
+          : {};
+      },
+      brotli(response) {
+        return response.headers.get("Content-Type")?.startsWith("text/html")
+          ? { flush: constants.BROTLI_OPERATION_FLUSH }
+          : {};
+      },
+    }),
     ignoreChromeDevToolsRequest,
     rootPublicFiles(),
     cop(),

--- a/test/newsletter.test.e2e.ts
+++ b/test/newsletter.test.e2e.ts
@@ -4,7 +4,10 @@ import { describe, it } from "remix/test";
 
 import { createAppRouter } from "../app/router.ts";
 import { routes } from "../app/routes.ts";
-import type { NewsletterRepository } from "../app/actions/newsletter/archive.ts";
+import {
+  NewsletterUpstreamUnavailableError,
+  type NewsletterRepository,
+} from "../app/actions/newsletter/archive.ts";
 import { swallowAbortErrors } from "../test/setup.ts";
 
 const newsletterRepository: NewsletterRepository = {
@@ -46,6 +49,60 @@ const newsletterRepository: NewsletterRepository = {
 };
 
 describe("Newsletter archive", () => {
+  it("renders the archive and signup without JavaScript", async (t) => {
+    let handler = swallowAbortErrors(createAppRouter({ newsletterRepository }));
+    let server = await createTestServer(handler);
+    let harnessPage = await t.serve(server);
+    let context = await harnessPage
+      .context()
+      .browser()!
+      .newContext({ javaScriptEnabled: false });
+    t.after(() => context.close());
+    let page = await context.newPage();
+    await page.goto(
+      new URL(routes.newsletter.index.href(), server.baseUrl).href,
+    );
+    await expect(
+      page.getByRole("link", { name: /Remix Newsletter #1/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Email address" }),
+    ).toBeVisible();
+    await expect(page.getByRole("status")).toHaveCount(0);
+  });
+
+  it("lets visitors retry a failed archive load while keeping signup available", async (t) => {
+    let unavailable = true;
+    let handler = swallowAbortErrors(
+      createAppRouter({
+        newsletterRepository: {
+          ...newsletterRepository,
+          async listSummaries() {
+            if (unavailable)
+              throw new NewsletterUpstreamUnavailableError(
+                "upstream unavailable",
+              );
+            return newsletterRepository.listSummaries();
+          },
+        },
+      }),
+    );
+    let page = await t.serve(await createTestServer(handler));
+    await page.goto(routes.newsletter.index.href());
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Try again" })).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Email address" }),
+    ).toBeVisible();
+    await expect(page.getByRole("status")).toHaveCount(0);
+
+    unavailable = false;
+    await page.getByRole("link", { name: "Try again" }).click();
+    await expect(
+      page.getByRole("link", { name: /Remix Newsletter #1/ }),
+    ).toBeVisible();
+  });
+
   it("opens issue images in the lightbox", async (t) => {
     let handler = swallowAbortErrors(createAppRouter({ newsletterRepository }));
     let page = await t.serve(await createTestServer(handler));


### PR DESCRIPTION
## Summary

- serve expired newsletter snapshots while a shared refresh runs in the background
- replace full repository tarball downloads with a recursive Git tree plus one batched GraphQL Markdown query
- fetch images lazily by immutable blob SHA and retain them in a bounded 64 MiB LRU cache
- reject redirects, truncated/partial responses, oversized bodies, and mismatched Markdown blob sizes
- flush compressed streamed HTML promptly and improve newsletter failure behavior
- reserve archive-card image space, prioritize visible images, and decode images asynchronously

This reduces cold newsletter metadata transfer from roughly 30 MB to roughly 300 KB while preserving six-hour stale-while-revalidate behavior.

## Validation

- `pnpm run validate`
- 240 tests passed
